### PR TITLE
Use QueryResultMetaData to judge case sensitive instead of `List<Boolean> columnCaseSensitive` in DistinctQueryResult

### DIFF
--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/AggregationDistinctQueryResult.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/AggregationDistinctQueryResult.java
@@ -43,9 +43,9 @@ public final class AggregationDistinctQueryResult extends DistinctQueryResult {
     
     private final AggregationDistinctQueryMetaData metaData;
         
-    private AggregationDistinctQueryResult(final QueryResultMetaData queryResultMetaData, final List<Boolean> columnCaseSensitive, final Iterator<QueryRow> resultData,
+    private AggregationDistinctQueryResult(final QueryResultMetaData queryResultMetaData, final Iterator<QueryRow> resultData,
         final AggregationDistinctQueryMetaData distinctQueryMetaData) {
-        super(queryResultMetaData, columnCaseSensitive, resultData);
+        super(queryResultMetaData, resultData);
         metaData = distinctQueryMetaData;
     }
     
@@ -74,7 +74,7 @@ public final class AggregationDistinctQueryResult extends DistinctQueryResult {
             public DistinctQueryResult apply(final QueryRow input) {
                 Set<QueryRow> resultData = new LinkedHashSet<>();
                 resultData.add(input);
-                return new AggregationDistinctQueryResult(getQueryResultMetaData(), getColumnCaseSensitive(), resultData.iterator(), metaData);
+                return new AggregationDistinctQueryResult(getQueryResultMetaData(), resultData.iterator(), metaData);
             }
         }));
     }

--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/DistinctQueryResult.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/DistinctQueryResult.java
@@ -53,8 +53,6 @@ public class DistinctQueryResult implements QueryResult {
     @Getter
     private final QueryResultMetaData queryResultMetaData;
     
-    private final List<Boolean> columnCaseSensitive;
-    
     private final Iterator<QueryRow> resultData;
     
     private QueryRow currentRow;
@@ -63,17 +61,7 @@ public class DistinctQueryResult implements QueryResult {
     public DistinctQueryResult(final Collection<QueryResult> queryResults, final List<String> distinctColumnLabels) {
         QueryResult firstQueryResult = queryResults.iterator().next();
         this.queryResultMetaData = firstQueryResult.getQueryResultMetaData();
-        this.columnCaseSensitive = getColumnCaseSensitive(firstQueryResult);
         resultData = getResultData(queryResults, distinctColumnLabels);
-    }
-    
-    @SneakyThrows
-    private List<Boolean> getColumnCaseSensitive(final QueryResult queryResult) {
-        List<Boolean> result = Lists.newArrayList(false);
-        for (int columnIndex = 1; columnIndex <= queryResult.getColumnCount(); columnIndex++) {
-            result.add(queryResult.isCaseSensitive(columnIndex));
-        }
-        return result;
     }
     
     @SneakyThrows
@@ -115,7 +103,8 @@ public class DistinctQueryResult implements QueryResult {
             public DistinctQueryResult apply(final QueryRow row) {
                 Set<QueryRow> resultData = new LinkedHashSet<>();
                 resultData.add(row);
-                return new DistinctQueryResult(queryResultMetaData, columnCaseSensitive, resultData.iterator());
+
+                return new DistinctQueryResult(queryResultMetaData, resultData.iterator());
             }
         }));
     }
@@ -177,7 +166,7 @@ public class DistinctQueryResult implements QueryResult {
     
     @Override
     public boolean isCaseSensitive(final int columnIndex) {
-        return columnCaseSensitive.get(columnIndex);
+        return queryResultMetaData.isCaseSensitive(columnIndex);
     }
     
     @Override

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/DistinctQueryResultTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/DistinctQueryResultTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.core.execute.sql.execute.result;
 
-import com.google.common.collect.Lists;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
@@ -150,6 +149,7 @@ public class DistinctQueryResultTest {
     
     @Test
     public void assertIsCaseSensitive() {
+        when(queryResultMetaData.isCaseSensitive(1)).thenReturn(true);
         assertTrue(distinctQueryResult.isCaseSensitive(1));
     }
     
@@ -178,12 +178,6 @@ public class DistinctQueryResultTest {
     @Test
     public void assertGetQueryResultMetaData() {
         assertThat(distinctQueryResult.getQueryResultMetaData(), is(queryResultMetaData));
-    }
-    
-    @Test
-    public void assertGetColumnCaseSensitive() {
-        List<Boolean> expected = Lists.newArrayList(false, true);
-        assertThat(distinctQueryResult.getColumnCaseSensitive(), is(expected));
     }
     
     @Test


### PR DESCRIPTION

Fixes https://github.com/apache/incubator-shardingsphere/issues/2857.

Changes proposed in this pull request:
1. remove List<Boolean> columnCaseSensitive from DistinctQueryResult.
2. modify AggregationDistinctQueryResult constructor.
3. modify unit tests class.
