### PR TITLE
cglib FastInvoke replace the jdk Invoke

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         
         <guava.version>18.0</guava.version>
         <slf4j.version>1.7.7</slf4j.version>
+        <cgib.version>3.2.10</cgib.version>
         
         <antlr4.version>4.7.1</antlr4.version>
         
@@ -101,6 +102,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib</artifactId>
+                <version>${cgib.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/sharding-jdbc/sharding-jdbc-core/pom.xml
+++ b/sharding-jdbc/sharding-jdbc-core/pom.xml
@@ -57,5 +57,9 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/AbstractShardingPreparedStatementAdapter.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/AbstractShardingPreparedStatementAdapter.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.shardingjdbc.jdbc.adapter;
 
 import lombok.Getter;
 import lombok.SneakyThrows;
+import org.apache.shardingsphere.shardingjdbc.jdbc.adapter.invocation.JdbcMethodInvocation;
 import org.apache.shardingsphere.shardingjdbc.jdbc.adapter.invocation.SetParameterMethodInvocation;
 import org.apache.shardingsphere.shardingjdbc.jdbc.unsupported.AbstractUnsupportedOperationPreparedStatement;
 
@@ -26,13 +27,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.SQLXML;
-import java.sql.Time;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
@@ -275,7 +270,7 @@ public abstract class AbstractShardingPreparedStatementAdapter extends AbstractU
     
     @SneakyThrows
     private void setParameter(final Class[] argumentTypes, final Object... arguments) {
-        setParameterMethodInvocations.add(new SetParameterMethodInvocation(PreparedStatement.class.getMethod("setObject", argumentTypes), arguments, arguments[1]));
+        setParameterMethodInvocations.add(new SetParameterMethodInvocation(JdbcMethodInvocation.build(PreparedStatement.class, PreparedStatement.class.getMethod("setObject", argumentTypes)), arguments, arguments[1]));
     }
     
     @Override

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/WrapperAdapter.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/WrapperAdapter.java
@@ -58,7 +58,7 @@ public abstract class WrapperAdapter implements Wrapper {
      */
     @SneakyThrows
     public final void recordMethodInvocation(final Class<?> targetClass, final String methodName, final Class<?>[] argumentTypes, final Object[] arguments) {
-        jdbcMethodInvocations.add(new JdbcMethodInvocation(targetClass.getMethod(methodName, argumentTypes), arguments));
+        jdbcMethodInvocations.add(new JdbcMethodInvocation(JdbcMethodInvocation.build(targetClass, targetClass.getMethod(methodName, argumentTypes)), arguments));
     }
     
     /**

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/JdbcMethodInvocation.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/JdbcMethodInvocation.java
@@ -25,6 +25,7 @@ import net.sf.cglib.reflect.FastClass;
 import net.sf.cglib.reflect.FastMethod;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -38,7 +39,11 @@ public class JdbcMethodInvocation {
     private static ConcurrentMap<Class<?>, FastClass> fastClassMap = Maps.newConcurrentMap();
 
     public static FastMethod build(final Class<?> clz, Method method) {
-        FastClass fastClz = fastClassMap.putIfAbsent(clz, FastClass.create(clz));
+        FastClass fastClz = fastClassMap.get(clz);
+        if (Objects.isNull(fastClz)) {
+            fastClz = FastClass.create(clz);
+            fastClassMap.putIfAbsent(clz, fastClz);
+        }
         return fastClz.getMethod(method);
     }
 

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/JdbcMethodInvocation.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/JdbcMethodInvocation.java
@@ -17,11 +17,15 @@
 
 package org.apache.shardingsphere.shardingjdbc.jdbc.adapter.invocation;
 
+import com.google.common.collect.Maps;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import net.sf.cglib.reflect.FastClass;
+import net.sf.cglib.reflect.FastMethod;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Invocation that reflected call for JDBC method.
@@ -30,9 +34,16 @@ import java.lang.reflect.Method;
  */
 @RequiredArgsConstructor
 public class JdbcMethodInvocation {
-    
+
+    private static ConcurrentMap<Class<?>, FastClass> fastClassMap = Maps.newConcurrentMap();
+
+    public static FastMethod build(final Class<?> clz, Method method) {
+        FastClass fastClz = fastClassMap.putIfAbsent(clz, FastClass.create(clz));
+        return fastClz.getMethod(method);
+    }
+
     @Getter
-    private final Method method;
+    private final FastMethod method;
     
     @Getter
     private final Object[] arguments;

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/SetParameterMethodInvocation.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/SetParameterMethodInvocation.java
@@ -18,8 +18,7 @@
 package org.apache.shardingsphere.shardingjdbc.jdbc.adapter.invocation;
 
 import lombok.Getter;
-
-import java.lang.reflect.Method;
+import net.sf.cglib.reflect.FastMethod;
 
 /**
  * Invocation that reflected call for {@code PreparedStatement.setParameter} method.
@@ -34,7 +33,7 @@ public final class SetParameterMethodInvocation extends JdbcMethodInvocation {
     @Getter
     private final Object value;
     
-    public SetParameterMethodInvocation(final Method method, final Object[] arguments, final Object value) {
+    public SetParameterMethodInvocation(final FastMethod method, final Object[] arguments, final Object value) {
         super(method, arguments);
         this.index = (int) arguments[0];
         this.value = value;

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/JdbcMethodInvocationTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/JdbcMethodInvocationTest.java
@@ -25,14 +25,14 @@ public final class JdbcMethodInvocationTest {
     @Test
     @SneakyThrows
     public void assertInvokeSuccess() {
-        JdbcMethodInvocation actual = new JdbcMethodInvocation(String.class.getMethod("length"), new Object[] {});
+        JdbcMethodInvocation actual = new JdbcMethodInvocation(JdbcMethodInvocation.build(String.class, String.class.getMethod("length")), new Object[] {});
         actual.invoke("");
     }
     
     @Test(expected = IllegalAccessException.class)
     @SneakyThrows
     public void assertInvokeFailure() {
-        JdbcMethodInvocation actual = new JdbcMethodInvocation(String.class.getDeclaredMethod("indexOfSupplementary", int.class, int.class), new Object[] {1, 1});
+        JdbcMethodInvocation actual = new JdbcMethodInvocation(JdbcMethodInvocation.build(String.class, String.class.getDeclaredMethod("indexOfSupplementary", int.class, int.class)), new Object[] {1, 1});
         actual.invoke("");
     }
 }

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/SetParameterMethodInvocationTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/invocation/SetParameterMethodInvocationTest.java
@@ -30,14 +30,14 @@ public final class SetParameterMethodInvocationTest {
     @Test
     @SneakyThrows
     public void assertGetValue() {
-        SetParameterMethodInvocation actual = new SetParameterMethodInvocation(PreparedStatement.class.getMethod("setInt", int.class, int.class), new Object[] {1, 100}, 100);
+        SetParameterMethodInvocation actual = new SetParameterMethodInvocation(JdbcMethodInvocation.build(PreparedStatement.class, PreparedStatement.class.getMethod("setInt", int.class, int.class)), new Object[] {1, 100}, 100);
         assertThat(actual.getValue(), is((Object) 100));
     }
     
     @Test
     @SneakyThrows
     public void assertChangeValueArgument() {
-        SetParameterMethodInvocation actual = new SetParameterMethodInvocation(PreparedStatement.class.getMethod("setInt", int.class, int.class), new Object[] {1, 100}, 100);
+        SetParameterMethodInvocation actual = new SetParameterMethodInvocation(JdbcMethodInvocation.build(PreparedStatement.class, PreparedStatement.class.getMethod("setInt", int.class, int.class)), new Object[] {1, 100}, 100);
         actual.changeValueArgument(200);
         assertThat(actual.getArguments()[1], is((Object) 200));
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- replace JdbcMethodInvocation member variable : Method method -> FastMethod method
- add cglib class to cache with name fastClassMap

use JdbcMethodInvocation sample test, loop 100k times, compare with cglib invoke, It's 1000% faster than jdk invoke.
