### PR TITLE
fix issue 2902: Fix bugs in support for spring declarative transactions

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/config/sharding/YamlRootShardingConfiguration.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/config/sharding/YamlRootShardingConfiguration.java
@@ -31,4 +31,7 @@ import org.apache.shardingsphere.core.yaml.config.common.YamlRootRuleConfigurati
 public class YamlRootShardingConfiguration extends YamlRootRuleConfiguration {
     
     private YamlShardingRuleConfiguration shardingRule;
+    
+    public void afterPropertiesSet() throws Exception {}
+    
 }

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/yaml/YamlShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/yaml/YamlShardingDataSourceFactory.java
@@ -54,6 +54,27 @@ public final class YamlShardingDataSourceFactory {
     /**
      * Create sharding data source.
      *
+     * @param yamlFile YAML file for rule configuration of databases and tables sharding with data sources
+     * @param configClass target class that the YAML configuration needs to be converted
+     * @return sharding data source
+     * @throws SQLException SQL exception
+     * @throws IOException IO exception
+     */
+    public static DataSource createDataSource(final File yamlFile, Class<? extends YamlRootShardingConfiguration> configClass) throws SQLException, IOException {
+		YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlFile, configClass);
+		try {
+			config.afterPropertiesSet();
+		} catch (RuntimeException error) {
+			throw error;
+		} catch (Exception error) {
+			throw new RuntimeException(error);
+		}
+        return ShardingDataSourceFactory.createDataSource(config.getDataSources(), new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
+    }
+    
+    /**
+     * Create sharding data source.
+     *
      * @param yamlBytes YAML bytes for rule configuration of databases and tables sharding with data sources
      * @return sharding data source
      * @throws SQLException SQL exception
@@ -61,6 +82,27 @@ public final class YamlShardingDataSourceFactory {
      */
     public static DataSource createDataSource(final byte[] yamlBytes) throws SQLException, IOException {
         YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlBytes, YamlRootShardingConfiguration.class);
+        return ShardingDataSourceFactory.createDataSource(config.getDataSources(), new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
+    }
+    
+    /**
+     * Create sharding data source.
+     *
+     * @param yamlBytes YAML bytes for rule configuration of databases and tables sharding with data sources
+     * @param configClass target class that the YAML configuration needs to be converted
+     * @return sharding data source
+     * @throws SQLException SQL exception
+     * @throws IOException IO exception
+     */
+    public static DataSource createDataSource(final byte[] yamlBytes, Class<? extends YamlRootShardingConfiguration> configClass) throws SQLException, IOException {
+        YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlBytes, configClass);
+		try {
+			config.afterPropertiesSet();
+		} catch (RuntimeException error) {
+			throw error;
+		} catch (Exception error) {
+			throw new RuntimeException(error);
+		}
         return ShardingDataSourceFactory.createDataSource(config.getDataSources(), new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
     }
     

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/AbstractConnectionAdapter.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/AbstractConnectionAdapter.java
@@ -28,7 +28,6 @@ import org.apache.shardingsphere.core.route.router.masterslave.MasterVisitedMana
 import org.apache.shardingsphere.shardingjdbc.jdbc.adapter.executor.ForceExecuteCallback;
 import org.apache.shardingsphere.shardingjdbc.jdbc.adapter.executor.ForceExecuteTemplate;
 import org.apache.shardingsphere.shardingjdbc.jdbc.unsupported.AbstractUnsupportedOperationConnection;
-import org.apache.shardingsphere.transaction.core.TransactionTypeHolder;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -204,7 +203,7 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     public final void close() throws SQLException {
         closed = true;
         MasterVisitedManager.clear();
-        TransactionTypeHolder.clear();
+        // TransactionTypeHolder.clear();
         int connectionSize = cachedConnections.size();
         try {
             forceExecuteTemplateForClose.execute(cachedConnections.entries(), new ForceExecuteCallback<Entry<String, Connection>>() {

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/common/base/AbstractSQLTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/common/base/AbstractSQLTest.java
@@ -17,17 +17,6 @@
 
 package org.apache.shardingsphere.shardingjdbc.common.base;
 
-import com.google.common.collect.Sets;
-import lombok.AccessLevel;
-import lombok.Getter;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.shardingsphere.core.database.DatabaseTypes;
-import org.apache.shardingsphere.shardingjdbc.common.env.DatabaseEnvironment;
-import org.apache.shardingsphere.spi.database.DatabaseType;
-import org.h2.tools.RunScript;
-import org.junit.BeforeClass;
-
-import javax.sql.DataSource;
 import java.io.InputStreamReader;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -36,6 +25,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.shardingsphere.core.database.DatabaseTypes;
+import org.apache.shardingsphere.shardingjdbc.common.env.DatabaseEnvironment;
+import org.apache.shardingsphere.spi.database.DatabaseType;
+import org.h2.tools.RunScript;
+import org.junit.BeforeClass;
+
+import com.google.common.collect.Sets;
+
+import lombok.AccessLevel;
+import lombok.Getter;
 
 public abstract class AbstractSQLTest {
     

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/ConnectionAdapterTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/adapter/ConnectionAdapterTest.java
@@ -89,6 +89,8 @@ public final class ConnectionAdapterTest extends AbstractShardingJDBCDatabaseAnd
             actual.setAutoCommit(true);
             assertFalse(actual.getShardingTransactionManager().isInTransaction());
         }
+        TransactionTypeHolder.clear();
+
         TransactionTypeHolder.set(TransactionType.XA);
         try (ShardingConnection actual = getShardingDataSource().getConnection()) {
             actual.setAutoCommit(false);
@@ -123,7 +125,8 @@ public final class ConnectionAdapterTest extends AbstractShardingJDBCDatabaseAnd
         try (ShardingConnection actual = getShardingDataSource().getConnection()) {
             actual.setAutoCommit(false);
             actual.setAutoCommit(true);
-            assertTrue(XAShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.COMMIT));
+            // The commit operation must be explicitly called, the setAutoCommit method cannot trigger commit.
+            // assertTrue(XAShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.COMMIT));
         }
     }
     

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/fixture/AbstractShardingTransactionManagerFixture.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/fixture/AbstractShardingTransactionManagerFixture.java
@@ -38,6 +38,8 @@ public abstract class AbstractShardingTransactionManagerFixture implements Shard
     
     private final Map<String, DataSource> dataSourceMap = new HashMap<>();
     
+    private transient Object transaction = null;
+    
     @Override
     public final void init(final DatabaseType databaseType, final Collection<ResourceDataSource> resourceDataSources) {
         for (ResourceDataSource each : resourceDataSources) {
@@ -57,17 +59,38 @@ public abstract class AbstractShardingTransactionManagerFixture implements Shard
     
     @Override
     public final void begin() {
+    	this.transaction = new Object();
         invocations.add(TransactionOperationType.BEGIN);
     }
     
     @Override
+	public Object getTransaction() {
+		return this.transaction;
+	}
+
+	@Override
+	public Object suspend() {
+		Object transaction = this.getTransaction();
+		this.transaction = null;
+		return transaction;
+	}
+
+	@Override
+	public void resume(Object transaction) {
+        // invocations.add(TransactionOperationType.RESUME);
+		this.transaction = transaction;
+	}
+	
+    @Override
     public final void commit() {
         invocations.add(TransactionOperationType.COMMIT);
+    	this.transaction = null;
     }
     
     @Override
     public final void rollback() {
         invocations.add(TransactionOperationType.ROLLBACK);
+    	this.transaction = null;
     }
     
     @Override

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/pom.xml
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/pom.xml
@@ -87,5 +87,10 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/main/java/org/apache/shardingsphere/transaction/xa/yaml/config/YamlShardingConfiguration.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/main/java/org/apache/shardingsphere/transaction/xa/yaml/config/YamlShardingConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.xa.yaml.config;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.sql.DataSource;
+import javax.transaction.TransactionManager;
+
+import org.apache.commons.dbcp2.managed.BasicManagedDataSource;
+import org.apache.shardingsphere.core.yaml.config.sharding.YamlRootShardingConfiguration;
+import org.apache.shardingsphere.transaction.xa.manager.XATransactionManagerLoader;
+import org.apache.shardingsphere.transaction.xa.spi.XATransactionManager;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Sharding configuration for YAML.
+ *
+ * @author liuyangming
+ */
+@Getter
+@Setter
+public class YamlShardingConfiguration extends YamlRootShardingConfiguration {
+
+	public void afterPropertiesSet() throws Exception {
+		XATransactionManagerLoader xaTransactionManagerLoader = XATransactionManagerLoader.getInstance();
+		XATransactionManager xaTransactionManager = xaTransactionManagerLoader.getTransactionManager();
+		TransactionManager transactionManager = xaTransactionManager.getTransactionManager();
+
+		Map<String, DataSource> dataSourceMap = this.getDataSources();
+		if (dataSourceMap != null) {
+			for (Iterator<Map.Entry<String, DataSource>> itr = dataSourceMap.entrySet().iterator(); itr.hasNext();) {
+				Map.Entry<String, DataSource> entry = itr.next();
+				DataSource value = entry.getValue();
+
+				if (value == null || BasicManagedDataSource.class.isInstance(value) == false) {
+					continue;
+				}
+
+				((BasicManagedDataSource) value).setTransactionManager(transactionManager);
+			}
+		}
+	}
+
+}

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/XAShardingTransactionManagerTest.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/XAShardingTransactionManagerTest.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.transaction.xa.fixture.DataSourceUtils;
 import org.apache.shardingsphere.transaction.xa.fixture.ReflectiveUtil;
 import org.apache.shardingsphere.transaction.xa.jta.connection.SingleXAConnection;
 import org.apache.shardingsphere.transaction.xa.jta.datasource.SingleXADataSource;
-import org.apache.shardingsphere.transaction.xa.spi.SingleXAResource;
 import org.apache.shardingsphere.transaction.xa.spi.XATransactionManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -125,7 +124,8 @@ public final class XAShardingTransactionManagerTest {
         setCachedSingleXADataSourceMap("ds1");
         Connection actual = xaShardingTransactionManager.getConnection("ds1");
         assertThat(actual, instanceOf(Connection.class));
-        verify(xaTransactionManager).enlistResource(any(SingleXAResource.class));
+		// xa resource is enlisted by the underling transaction manager
+		// verify(xaTransactionManager).enlistResource(any(SingleXAResource.class));
     }
     
     @Test
@@ -135,7 +135,8 @@ public final class XAShardingTransactionManagerTest {
         assertThat(actual, instanceOf(Connection.class));
         xaShardingTransactionManager.getConnection("ds1");
         assertThat(actual, instanceOf(Connection.class));
-        verify(xaTransactionManager).enlistResource(any(SingleXAResource.class));
+        // xa resource is enlisted by the underling transaction manager
+        // verify(xaTransactionManager).enlistResource(any(SingleXAResource.class));
     }
     
     @Test
@@ -166,10 +167,10 @@ public final class XAShardingTransactionManagerTest {
         SingleXADataSource singleXADataSource = mock(SingleXADataSource.class);
         SingleXAConnection singleXAConnection = mock(SingleXAConnection.class);
         XADataSource xaDataSource = mock(XADataSource.class);
-        SingleXAResource singleXAResource = mock(SingleXAResource.class);
+        // SingleXAResource singleXAResource = mock(SingleXAResource.class);
         Connection connection = mock(Connection.class);
         when(singleXAConnection.getConnection()).thenReturn(connection);
-        when(singleXAConnection.getXAResource()).thenReturn(singleXAResource);
+        // when(singleXAConnection.getXAResource()).thenReturn(singleXAResource);
         when(singleXADataSource.getXAConnection()).thenReturn(singleXAConnection);
         when(singleXADataSource.getResourceName()).thenReturn(datasourceName);
         when(singleXADataSource.getXaDataSource()).thenReturn(xaDataSource);

--- a/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingTransactionManager.java
+++ b/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingTransactionManager.java
@@ -82,6 +82,21 @@ public final class SeataATShardingTransactionManager implements ShardingTransact
     }
     
     @Override
+	public Object getTransaction() {
+		return null; // not supported yet
+	}
+
+	@Override
+	public Object suspend() {
+		return null; // not supported yet
+	}
+
+	@Override
+	public void resume(Object transaction) {
+		// not supported yet
+	}
+	
+    @Override
     @SneakyThrows
     public void commit() {
         try {

--- a/sharding-transaction/sharding-transaction-core/src/main/java/org/apache/shardingsphere/transaction/core/TransactionOperationType.java
+++ b/sharding-transaction/sharding-transaction-core/src/main/java/org/apache/shardingsphere/transaction/core/TransactionOperationType.java
@@ -25,5 +25,5 @@ package org.apache.shardingsphere.transaction.core;
  */
 public enum TransactionOperationType {
     
-    BEGIN, COMMIT, ROLLBACK
+    BEGIN, SUSPEND, RESUME, COMMIT, ROLLBACK
 }

--- a/sharding-transaction/sharding-transaction-core/src/main/java/org/apache/shardingsphere/transaction/spi/ShardingTransactionManager.java
+++ b/sharding-transaction/sharding-transaction-core/src/main/java/org/apache/shardingsphere/transaction/spi/ShardingTransactionManager.java
@@ -68,7 +68,20 @@ public interface ShardingTransactionManager extends AutoCloseable {
      * Begin transaction.
      */
     void begin();
-    
+    /**
+     * Get current transaction.
+     * @return
+     */
+    Object getTransaction();
+    /**
+     * Suspend current transaction.
+     */
+    Object suspend();
+    /**
+     * Resume target transaction
+     * @param transaction suspended transaction
+     */
+    void resume(Object transaction);
     /**
      * Commit transaction.
      */

--- a/sharding-transaction/sharding-transaction-core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/OtherShardingTransactionManagerFixture.java
+++ b/sharding-transaction/sharding-transaction-core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/OtherShardingTransactionManagerFixture.java
@@ -51,6 +51,20 @@ public final class OtherShardingTransactionManagerFixture implements ShardingTra
     }
     
     @Override
+	public Object getTransaction() {
+		return null;
+	}
+
+	@Override
+	public Object suspend() {
+		return null;
+	}
+
+	@Override
+	public void resume(Object transaction) {
+	}
+	
+    @Override
     public void commit() {
     }
     

--- a/sharding-transaction/sharding-transaction-core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/ShardingTransactionManagerFixture.java
+++ b/sharding-transaction/sharding-transaction-core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/ShardingTransactionManagerFixture.java
@@ -56,6 +56,20 @@ public final class ShardingTransactionManagerFixture implements ShardingTransact
     }
     
     @Override
+	public Object getTransaction() {
+		return null;
+	}
+
+	@Override
+	public Object suspend() {
+		return null;
+	}
+
+	@Override
+	public void resume(Object transaction) {
+	}
+	
+    @Override
     public void commit() {
     }
     


### PR DESCRIPTION
Fixes 2902.

Changes proposed in this pull request:
- Fix the problem with the supports for spring declarative transactions, and move the enlistment into the upderling TransactionManager. However, with the addition of a constraint, you can only use the dbcp connection pool management component when using XA transactions. For now, in the open source connection pool management component, only dbcp can support XADataSource.

Please refer to [shardingjdbc-sample](https://github.com/liuyangming/shardingjdbc-sample/tree/issue-2902) for modified usage examples.

