### PR TITLE
postgres SQL execute bind parameter ERROR paser

### DIFF
--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/PostgreSQLComBindPacket.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/PostgreSQLComBindPacket.java
@@ -72,9 +72,9 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
         int parametersCount = payload.readInt2();
         List<Object> result = new ArrayList<>(parametersCount);
         for (int parameterIndex = 0; parameterIndex < parametersCount; parameterIndex++) {
-            payload.readInt4();
-            PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(parameterTypes.get(parameterIndex).getColumnType());
-            result.add(binaryProtocolValue.read(payload));
+           int length= payload.readInt4();
+           PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(parameterTypes.get(parameterIndex).getColumnType());
+           result.add(binaryProtocolValue.read(payload,length));
         }
         return result;
     }

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/PostgreSQLComBindPacket.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/PostgreSQLComBindPacket.java
@@ -41,15 +41,15 @@ import java.util.List;
 @Getter
 @ToString
 public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
-    
+
     private final String statementId;
-    
+
     private final String sql;
-    
+
     private final List<Object> parameters;
-    
+
     private final boolean binaryRowData;
-    
+
     public PostgreSQLComBindPacket(final PostgreSQLPacketPayload payload, final int connectionId) throws SQLException {
         payload.readInt4();
         payload.readStringNul();
@@ -67,22 +67,22 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
             payload.readInt2();
         }
     }
-    
+
     private List<Object> getParameters(final PostgreSQLPacketPayload payload, final List<PostgreSQLBinaryStatementParameterType> parameterTypes) throws SQLException {
         int parametersCount = payload.readInt2();
         List<Object> result = new ArrayList<>(parametersCount);
         for (int parameterIndex = 0; parameterIndex < parametersCount; parameterIndex++) {
-           int length= payload.readInt4();
-           PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(parameterTypes.get(parameterIndex).getColumnType());
-           result.add(binaryProtocolValue.read(payload,length));
+            int length = payload.readInt4();
+            PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(parameterTypes.get(parameterIndex).getColumnType());
+            result.add(binaryProtocolValue.read(payload, length));
         }
         return result;
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload) {
     }
-    
+
     @Override
     public char getMessageType() {
         return PostgreSQLCommandPacketType.BIND.getValue();

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValue.java
@@ -46,6 +46,17 @@ public interface PostgreSQLBinaryProtocolValue {
     Object read(PostgreSQLPacketPayload payload) throws SQLException;
     
     /**
+     * Read binary protocol value.
+     *
+     * @param payload payload operation for PostgreSQL packet
+     * @param len need read length
+     * @return binary value result
+     * @throws SQLException SQL exception
+     */
+    default Object read(PostgreSQLPacketPayload payload ,int len) throws SQLException{
+        return  read(payload);
+    }
+    /**
      * Write binary protocol value.
      *
      * @param payload payload operation for PostgreSQL packet

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValue.java
@@ -27,7 +27,7 @@ import java.sql.SQLException;
  * @author zhangyonglun
  */
 public interface PostgreSQLBinaryProtocolValue {
-    
+
     /**
      * Get column length.
      *
@@ -35,32 +35,22 @@ public interface PostgreSQLBinaryProtocolValue {
      * @return column length
      */
     int getColumnLength(Object value);
-    
+
     /**
      * Read binary protocol value.
      *
      * @param payload payload operation for PostgreSQL packet
+     * @param len     need read length
      * @return binary value result
      * @throws SQLException SQL exception
      */
-    Object read(PostgreSQLPacketPayload payload) throws SQLException;
-    
-    /**
-     * Read binary protocol value.
-     *
-     * @param payload payload operation for PostgreSQL packet
-     * @param len need read length
-     * @return binary value result
-     * @throws SQLException SQL exception
-     */
-    default Object read(PostgreSQLPacketPayload payload ,int len) throws SQLException{
-        return  read(payload);
-    }
+    Object read(PostgreSQLPacketPayload payload, int len) throws SQLException;
+
     /**
      * Write binary protocol value.
      *
      * @param payload payload operation for PostgreSQL packet
-     * @param value value to be written
+     * @param value   value to be written
      */
     void write(PostgreSQLPacketPayload payload, Object value);
 }

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
@@ -28,17 +28,17 @@ import java.sql.Timestamp;
  * @author zhangyonglun
  */
 public final class PostgreSQLDateBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 8;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload,final  int length) throws SQLException {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) throws SQLException {
         return payload.readInt8();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.writeInt8(((Timestamp) value).getTime());

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
@@ -35,7 +35,7 @@ public final class PostgreSQLDateBinaryProtocolValue implements PostgreSQLBinary
     }
     
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) throws SQLException {
+    public Object read(final PostgreSQLPacketPayload payload, int length) throws SQLException {
         return payload.readInt8();
     }
     

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
@@ -35,7 +35,7 @@ public final class PostgreSQLDateBinaryProtocolValue implements PostgreSQLBinary
     }
     
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) throws SQLException {
+    public Object read(final PostgreSQLPacketPayload payload,final  int length) throws SQLException {
         return payload.readInt8();
     }
     

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDoubleBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDoubleBinaryProtocolValue.java
@@ -25,17 +25,17 @@ import org.apache.shardingsphere.shardingproxy.transport.postgresql.payload.Post
  * @author zhangyonglun
  */
 public final class PostgreSQLDoubleBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 8;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
+    public Object read(final PostgreSQLPacketPayload payload, int length) {
         return payload.getByteBuf().readDouble();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.getByteBuf().writeDouble(Double.parseDouble(value.toString()));

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDoubleBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLDoubleBinaryProtocolValue.java
@@ -32,7 +32,7 @@ public final class PostgreSQLDoubleBinaryProtocolValue implements PostgreSQLBina
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) {
         return payload.getByteBuf().readDouble();
     }
 

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
@@ -32,7 +32,7 @@ public final class PostgreSQLFloatBinaryProtocolValue implements PostgreSQLBinar
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) {
+    public Object read(final PostgreSQLPacketPayload payload,final  int length) {
         return payload.getByteBuf().readFloat();
     }
 

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
@@ -25,17 +25,17 @@ import org.apache.shardingsphere.shardingproxy.transport.postgresql.payload.Post
  * @author zhangyonglun
  */
 public final class PostgreSQLFloatBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 4;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
+    public Object read(final PostgreSQLPacketPayload payload, int length) {
         return payload.getByteBuf().readFloat();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.getByteBuf().writeFloat(Float.parseFloat(value.toString()));

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
@@ -32,7 +32,7 @@ public final class PostgreSQLFloatBinaryProtocolValue implements PostgreSQLBinar
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload,final  int length) {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) {
         return payload.getByteBuf().readFloat();
     }
 

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt2BinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt2BinaryProtocolValue.java
@@ -21,21 +21,21 @@ import org.apache.shardingsphere.shardingproxy.transport.postgresql.payload.Post
 
 /**
  * Binary protocol value for int2 for PostgreSQL.
- * 
+ *
  * @author zhangyonglun
  */
 public final class PostgreSQLInt2BinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 2;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
+    public Object read(final PostgreSQLPacketPayload payload, int length) {
         return payload.readInt2();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.writeInt2((Integer) value);

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt2BinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt2BinaryProtocolValue.java
@@ -32,7 +32,7 @@ public final class PostgreSQLInt2BinaryProtocolValue implements PostgreSQLBinary
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) {
         return payload.readInt2();
     }
 

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt4BinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt4BinaryProtocolValue.java
@@ -32,7 +32,7 @@ public final class PostgreSQLInt4BinaryProtocolValue implements PostgreSQLBinary
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) {
         return payload.readInt4();
     }
 

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt4BinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt4BinaryProtocolValue.java
@@ -21,21 +21,21 @@ import org.apache.shardingsphere.shardingproxy.transport.postgresql.payload.Post
 
 /**
  * Binary protocol value for int4 for PostgreSQL.
- * 
+ *
  * @author zhangyonglun
  */
 public final class PostgreSQLInt4BinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 4;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
+    public Object read(final PostgreSQLPacketPayload payload, int length) {
         return payload.readInt4();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.writeInt4((Integer) value);

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt8BinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt8BinaryProtocolValue.java
@@ -34,7 +34,7 @@ public final class PostgreSQLInt8BinaryProtocolValue implements PostgreSQLBinary
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) {
         return payload.readInt8();
     }
 

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt8BinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLInt8BinaryProtocolValue.java
@@ -23,21 +23,21 @@ import java.math.BigDecimal;
 
 /**
  * Binary protocol value for int8 for PostgreSQL.
- * 
+ *
  * @author zhangyonglun
  */
 public final class PostgreSQLInt8BinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 8;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
+    public Object read(final PostgreSQLPacketPayload payload, int length) {
         return payload.readInt8();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.writeInt8(value instanceof BigDecimal ? ((BigDecimal) value).longValue() : (Long) value);

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -30,7 +30,7 @@ public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBina
     public int getColumnLength(final Object value) {
         return value.toString().length();
     }
-    
+
     @Override
     public Object read(final PostgreSQLPacketPayload payload, final int len) {
         byte[] result = new byte[len];

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -25,24 +25,20 @@ import org.apache.shardingsphere.shardingproxy.transport.postgresql.payload.Post
  * @author zhangyonglun
  */
 public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return value.toString().length();
     }
-    
-    @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
-        return payload.readStringNul();
-    }
+
 
     @Override
     public Object read(PostgreSQLPacketPayload payload, int len) {
-         byte[] result = new byte[len];
-         payload.getByteBuf().readBytes(result);
-        return  new String(result);
+        byte[] result = new byte[len];
+        payload.getByteBuf().readBytes(result);
+        return new String(result);
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         if (value instanceof byte[]) {

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -35,6 +35,13 @@ public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBina
     public Object read(final PostgreSQLPacketPayload payload) {
         return payload.readStringNul();
     }
+
+    @Override
+    public Object read(PostgreSQLPacketPayload payload, int len) {
+         byte[] result = new byte[len];
+         payload.getByteBuf().readBytes(result);
+        return  new String(result);
+    }
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -30,10 +30,9 @@ public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBina
     public int getColumnLength(final Object value) {
         return value.toString().length();
     }
-
-
+    
     @Override
-    public Object read(PostgreSQLPacketPayload payload, int len) {
+    public Object read(final PostgreSQLPacketPayload payload, final int len) {
         byte[] result = new byte[len];
         payload.getByteBuf().readBytes(result);
         return new String(result);

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLTimeBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLTimeBinaryProtocolValue.java
@@ -27,17 +27,17 @@ import java.sql.Timestamp;
  * @author zhangyonglun
  */
 public final class PostgreSQLTimeBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
-    
+
     @Override
     public int getColumnLength(final Object value) {
         return 8;
     }
-    
+
     @Override
-    public Object read(final PostgreSQLPacketPayload payload) {
+    public Object read(final PostgreSQLPacketPayload payload, int length) {
         return payload.readInt8();
     }
-    
+
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
         payload.writeInt8(((Timestamp) value).getTime());

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLTimeBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLTimeBinaryProtocolValue.java
@@ -34,7 +34,7 @@ public final class PostgreSQLTimeBinaryProtocolValue implements PostgreSQLBinary
     }
 
     @Override
-    public Object read(final PostgreSQLPacketPayload payload, int length) {
+    public Object read(final PostgreSQLPacketPayload payload, final int length) {
         return payload.readInt8();
     }
 


### PR DESCRIPTION
 Fix ShardingSphere proxy Postgres transport read BindPacket , prepare Statement  Parser 'B' Protocol ERROR ,Error Read Parameters .See 
Fixes #3233

Changes proposed in this pull request:
-   org.apache.shardingsphere.shardingproxy.transport.postgresql.packet.command.query.binary.bind.PostgreSQLComBindPacket.java
-org.apache.shardingsphere.shardingproxy.transport.postgresql.packet.command.query.binary.bind.protocol.PostgreSQLBinaryProtocolValue
-org.apache.shardingsphere.shardingproxy.transport.postgresql.packet.command.query.binary.bind.protocol.PostgreSQLStringBinaryProtocolValue
