### PR TITLE
use pattern replace the try/catch determine database driver class 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <tomcat-dbcp.version>9.0.14</tomcat-dbcp.version>
         <commons-pool.version>1.6</commons-pool.version>
         <h2.version>1.4.196</h2.version>
-        <mysql-connector-java.version>5.1.42</mysql-connector-java.version>
+        <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <postgresql.version>9.4.1212</postgresql.version>
         <mssql.version>6.1.7.jre7-preview</mssql.version>
         

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermine.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermine.java
@@ -2,17 +2,21 @@ package io.shardingsphere.shardingproxy.backend.jdbc.datasource;
 
 import io.shardingsphere.core.metadata.datasource.dialect.MySQLDataSourceMetaData;
 import io.shardingsphere.core.metadata.datasource.dialect.PostgreSQLDataSourceMetaData;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class JDBCClassDetermine {
 
     /*
     for MySQL-connector-java 8.x compatibility
     TODO getXADataSourceClassName
      */
-    static String mysqlclass=null;
+    static private String mysqlclass="";
 
     private Pattern pattern = Pattern.compile("jdbc:(mysql|postgresql):.*", Pattern.CASE_INSENSITIVE);
 
@@ -25,7 +29,7 @@ public class JDBCClassDetermine {
             switch (databaseType) {
                 case "mysql":
                     new MySQLDataSourceMetaData(url);
-                    if (mysqlclass==null){
+                    if (mysqlclass.isEmpty()){
                         try{
                             Class.forName("com.mysql.jdbc.Driver");
                             mysqlclass="com.mysql.jdbc.Driver";

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermine.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermine.java
@@ -1,0 +1,51 @@
+package io.shardingsphere.shardingproxy.backend.jdbc.datasource;
+
+import io.shardingsphere.core.metadata.datasource.dialect.MySQLDataSourceMetaData;
+import io.shardingsphere.core.metadata.datasource.dialect.PostgreSQLDataSourceMetaData;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JDBCClassDetermine {
+
+    /*
+    for MySQL-connector-java 8.x compatibility
+    TODO getXADataSourceClassName
+     */
+    static String mysqlclass=null;
+
+    private Pattern pattern = Pattern.compile("jdbc:(mysql|postgresql):.*", Pattern.CASE_INSENSITIVE);
+
+
+    public String getDriverClassName(String url) {
+
+        Matcher matcher = pattern.matcher(url);
+        if (matcher.find()) {
+            String databaseType = matcher.group(1).toLowerCase();
+            switch (databaseType) {
+                case "mysql":
+                    new MySQLDataSourceMetaData(url);
+                    if (mysqlclass==null){
+                        try{
+                            Class.forName("com.mysql.jdbc.Driver");
+                            mysqlclass="com.mysql.jdbc.Driver";
+                        }catch (ClassNotFoundException e){
+                            try {
+                                Class.forName("com.mysql.cj.jdbc.Driver");
+                                mysqlclass="com.mysql.cj.jdbc.Driver";
+                            }catch (ClassNotFoundException mysql8_e){
+                                throw new UnsupportedOperationException(String.format("Cannot support url `%s`,no vailed mysql driver found", url));
+                            }
+                        }
+                    }
+                    return  mysqlclass;
+                case "postgresql":
+                    new PostgreSQLDataSourceMetaData(url);
+                    return "org.postgresql.Driver";
+                default:
+                    throw new UnsupportedOperationException(String.format("Cannot support url `%s`", url));
+            }
+        }
+        throw new UnsupportedOperationException(String.format("Cannot support url `%s`", url));
+    }
+}

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCRawBackendDataSourceFactory.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCRawBackendDataSourceFactory.java
@@ -20,8 +20,6 @@ package io.shardingsphere.shardingproxy.backend.jdbc.datasource;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.shardingsphere.core.exception.ShardingException;
-import io.shardingsphere.core.metadata.datasource.dialect.MySQLDataSourceMetaData;
-import io.shardingsphere.core.metadata.datasource.dialect.PostgreSQLDataSourceMetaData;
 import io.shardingsphere.shardingproxy.util.DataSourceParameter;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -78,17 +76,8 @@ public final class JDBCRawBackendDataSourceFactory implements JDBCBackendDataSou
     
     // TODO judge database type
     private String getDriverClassName(final String url) {
-        try {
-            new MySQLDataSourceMetaData(url);
-            return "com.mysql.jdbc.Driver";
-        } catch (final ShardingException ignore) {
-        }
-        try {
-            new PostgreSQLDataSourceMetaData(url);
-            return "org.postgresql.Driver";
-        } catch (final ShardingException ignore) {
-        }
-        throw new UnsupportedOperationException(String.format("Cannot support url `%s`", url));
+        JDBCClassDetermine jdbcClassDetermine= new JDBCClassDetermine();
+        return jdbcClassDetermine.getDriverClassName(url);
     }
     
     private void validateDriverClassName(final String driverClassName) {

--- a/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
+++ b/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
@@ -8,7 +8,7 @@ import io.shardingsphere.shardingproxy.backend.jdbc.datasource.JDBCClassDetermin
 
 public class JDBCClassDetermineTest {
 
-    JDBCClassDetermine jdbcClassDetermine=new JDBCClassDetermine();
+    privateJDBCClassDetermine jdbcClassDetermine=new JDBCClassDetermine();
 
     @Test
     public void testMySQLUrl() {

--- a/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
+++ b/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
@@ -8,7 +8,7 @@ import io.shardingsphere.shardingproxy.backend.jdbc.datasource.JDBCClassDetermin
 
 public class JDBCClassDetermineTest {
 
-    privateJDBCClassDetermine jdbcClassDetermine=new JDBCClassDetermine();
+    private JDBCClassDetermine jdbcClassDetermine=new JDBCClassDetermine();
 
     @Test
     public void testMySQLUrl() {

--- a/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
+++ b/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
@@ -11,23 +11,23 @@ public class JDBCClassDetermineTest {
     JDBCClassDetermine jdbcClassDetermine=new JDBCClassDetermine();
 
     @Test
-    public void MySQLUrl() {
+    public void testMySQLUrl() {
         assertEquals("com.mysql.jdbc.Driver",jdbcClassDetermine.getDriverClassName("jdbc:mysql://localhost:3306/demo_ds_master"));
     }
     @Test
-    public void PostgreSQLUrl() {
+    public void testPostgreSQLUrl() {
         assertEquals("org.postgresql.Driver",jdbcClassDetermine.getDriverClassName("jdbc:postgresql://db.psql:5432/postgres"));
 
     }
     @Test(expected = UnsupportedOperationException.class)
     @SneakyThrows
-    public void FailedUrl() {
+    public void testFailedUrl() {
         assertEquals("com.mysql.jdbc.Driver",jdbcClassDetermine.getDriverClassName("jdbc:oracle://db.psql:5432/postgres"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
     @SneakyThrows
-    public void FailedUrl2() {
+    public void testFailedUrl2() {
         assertEquals("com.mysql.jdbc.Driver",jdbcClassDetermine.getDriverClassName("xxxx"));
     }
 }

--- a/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
+++ b/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/backend/jdbc/datasource/JDBCClassDetermineTest.java
@@ -1,0 +1,33 @@
+package io.shardingsphere.shardingproxy.backend.jdbc.datasource;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import io.shardingsphere.shardingproxy.backend.jdbc.datasource.JDBCClassDetermine;
+
+public class JDBCClassDetermineTest {
+
+    JDBCClassDetermine jdbcClassDetermine=new JDBCClassDetermine();
+
+    @Test
+    public void MySQLUrl() {
+        assertEquals("com.mysql.jdbc.Driver",jdbcClassDetermine.getDriverClassName("jdbc:mysql://localhost:3306/demo_ds_master"));
+    }
+    @Test
+    public void PostgreSQLUrl() {
+        assertEquals("org.postgresql.Driver",jdbcClassDetermine.getDriverClassName("jdbc:postgresql://db.psql:5432/postgres"));
+
+    }
+    @Test(expected = UnsupportedOperationException.class)
+    @SneakyThrows
+    public void FailedUrl() {
+        assertEquals("com.mysql.jdbc.Driver",jdbcClassDetermine.getDriverClassName("jdbc:oracle://db.psql:5432/postgres"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    @SneakyThrows
+    public void FailedUrl2() {
+        assertEquals("com.mysql.jdbc.Driver",jdbcClassDetermine.getDriverClassName("xxxx"));
+    }
+}


### PR DESCRIPTION
use pattern replace the try/catch determine database driver class with mysql-connector-java version 8.x compatibility

impl in JDBCClassDetermine and test in JDBCClassDetermineTest

change JDBCRawBackendDataSourceFactory

upgrade the mysql-connector-java version from 5.1.42 to 5.1.47 for support MySQL 8.0.x