### PR TITLE
Code style error correction and  Improved coverage for insertValueContext#setValue

### DIFF
--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/optimize/segment/insert/InsertValueContextTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/optimize/segment/insert/InsertValueContextTest.java
@@ -31,8 +31,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public final class InsertValueContextTest {
     
@@ -41,7 +41,7 @@ public final class InsertValueContextTest {
         Collection<ExpressionSegment> assignments = Lists.newArrayList();
         List<Object> parameters = Collections.emptyList();
         int parametersOffset = 0;
-        InsertValueContext insertValueContext = new InsertValueContext(assignments,parameters, parametersOffset);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, parametersOffset);
         Method calculateParametersCountMethod = InsertValueContext.class.getDeclaredMethod("calculateParametersCount", Collection.class);
         calculateParametersCountMethod.setAccessible(true);
         int calculateParametersCountResult = (int) calculateParametersCountMethod.invoke(insertValueContext, new Object[] {assignments});
@@ -62,9 +62,9 @@ public final class InsertValueContextTest {
         String parameterValue = "test";
         List<Object> parameters = Collections.<Object>singletonList(parameterValue);
         int parametersOffset = 0;
-        InsertValueContext insertValueContext = new InsertValueContext(assignments,parameters, parametersOffset);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, parametersOffset);
         Object valueFromInsertValueContext = insertValueContext.getValue(0);
-        assertThat((String)valueFromInsertValueContext, is(parameterValue));
+        assertThat((String) valueFromInsertValueContext, is(parameterValue));
     }
     
     private Collection<ExpressionSegment> makeParameterMarkerExpressionSegment() {
@@ -77,7 +77,7 @@ public final class InsertValueContextTest {
         Object literalObject = new Object();
         Collection<ExpressionSegment> assignments = makeLiteralExpressionSegment(literalObject);
         List<Object> parameters = Collections.emptyList();
-        InsertValueContext insertValueContext = new InsertValueContext(assignments,parameters, 0);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, 0);
         Object valueFromInsertValueContext = insertValueContext.getValue(0);
         assertThat(valueFromInsertValueContext, is(literalObject));
     }
@@ -91,7 +91,7 @@ public final class InsertValueContextTest {
     public void assertAppendValueWhenParametersIsEmpty() {
         Collection<ExpressionSegment> assignments = Collections.emptyList();
         List<Object> parameters = Collections.emptyList();
-        InsertValueContext insertValueContext = new InsertValueContext(assignments,parameters, 0);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, 0);
         Object value = "test";
         String type = "String";
         insertValueContext.appendValue(value, type);
@@ -108,7 +108,7 @@ public final class InsertValueContextTest {
         String parameterValue = "test";
         List<Object> parameters = Collections.<Object>singletonList(parameterValue);
         int parametersOffset = 0;
-        InsertValueContext insertValueContext = new InsertValueContext(assignments,parameters, parametersOffset);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, parametersOffset);
         Object value = "test";
         String type = "String";
         insertValueContext.appendValue(value, type);
@@ -117,5 +117,38 @@ public final class InsertValueContextTest {
         DerivedParameterMarkerExpressionSegment segmentInInsertValueContext = (DerivedParameterMarkerExpressionSegment) valueExpressions.get(1);
         assertThat(segmentInInsertValueContext.getType(), is(type));
         assertThat(segmentInInsertValueContext.getParameterMarkerIndex(), is(parameters.size() - 1));
+    }
+    
+    @Test
+    public void assertSetValueWhenValueExpressionInstanceofParameterMarkerExpressionSegment() {
+        Collection<ExpressionSegment> assignments = makeParameterMarkerExpressionSegment();
+        String parameterValue = "test";
+        List<Object> parameters = Collections.<Object>singletonList(parameterValue);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, 0);
+        int index = 0;
+        String value = "String";
+        insertValueContext.setValue(index, value);
+        List<Object> parametersInInsertValueContext = insertValueContext.getParameters();
+        assertThat(parametersInInsertValueContext.size(), is(1));
+        Object valueFromParametersInInsertValueContext = parametersInInsertValueContext.get(0);
+        assertThat(valueFromParametersInInsertValueContext, is((Object) parameterValue));
+    }
+    
+    @Test
+    public void assertSetValueWhenValueExpressionNotInstanceofParameterMarkerExpressionSegment() {
+        Object literalObject = new Object();
+        Collection<ExpressionSegment> assignments = makeLiteralExpressionSegment(literalObject);
+        String parameterValue = "test";
+        List<Object> parameters = Collections.<Object>singletonList(parameterValue);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, parameters, 0);
+        int index = 0;
+        String value = "String";
+        insertValueContext.setValue(index, value);
+        List<ExpressionSegment> valueExpressionsInInsertValueContext = insertValueContext.getValueExpressions();
+        assertThat(valueExpressionsInInsertValueContext.size(), is(1));
+        LiteralExpressionSegment valueFromParametersInInsertValueContext = (LiteralExpressionSegment) valueExpressionsInInsertValueContext.get(0);
+        assertThat(valueFromParametersInInsertValueContext.getLiterals(), is((Object) value));
+        assertThat(valueFromParametersInInsertValueContext.getStartIndex(), is(0));
+        assertThat(valueFromParametersInInsertValueContext.getStopIndex(), is(10));
     }
 }

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/optimize/segment/insert/expression/DerivedLiteralExpressionSegmentTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/optimize/segment/insert/expression/DerivedLiteralExpressionSegmentTest.java
@@ -18,8 +18,9 @@
 package org.apache.shardingsphere.core.optimize.segment.insert.expression;
 
 import org.junit.Test;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public final class DerivedLiteralExpressionSegmentTest {
     
@@ -27,7 +28,7 @@ public final class DerivedLiteralExpressionSegmentTest {
     public void assertInstanceConstructedOk() {
         Object literals = new Object();
         String type = "type";
-        DerivedLiteralExpressionSegment derivedLiteralExpressionSegment = new DerivedLiteralExpressionSegment(literals,type);
+        DerivedLiteralExpressionSegment derivedLiteralExpressionSegment = new DerivedLiteralExpressionSegment(literals, type);
         assertThat(derivedLiteralExpressionSegment.getType(), is(type));
         assertThat(derivedLiteralExpressionSegment.getStartIndex(), is(0));
         assertThat(derivedLiteralExpressionSegment.getStopIndex(), is(0));

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/optimize/segment/insert/expression/DerivedParameterMarkerExpressionSegmentTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/optimize/segment/insert/expression/DerivedParameterMarkerExpressionSegmentTest.java
@@ -18,8 +18,9 @@
 package org.apache.shardingsphere.core.optimize.segment.insert.expression;
 
 import org.junit.Test;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public final class DerivedParameterMarkerExpressionSegmentTest {
     
@@ -27,7 +28,7 @@ public final class DerivedParameterMarkerExpressionSegmentTest {
     public void assertInstanceConstructedOk() {
         int parameterMarkerIndex = 10;
         String type = "type";
-        DerivedParameterMarkerExpressionSegment derivedParameterMarkerExpressionSegment = new DerivedParameterMarkerExpressionSegment(parameterMarkerIndex,type);
+        DerivedParameterMarkerExpressionSegment derivedParameterMarkerExpressionSegment = new DerivedParameterMarkerExpressionSegment(parameterMarkerIndex, type);
         assertThat(derivedParameterMarkerExpressionSegment.getType(), is(type));
         assertThat(derivedParameterMarkerExpressionSegment.getStartIndex(), is(0));
         assertThat(derivedParameterMarkerExpressionSegment.getStopIndex(), is(0));


### PR DESCRIPTION
1. use org.junit.Assert.assertThat and org.hamcrest.CoreMatches.is, instead of org.hamcrest.core.Is.is and org.hamcrest.MatcherAssert.assertThat
2. after ',' there should be a whitespace.
3. after typecast , there should be a whitespace.
4. before static import, there should a blank line.
5. testcase code added for InsertValueContext#setValue