### PR TITLE
#1818 add sql.simple.length config

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/constant/properties/ShardingPropertiesConstant.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/constant/properties/ShardingPropertiesConstant.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
  * 
  * @author gaohongtao
  * @author caohao
+ * @author cookie
  */
 @RequiredArgsConstructor
 @Getter
@@ -41,7 +42,16 @@ public enum ShardingPropertiesConstant {
      * </p>
      */
     SQL_SHOW("sql.show", String.valueOf(Boolean.FALSE), boolean.class),
-    
+
+    /**
+     *<p>
+     * Maximum length of logic SQL.
+     * In sharding mode, if the length of logic SQL longer than the number, log will display in simple style to avoid too much content .
+     * Default: Integer.MAX_VALUE
+     *</p>
+     */
+    SQL_SIMPLE_LENGTH("sql.simple.length", String.valueOf(Integer.MAX_VALUE), int.class),
+
     /**
      * Worker group or user group thread max size.
      *

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/constant/ShardingPropertiesConstantTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/constant/ShardingPropertiesConstantTest.java
@@ -30,6 +30,7 @@ public class ShardingPropertiesConstantTest {
     public void assertFindByKey() {
         assertThat(ShardingPropertiesConstant.findByKey("sql.show"), is(ShardingPropertiesConstant.SQL_SHOW));
         assertThat(ShardingPropertiesConstant.findByKey("executor.size"), is(ShardingPropertiesConstant.EXECUTOR_SIZE));
+        assertThat(ShardingPropertiesConstant.findByKey("sql.simple.length"), is(ShardingPropertiesConstant.SQL_SIMPLE_LENGTH));
     }
     
     @Test

--- a/sharding-core/sharding-core-entry/src/main/java/org/apache/shardingsphere/core/BaseShardingEngine.java
+++ b/sharding-core/sharding-core-entry/src/main/java/org/apache/shardingsphere/core/BaseShardingEngine.java
@@ -64,7 +64,8 @@ public abstract class BaseShardingEngine {
         SQLRouteResult result = route(sql, clonedParameters);
         result.getRouteUnits().addAll(HintManager.isDatabaseShardingOnly() ? convert(sql, clonedParameters, result) : rewriteAndConvert(sql, clonedParameters, result));
         if (shardingProperties.getValue(ShardingPropertiesConstant.SQL_SHOW)) {
-            SQLLogger.logSQL(sql, result.getSqlStatement(), result.getRouteUnits());
+            int maxLogicSqlLength = shardingProperties.getValue(ShardingPropertiesConstant.SQL_SIMPLE_LENGTH);
+            SQLLogger.logSQL(sql, maxLogicSqlLength, result.getSqlStatement(), result.getRouteUnits());
         }
         return result;
     }

--- a/sharding-core/sharding-core-entry/src/test/java/org/apache/shardingsphere/core/BaseShardingEngineTest.java
+++ b/sharding-core/sharding-core-entry/src/test/java/org/apache/shardingsphere/core/BaseShardingEngineTest.java
@@ -46,6 +46,7 @@ public abstract class BaseShardingEngineTest {
     protected final ShardingProperties getShardingProperties() {
         Properties result = new Properties();
         result.setProperty(ShardingPropertiesConstant.SQL_SHOW.getKey(), Boolean.TRUE.toString());
+        result.setProperty(ShardingPropertiesConstant.SQL_SIMPLE_LENGTH.getKey(), "10");
         return new ShardingProperties(result);
     }
     

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/SQLLogger.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/SQLLogger.java
@@ -24,6 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.core.parse.parser.sql.SQLStatement;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * SQL logger.
@@ -39,19 +41,31 @@ public final class SQLLogger {
      * Print SQL log for sharding rule.
      * 
      * @param logicSQL logic SQL
+     * @param maxLogicSqlLength max length of logic SQL
      * @param sqlStatement SQL statement
      * @param routeUnits route units
      */
-    public static void logSQL(final String logicSQL, final SQLStatement sqlStatement, final Collection<RouteUnit> routeUnits) {
+    public static void logSQL(final String logicSQL, final int maxLogicSqlLength, final SQLStatement sqlStatement, final Collection<RouteUnit> routeUnits) {
         log("Rule Type: sharding");
-        log("Logic SQL: {}", logicSQL);
-        log("SQLStatement: {}", sqlStatement);
-        for (RouteUnit each : routeUnits) {
-            if (each.getSqlUnit().getParameters().isEmpty()) {
-                log("Actual SQL: {} ::: {}", each.getDataSourceName(), each.getSqlUnit().getSql());
-            } else {
-                log("Actual SQL: {} ::: {} ::: {}", each.getDataSourceName(), each.getSqlUnit().getSql(), each.getSqlUnit().getParameters());
+        int logicSqlLength = logicSQL.length();
+        if (logicSqlLength <= maxLogicSqlLength) {
+            log("Logic SQL: {}", logicSQL);
+            log("SQLStatement: {}", sqlStatement);
+            for (RouteUnit each : routeUnits) {
+                if (each.getSqlUnit().getParameters().isEmpty()) {
+                    log("Actual SQL: {} ::: {}", each.getDataSourceName(), each.getSqlUnit().getSql());
+                } else {
+                    log("Actual SQL: {} ::: {} ::: {}", each.getDataSourceName(), each.getSqlUnit().getSql(), each.getSqlUnit().getParameters());
+                }
             }
+        } else {
+            log("Logic SQL(simple): {}", logicSQL.substring(0, maxLogicSqlLength));
+            log("SQLStatement: {}", sqlStatement);
+            Set<String> dataSourceNames = new HashSet<>(routeUnits.size());
+            for (RouteUnit each : routeUnits) {
+                dataSourceNames.add(each.getDataSourceName());
+            }
+            log("Actual SQL(simple): {} ::: {}", dataSourceNames, routeUnits.size());
         }
     }
     


### PR DESCRIPTION
Fixes #1818 .

Changes proposed in this pull request:
- add sql.simple.length for shard config
- In sharding mode, if the length of logic SQL longer than the number, log will display in simple style to avoid too much content
