### PR TITLE
fix: OrchestrationDataSource renew error. issue: #1773

### DIFF
--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationMasterSlaveDataSource.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationMasterSlaveDataSource.java
@@ -102,9 +102,10 @@ public class OrchestrationMasterSlaveDataSource extends AbstractOrchestrationDat
     @Subscribe
     @SneakyThrows
     public final synchronized void renew(final DataSourceChangedEvent dataSourceChangedEvent) {
-        dataSource.close();
+        MasterSlaveDataSource dataSourceOld = dataSource;
         dataSource = new MasterSlaveDataSource(
                 DataSourceConverter.getDataSourceMap(dataSourceChangedEvent.getDataSourceConfigurations()), dataSource.getMasterSlaveRule(), dataSource.getShardingProperties().getProps());
+        dataSourceOld.close();
     }
     
     /**

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
@@ -98,9 +98,10 @@ public class OrchestrationShardingDataSource extends AbstractOrchestrationDataSo
     @Subscribe
     @SneakyThrows
     public final synchronized void renew(final DataSourceChangedEvent dataSourceChangedEvent) {
-        dataSource.close();
+        ShardingDataSource dataSourceOld = dataSource;
         dataSource = new ShardingDataSource(DataSourceConverter.getDataSourceMap(dataSourceChangedEvent.getDataSourceConfigurations()), dataSource.getShardingContext().getShardingRule(),
                 dataSource.getShardingContext().getShardingProperties().getProps());
+        dataSourceOld.close();
     }
     
     /**


### PR DESCRIPTION
Fixes #1773.

Changes proposed in this pull request:
- correct process of OrchestrationDataSource renewing by this way:

while get DataSourceChangedEvent:
1. old datasources keep working(processing sql requests already received).
2. create new datasources, and new sql requests will get connections by these new datasources.
3. close old datasources gracefully.

