### PR TITLE
Fix#2629

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNames.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNames.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.core.rule;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import lombok.Getter;
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
@@ -41,6 +42,7 @@ public final class ShardingDataSourceNames {
     private final Collection<String> dataSourceNames;
     
     public ShardingDataSourceNames(final ShardingRuleConfiguration shardingRuleConfig, final Collection<String> rawDataSourceNames) {
+        Preconditions.checkArgument(null != shardingRuleConfig, "can not construct ShardingDataSourceNames with null ShardingRuleConfig");
         this.shardingRuleConfig = shardingRuleConfig;
         dataSourceNames = getAllDataSourceNames(rawDataSourceNames);
     }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
@@ -73,7 +73,8 @@ public class ShardingRule implements BaseRule {
     private final EncryptRule encryptRule;
     
     public ShardingRule(final ShardingRuleConfiguration shardingRuleConfig, final Collection<String> dataSourceNames) {
-        Preconditions.checkArgument(!dataSourceNames.isEmpty(), "Data sources cannot be empty.");
+        Preconditions.checkArgument(null != shardingRuleConfig, "ShardingRuleConfig cannot be null.");
+        Preconditions.checkArgument(null != dataSourceNames && !dataSourceNames.isEmpty(), "Data sources cannot be empty.");
         this.shardingRuleConfig = shardingRuleConfig;
         shardingDataSourceNames = new ShardingDataSourceNames(shardingRuleConfig, dataSourceNames);
         tableRules = createTableRules(shardingRuleConfig);

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNamesTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNamesTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public final class ShardingDataSourceNamesTest {
     
@@ -89,5 +90,16 @@ public final class ShardingDataSourceNamesTest {
                 new MasterSlaveRuleConfiguration("ms_ds", "master_ds", Collections.singletonList("slave_ds"), new LoadBalanceStrategyConfiguration("ROUND_ROBIN")));
         String actual = new ShardingDataSourceNames(shardingRuleConfig, Arrays.asList("master_ds", "slave_ds")).getRawMasterDataSourceName("default_ds");
         assertThat(actual, is("default_ds"));
+    }
+
+    @Test
+    public void assertConstructShardingDataSourceNamesWithNullShardingRuleConfiguration() {
+        try {
+            new ShardingDataSourceNames(null, Arrays.asList("master_ds", "slave_ds")).getRawMasterDataSourceName("default_ds");
+            fail("should throw a IllegalArgumentException when execute ShardingDataSourceNames's constructor with null ShardingRuleConfig");
+        } catch (IllegalArgumentException ignored){
+        } catch (Exception ex){
+            fail("should throw a IllegalArgumentException when execute ShardingDataSourceNames's construction with null ShardingRuleConfig");
+        }
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNamesTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNamesTest.java
@@ -92,7 +92,7 @@ public final class ShardingDataSourceNamesTest {
         assertThat(actual, is("default_ds"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void assertConstructShardingDataSourceNamesWithNullShardingRuleConfiguration() {
         try {
             new ShardingDataSourceNames(null, Arrays.asList("master_ds", "slave_ds")).getRawMasterDataSourceName("default_ds");

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNamesTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingDataSourceNamesTest.java
@@ -94,12 +94,6 @@ public final class ShardingDataSourceNamesTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void assertConstructShardingDataSourceNamesWithNullShardingRuleConfiguration() {
-        try {
-            new ShardingDataSourceNames(null, Arrays.asList("master_ds", "slave_ds")).getRawMasterDataSourceName("default_ds");
-            fail("should throw a IllegalArgumentException when execute ShardingDataSourceNames's constructor with null ShardingRuleConfig");
-        } catch (IllegalArgumentException ignored){
-        } catch (Exception ex){
-            fail("should throw a IllegalArgumentException when execute ShardingDataSourceNames's construction with null ShardingRuleConfig");
-        }
+        new ShardingDataSourceNames(null, Arrays.asList("master_ds", "slave_ds")).getRawMasterDataSourceName("default_ds");
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -331,14 +331,8 @@ public final class ShardingRuleTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void assertConstructShardingRuleWithNullShardingRuleConfiguration(){
-        try {
+    public void assertConstructShardingRuleWithNullShardingRuleConfiguration() {
         new ShardingRule(null, createDataSourceNames());
-            fail("should throw a IllegalArgumentException when execute ShardingRule's constructor with null ShardingRuleConfiguration");
-        } catch (IllegalArgumentException ignored){
-        } catch (Exception ex){
-            fail("should throw a IllegalArgumentException when execute ShardingRule's construction with null ShardingRuleConfiguration");
-        }
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -348,13 +342,7 @@ public final class ShardingRuleTest {
         shardingRuleConfiguration.getTableRuleConfigs().add(tableRuleConfiguration);
         shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_0", "master_ds_0", "slave_ds_0"));
         shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_1", "master_ds_1", "slave_ds_1"));
-        try {
-            new ShardingRule(shardingRuleConfiguration, null);
-            fail("should throw a IllegalArgumentException when execute ShardingRule's constructor with null DataSourceNames");
-        } catch (IllegalArgumentException ignored){
-        } catch (Exception ex){
-            fail("should throw a IllegalArgumentException when execute ShardingRule's construction with null DataSourceNames");
-        }
+        new ShardingRule(shardingRuleConfiguration, null);
     }
     
     private ShardingRule createMaximumShardingRule() {

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -341,7 +341,7 @@ public final class ShardingRuleTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void assertConstructShardingRuleWithNullDataSourceNames(){
         ShardingRuleConfiguration shardingRuleConfiguration = new ShardingRuleConfiguration();
         TableRuleConfiguration tableRuleConfiguration = createTableRuleConfiguration("LOGIC_TABLE", "ms_ds_${0..1}.table_${0..2}");

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -330,7 +330,7 @@ public final class ShardingRuleTest {
         assertThat(actual.getShardingLogicTableNames(Arrays.asList("LOGIC_TABLE", "BROADCAST_TABLE")), CoreMatchers.<Collection<String>>is(Collections.singletonList("LOGIC_TABLE")));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void assertConstructShardingRuleWithNullShardingRuleConfiguration(){
         try {
         new ShardingRule(null, createDataSourceNames());

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -327,6 +328,33 @@ public final class ShardingRuleTest {
     public void assertGetShardingLogicTableNames() {
         ShardingRule actual = createMaximumShardingRule();
         assertThat(actual.getShardingLogicTableNames(Arrays.asList("LOGIC_TABLE", "BROADCAST_TABLE")), CoreMatchers.<Collection<String>>is(Collections.singletonList("LOGIC_TABLE")));
+    }
+
+    @Test
+    public void assertConstructShardingRuleWithNullShardingRuleConfiguration(){
+        try {
+        new ShardingRule(null, createDataSourceNames());
+            fail("should throw a IllegalArgumentException when execute ShardingRule's constructor with null ShardingRuleConfiguration");
+        } catch (IllegalArgumentException ignored){
+        } catch (Exception ex){
+            fail("should throw a IllegalArgumentException when execute ShardingRule's construction with null ShardingRuleConfiguration");
+        }
+    }
+
+    @Test
+    public void assertConstructShardingRuleWithNullDataSourceNames(){
+        ShardingRuleConfiguration shardingRuleConfiguration = new ShardingRuleConfiguration();
+        TableRuleConfiguration tableRuleConfiguration = createTableRuleConfiguration("LOGIC_TABLE", "ms_ds_${0..1}.table_${0..2}");
+        shardingRuleConfiguration.getTableRuleConfigs().add(tableRuleConfiguration);
+        shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_0", "master_ds_0", "slave_ds_0"));
+        shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_1", "master_ds_1", "slave_ds_1"));
+        try {
+            new ShardingRule(shardingRuleConfiguration, null);
+            fail("should throw a IllegalArgumentException when execute ShardingRule's constructor with null DataSourceNames");
+        } catch (IllegalArgumentException ignored){
+        } catch (Exception ex){
+            fail("should throw a IllegalArgumentException when execute ShardingRule's construction with null DataSourceNames");
+        }
     }
     
     private ShardingRule createMaximumShardingRule() {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-shardingsphere/issues/2629.

Changes proposed in this pull request:
- add not null judge for ShardingDataSourceNames's constructor and unit test
- add not null judge for ShardingRule's constructor and unit test
