### PR TITLE
[INFRA-18812] Switch to .mvn/jvm.config ...

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx1024m -XX:MaxPermSize=256m

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -39,7 +39,8 @@ pipeline {
         }
         stage('Build & Test') {
             tools {
-                maven 'maven-3.2.1'
+			    // use at least Apache Maven 3.3.1 to have .mvn/jvm.config support
+                maven 'maven-3.3.1'
                 jdk 'JDK 1.8 (latest)'
             }
             steps {
@@ -47,8 +48,7 @@ pipeline {
                     ssBuildBadge.setStatus('running')
                     try {
                         sh '''
-                        echo "MAVEN_OPTS='-Xmx1024m -XX:MaxPermSize=256m'" > ~/.mavenrc
-                        mvn clean install cobertura:cobertura coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN} -Prelease
+                        mvn clean verify cobertura:cobertura coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN} -Prelease
                         '''
                         ssBuildBadge.setStatus('passing')
                     } catch (Exception err) {

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         stage('Build & Test') {
             tools {
 			    // use at least Apache Maven 3.3.1 to have .mvn/jvm.config support
-                maven 'maven-3.3.1'
+                maven 'Maven 3.6.0'
                 jdk 'JDK 1.8 (latest)'
             }
             steps {


### PR DESCRIPTION
... so MAVEN_OPTS won't get polluted.

Recently while running integration tests of Apache Maven we noticed our builds becoming more and more unstable. These tests all were testing MAVEN_OPTS.
We discovered that this project was generating .mavenrc files that stayed on the server, meaning that every new build was using this file and the new MAVEN_OPTS.
Since Maven 3.3.1 it is possible to define jvm arguments per project. This PR contains those changes and that will restore the predictable behaviour of Jenkins.


