### PR TITLE
Fixes 3014 add judgement for null in QueryRow.isEqualPartly().

### DIFF
--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/row/QueryRow.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/row/QueryRow.java
@@ -66,7 +66,10 @@ public final class QueryRow {
     
     private boolean isEqualPartly(final QueryRow queryRow) {
         for (int i = 0; i < distinctColumnIndexes.size(); i++) {
-            if (!rowData.get(i).equals(queryRow.getRowData().get(i))) {
+            if (null == rowData.get(i) && null != queryRow.getRowData().get(i)) {
+                return false;
+            }
+            if (null != rowData.get(i) && !rowData.get(i).equals(queryRow.getRowData().get(i))) {
                 return false;
             }
         }

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/row/QueryRowTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/row/QueryRowTest.java
@@ -55,6 +55,15 @@ public final class QueryRowTest {
         assertTrue(queryRow.equals(queryRow1));
         assertFalse(queryRow.equals(queryRow2));
     }
+
+    @Test
+    public void assertEqualPartlyWithNull() {
+        QueryRow queryRowWithNull = new QueryRow(Collections.singletonList(null), Collections.singletonList(1));
+        QueryRow queryRowWithNull2 = new QueryRow(Collections.singletonList(null), Collections.singletonList(1));
+        QueryRow queryRowWithNonNull = new QueryRow(Collections.singletonList((Object) 8), Collections.singletonList(1));
+        assertTrue(queryRowWithNull.equals(queryRowWithNull2));
+        assertFalse(queryRowWithNull.equals(queryRowWithNonNull));
+    }
     
     @Test
     public void assertHashCode() {


### PR DESCRIPTION

Fixes https://github.com/apache/incubator-shardingsphere/issues/3014.

Changes proposed in this pull request:
1. add judgement for null in QueryRow.
2. add UT.
