### PR TITLE
Replay for ShardingPreparedStatement when execute.

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
@@ -197,11 +197,18 @@ public final class ShardingPreparedStatement extends AbstractShardingPreparedSta
     private void initPreparedStatementExecutor() throws SQLException {
         preparedStatementExecutor.init(sqlRouteResult);
         setParametersForStatements();
+        replayMethodForStatements();
     }
     
     private void setParametersForStatements() {
         for (int i = 0; i < preparedStatementExecutor.getStatements().size(); i++) {
             replaySetParameter((PreparedStatement) preparedStatementExecutor.getStatements().get(i), preparedStatementExecutor.getParameterSets().get(i));
+        }
+    }
+    
+    private void replayMethodForStatements() {
+        for (Statement each : preparedStatementExecutor.getStatements()) {
+            replayMethodsInvocation(each);
         }
     }
     

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
@@ -219,4 +219,16 @@ public final class ShardingPreparedStatementTest extends AbstractShardingJDBCDat
             assertThat(result.length, is(0));
         }
     }
+    
+    @Test
+    public void assertInitPreparedStatementExecutorWithReplayMethod() throws SQLException {
+        String sql = "SELECT item_id from t_order_item where user_id = ? and order_id= ? and status = 'BATCH'";
+        try (PreparedStatement preparedStatement = getShardingDataSource().getConnection().prepareStatement(sql)) {
+            preparedStatement.setQueryTimeout(1);
+            preparedStatement.setInt(1, 11);
+            preparedStatement.setInt(2, 11);
+            preparedStatement.executeQuery();
+            assertThat(preparedStatement.getQueryTimeout(), is(1));
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-shardingsphere/issues/2981.

Changes proposed in this pull request:
1. add replayMethodForStatements for `ShardingPreparedStatement`.
2. add UT.
