### PR TITLE
When the key of Map/Set is a custom object, you must override hashCode and equals.

### DIFF
--- a/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/sql/context/selectitem/AggregationDistinctSelectItem.java
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/sql/context/selectitem/AggregationDistinctSelectItem.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.core.parse.sql.context.selectitem;
 
 import com.google.common.base.Optional;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.shardingsphere.core.constant.AggregationType;
 
@@ -27,6 +28,7 @@ import org.apache.shardingsphere.core.constant.AggregationType;
  * @author panjuan
  */
 @Getter
+@EqualsAndHashCode
 public final class AggregationDistinctSelectItem extends AggregationSelectItem {
     
     private final String distinctColumnName;

--- a/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/sql/context/selectitem/DistinctSelectItem.java
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/sql/context/selectitem/DistinctSelectItem.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.core.parse.sql.context.selectitem;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.core.parse.util.SQLUtil;
@@ -34,6 +35,7 @@ import java.util.Set;
  */
 @RequiredArgsConstructor
 @Getter
+@EqualsAndHashCode
 public final class DistinctSelectItem implements SelectItem {
     
     private final Set<String> distinctColumnNames;


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
When the key of Map/Set is a custom object, you must override hashCode and equals.