### PR TITLE
try commit a startup boosted mode and default set to false

### DIFF
--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/metadata/TableMetaDataInitializer.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/metadata/TableMetaDataInitializer.java
@@ -30,10 +30,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Table meta data initializer.
@@ -41,65 +39,168 @@ import java.util.Map;
  * @author zhangliang
  */
 public final class TableMetaDataInitializer {
-    
+
     private final ShardingDataSourceMetaData shardingDataSourceMetaData;
-    
+
     private final TableMetaDataConnectionManager connectionManager;
-    
+
     private final TableMetaDataLoader tableMetaDataLoader;
-    
-    public TableMetaDataInitializer(final ShardingDataSourceMetaData shardingDataSourceMetaData, final ShardingExecuteEngine executeEngine, 
+
+    //Here's a switch to open boosted startup mode;
+    //before function integrated into base project,
+    //you can rebuild org.apache.shardingsphere.core.execute module,
+    //change this to true ,then "mvn clean install" to use this function in your local environment.
+    private boolean startUpBoostedMode = false;
+
+    public TableMetaDataInitializer(final ShardingDataSourceMetaData shardingDataSourceMetaData, final ShardingExecuteEngine executeEngine,
                                     final TableMetaDataConnectionManager connectionManager, final int maxConnectionsSizePerQuery, final boolean isCheckingMetaData) {
         this.shardingDataSourceMetaData = shardingDataSourceMetaData;
         this.connectionManager = connectionManager;
         tableMetaDataLoader = new TableMetaDataLoader(shardingDataSourceMetaData, executeEngine, connectionManager, maxConnectionsSizePerQuery, isCheckingMetaData);
     }
-    
+
+    public boolean isStartUpBoostedMode() {
+        return startUpBoostedMode;
+    }
+
+    public void setStartUpBoostedMode(boolean startUpBoostedMode) {
+        this.startUpBoostedMode = startUpBoostedMode;
+    }
+
     /**
      * Load table meta data.
      *
      * @param logicTableName logic table name
-     * @param shardingRule sharding rule
+     * @param shardingRule   sharding rule
      * @return table meta data
      */
     @SneakyThrows
     public TableMetaData load(final String logicTableName, final ShardingRule shardingRule) {
         return tableMetaDataLoader.load(logicTableName, shardingRule);
     }
-    
+
     /**
      * Load all table meta data.
-     * 
+     *
      * @param shardingRule sharding rule
      * @return all table meta data
      */
     @SneakyThrows
     public Map<String, TableMetaData> load(final ShardingRule shardingRule) {
         Map<String, TableMetaData> result = new HashMap<>();
+        if (startUpBoostedMode) {
+            System.out.println("org.apache.shardingsphere.core.execute.TableMetaDataInitializer:\n" +
+                    "    Beta function warn: Startup boosted mode is friendly for dev mode, " +
+                    "but it may cause database resources exhausted. \n" +
+                    "    Number of sqrt(number of all actual tables) threads created and finished in process. " +
+                    "if error occurs, change to stable mode. \n"+
+                    "    Or just use this in your local dev environment. ");
+        }
         result.putAll(loadShardingTables(shardingRule));
         result.putAll(loadDefaultTables(shardingRule));
         return result;
     }
-    
+
     private Map<String, TableMetaData> loadShardingTables(final ShardingRule shardingRule) throws SQLException {
-        Map<String, TableMetaData> result = new HashMap<>(shardingRule.getTableRules().size(), 1);
-        for (TableRule each : shardingRule.getTableRules()) {
-            result.put(each.getLogicTable(), tableMetaDataLoader.load(each.getLogicTable(), shardingRule));
+
+        //get ready for tableNameList
+        Collection<TableRule> tableRules = shardingRule.getTableRules();
+        List<String> logicNameList = new ArrayList<>();
+        for (TableRule each : tableRules) {
+            logicNameList.add(each.getLogicTable());
         }
-        return result;
+
+        if (startUpBoostedMode) {
+            return loadTablesInBoostedMode(logicNameList, shardingRule);
+        } else {
+            return loadTablesInStableMode(logicNameList, shardingRule);
+        }
+
     }
-    
+
     private Map<String, TableMetaData> loadDefaultTables(final ShardingRule shardingRule) throws SQLException {
-        Map<String, TableMetaData> result = new HashMap<>(shardingRule.getTableRules().size(), 1);
+        Map<String, TableMetaData> result = new ConcurrentHashMap<>(shardingRule.getTableRules().size(), 1);
         Optional<String> actualDefaultDataSourceName = shardingRule.findActualDefaultDataSourceName();
         if (actualDefaultDataSourceName.isPresent()) {
-            for (String each : getAllTableNames(actualDefaultDataSourceName.get())) {
-                result.put(each, tableMetaDataLoader.load(each, shardingRule));
+
+            //get ready data
+            Collection<String> allTableNames = getAllTableNames(actualDefaultDataSourceName.get());
+            List<String> allTableNamesList = new ArrayList<>(allTableNames);
+
+            if (startUpBoostedMode) {
+                return loadTablesInBoostedMode(allTableNamesList, shardingRule);
+            } else {
+                return loadTablesInStableMode(allTableNamesList, shardingRule);
             }
+
         }
         return result;
     }
-    
+
+    private Map<String, TableMetaData> loadTablesInBoostedMode(List<String> tableNameList, final ShardingRule shardingRule) throws SQLException {
+
+        //Use multi threads to boost the start up .
+        final ConcurrentHashMap<String, TableMetaData> result = new ConcurrentHashMap<>(shardingRule.getTableRules().size(), 1);
+
+        //Slice the tableNameList to small parts.
+        Integer elementNumber = (int) Math.sqrt(tableNameList.size());
+        List<List<String>> parts = new ArrayList<>();
+        for (int i = 0, len = tableNameList.size(); i < len; i += elementNumber) {
+            if (i + elementNumber <= len) {
+                parts.add(tableNameList.subList(i, i + elementNumber));
+            } else {
+                parts.add(tableNameList.subList(i, len));
+            }
+        }
+
+        //process for every slices
+        List<Thread> threadList = new ArrayList<>();
+        final List<SQLException> exceptionList = new ArrayList<>();
+
+        for (final List<String> eachPart : parts) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    for (String each : eachPart) {
+                        try {
+                            result.put(each, tableMetaDataLoader.load(each, shardingRule));
+                        } catch (SQLException e) {
+                            exceptionList.add(e);
+                        }
+                    }
+                }
+            });
+            thread.start();
+            threadList.add(thread);
+        }
+
+        //use 'join()' wait all thread finished.
+        for (Thread thread : threadList) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        //throw SQLException
+        if (exceptionList.size() != 0) {
+            throw exceptionList.get(0);
+        }
+
+        return result;
+    }
+
+    private Map<String, TableMetaData> loadTablesInStableMode(List<String> tableNameList, ShardingRule shardingRule) throws SQLException {
+        final Map<String, TableMetaData> result = new ConcurrentHashMap<>(shardingRule.getTableRules().size(), 1);
+
+        for (String each : tableNameList) {
+            result.put(each, tableMetaDataLoader.load(each, shardingRule));
+        }
+
+        return result;
+    }
+
     private Collection<String> getAllTableNames(final String dataSourceName) throws SQLException {
         Collection<String> result = new LinkedHashSet<>();
         DataSourceMetaData dataSourceMetaData = shardingDataSourceMetaData.getActualDataSourceMetaData(dataSourceName);
@@ -115,7 +216,7 @@ public final class TableMetaDataInitializer {
         }
         return result;
     }
-    
+
     private String getCurrentSchemaName(final Connection connection) throws SQLException {
         try {
             return connection.getSchema();


### PR DESCRIPTION
When we used sharding-jdbc for a development environment , if we have many actual tables, like more than 200 total , it's cost more time to start up the sharding-jdbc .  This may cost several times for developers , especially non-elite programmers for debug process.

I try to found out why this happend , then I try to fix or improve some function especially for dev environment.

I used multi threads to get ready for some map data , really, it's cost more connection database , when sharding-jdbc start up . As @terrymanu  said , it may cause database resources exhausted.

Then I make threads in number of [ sqrt(total actual tables) ], assemby a arraylist to split the slice, into parts of alltableNames, to reduce the threads number , in hope to reduce connection to database.

I collected SQLExceptions , re throw them like origin code to upper logic, but can not throw new exceptions like InterruptedException to upper , because it will change the upper function's "throws" . so I droped them.

why I try to commit a unstable function (or it stable but we don't Long-term tested) , and make a switcher to close this function ?

Because , in our small business, or others like us . Our coder are not elited at all , they cost many many time to restart the local environment to debug ,to change propertitys. So sad , in the waiting time, they are very depressed and complaining complaining ... In our case, it's cost more than 4 minutes :(  in one time. And now it's reduce to 40 seconds , that's within temptation and boost morale !

So I hope is , may officer can make a global switcher in a suitable location to let us set this like a dev frendly mode , to let us boosted the startup process , especially  in a develop environment.

Fixes #ISSUSE_ID.

Changes proposed in this pull request:

in class TableMetaDataInitializer

    //Here's a switch to open boosted startup mode;
    //before function integrated into base project,
    //you can rebuild org.apache.shardingsphere.core.execute module,
    //change this to true ,then "mvn clean install" to use this function in your local environment.
    private boolean startUpBoostedMode = false;

in function Map<String, TableMetaData> load(final ShardingRule shardingRule):

     if (startUpBoostedMode) {
            System.out.println("org.apache.shardingsphere.core.execute.TableMetaDataInitializer:\n" +
                    "    Beta function warn: Startup boosted mode is friendly for dev mode, " +
                    "but it may cause database resources exhausted. \n" +
                    "    Number of sqrt(number of all actual tables) threads created and finished in process. " +
                    "if error occurs, change to stable mode. \n"+
                    "    Or just use this in your local dev environment. ");
        }