### PR TITLE
Fixed Unsupported data type:boolean exceptions

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/resultset/ResultSetUtil.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/resultset/ResultSetUtil.java
@@ -103,6 +103,8 @@ public final class ResultSetUtil {
                 return value;
             case "java.lang.String":
                 return value.toString();
+            case "boolean":
+                return number.intValue() == 1;
             default:
                 throw new ShardingException("Unsupported data type:%s", convertType);
         }


### PR DESCRIPTION
When use jpa&mysql boolean in entity will convert to 0,1 by mysql store as tinyint.Then when read by resultset util the true value(0,1) and boolean type in entity will make ShardingException("Unsupported data type:%s", convertType);

Fixes #2528 .

Changes proposed in this pull request:
- support boolean in entity and tinyint in mysql.
-
-
