### PR TITLE
fix jacoco local report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         
         <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
     </properties>
     
     <dependencyManagement>
@@ -508,9 +509,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Change-Id: I9bad46fbc7527df5d59d10023820ee0bb118fa89

from [offical documentation](https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html)

```
Another way is to define "argLine" as a Maven property rather than as part of the configuration of maven-surefire-plugin:

  <properties>
    <argLine>-your -extra -arguments</argLine>
  </properties>
  ...
  <plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-surefire-plugin</artifactId>
    <configuration>
      <!-- no argLine here -->
    </configuration>
  </plugin>
```
after the change, jacoco working, output dir `traget/site/jacoco`
![image](https://user-images.githubusercontent.com/13444999/66252641-665a1f80-e790-11e9-97ae-85c5ff9a4b16.png)

