### PR TITLE
For #1933, use connection.getSchema to filter unnecessary tables

### DIFF
--- a/sharding-core/src/main/java/org/apache/shardingsphere/core/metadata/table/executor/TableMetaDataInitializer.java
+++ b/sharding-core/src/main/java/org/apache/shardingsphere/core/metadata/table/executor/TableMetaDataInitializer.java
@@ -92,7 +92,7 @@ public final class TableMetaDataInitializer {
         DataSourceMetaData dataSourceMetaData = shardingDataSourceMetaData.getActualDataSourceMetaData(dataSourceName);
         String catalog = null == dataSourceMetaData ? null : dataSourceMetaData.getSchemaName();
         try (Connection connection = connectionManager.getConnection(dataSourceName);
-             ResultSet resultSet = connection.getMetaData().getTables(catalog, null, null, new String[]{"TABLE"})) {
+             ResultSet resultSet = connection.getMetaData().getTables(catalog, connection.getSchema(), null, new String[]{"TABLE"})) {
             while (resultSet.next()) {
                 String tableName = resultSet.getString("TABLE_NAME");
                 if (!tableName.contains("$") && !tableName.contains("/")) {


### PR DESCRIPTION
Fixes #1933.