### PR TITLE
fix SQL rewrite issue

### DIFF
--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/ParsingSQLRouter.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/ParsingSQLRouter.java
@@ -102,7 +102,7 @@ public final class ParsingSQLRouter implements ShardingRouter {
             mergeShardingValues(optimizeResult.getShardingConditions());
         }
         RoutingResult routingResult = RoutingEngineFactory.newInstance(shardingRule, shardingMetaData.getDataSource(), sqlStatement, optimizeResult).route();
-        if (sqlStatement instanceof SelectStatement && null != ((SelectStatement) sqlStatement).getLimit()) {
+        if (sqlStatement instanceof SelectStatement && null != ((SelectStatement) sqlStatement).getLimit() && !routingResult.isSingleRouting()) {
             processLimit(parameters, (SelectStatement) sqlStatement, routingResult.isSingleRouting());
         }
         if (needMerge) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-I reported an issue 4 months ago,https://github.com/apache/incubator-shardingsphere/issues/1348.
-Loxp fixed it,https://github.com/apache/incubator-shardingsphere/pull/1499.
-But it's not perfect,it has another issue. If the SQL is single routing and the pagesize is bigger than one,then the query result will return all rows,bacause the parameters has been rewrited in ParsingSQLRouter.route().
