### PR TITLE
remove check resultSets whether empty when initialize AbstractResultSetAdapter

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/AbstractResultSetAdapter.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/AbstractResultSetAdapter.java
@@ -63,7 +63,6 @@ public abstract class AbstractResultSetAdapter extends AbstractUnsupportedOperat
     private final Map<String, String> logicAndActualColumns; 
     
     public AbstractResultSetAdapter(final List<ResultSet> resultSets, final Statement statement, final SQLRouteResult sqlRouteResult) {
-        Preconditions.checkArgument(!resultSets.isEmpty());
         this.resultSets = resultSets;
         this.statement = statement;
         this.sqlRouteResult = sqlRouteResult;


### PR DESCRIPTION
Fixes #2922.

Changes proposed in this pull request:
- remove check resultSets whether empty when initialize AbstractResultSetAdapter
