### PR TITLE
Delete duplicate method: isDerivedColumnName

### DIFF
--- a/sharding-core/sharding-core-preprocessor/src/main/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumn.java
+++ b/sharding-core/sharding-core-preprocessor/src/main/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumn.java
@@ -51,21 +51,6 @@ public enum DerivedColumn {
     }
     
     /**
-     * Judge is derived column name or not.
-     *
-     * @param columnName column name to be judged
-     * @return is derived column name or not
-     */
-    public static boolean isDerivedColumnName(final String columnName) {
-        for (DerivedColumn each : DerivedColumn.values()) {
-            if (columnName.startsWith(each.pattern)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    /**
      * Judge is derived column or not.
      *
      * @param columnName column name to be judged

--- a/sharding-core/sharding-core-preprocessor/src/main/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumn.java
+++ b/sharding-core/sharding-core-preprocessor/src/main/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumn.java
@@ -31,15 +31,15 @@ import java.util.Collection;
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum DerivedColumn {
-    
-    AVG_COUNT_ALIAS("AVG_DERIVED_COUNT_"), 
-    AVG_SUM_ALIAS("AVG_DERIVED_SUM_"), 
-    ORDER_BY_ALIAS("ORDER_BY_DERIVED_"), 
+
+    AVG_COUNT_ALIAS("AVG_DERIVED_COUNT_"),
+    AVG_SUM_ALIAS("AVG_DERIVED_SUM_"),
+    ORDER_BY_ALIAS("ORDER_BY_DERIVED_"),
     GROUP_BY_ALIAS("GROUP_BY_DERIVED_"),
     AGGREGATION_DISTINCT_DERIVED("AGGREGATION_DISTINCT_DERIVED_");
-    
+
     private final String pattern;
-    
+
     /**
      * Get alias of derived column.
      *
@@ -49,7 +49,7 @@ public enum DerivedColumn {
     public String getDerivedColumnAlias(final int derivedColumnCount) {
         return String.format(pattern + "%s", derivedColumnCount);
     }
-    
+
     /**
      * Judge is derived column or not.
      *
@@ -64,7 +64,7 @@ public enum DerivedColumn {
         }
         return false;
     }
-    
+
     private static Collection<DerivedColumn> getValues() {
         Collection<DerivedColumn> result = new ArrayList<>(Arrays.asList(DerivedColumn.values()));
         result.remove(DerivedColumn.AGGREGATION_DISTINCT_DERIVED);

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumnTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumnTest.java
@@ -25,39 +25,27 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class DerivedColumnTest {
-    
+
     @Test
     public void assertGetDerivedColumnAlias() {
         assertThat(DerivedColumn.AVG_COUNT_ALIAS.getDerivedColumnAlias(0), is("AVG_DERIVED_COUNT_0"));
         assertThat(DerivedColumn.AVG_SUM_ALIAS.getDerivedColumnAlias(1), is("AVG_DERIVED_SUM_1"));
         assertThat(DerivedColumn.ORDER_BY_ALIAS.getDerivedColumnAlias(0), is("ORDER_BY_DERIVED_0"));
         assertThat(DerivedColumn.GROUP_BY_ALIAS.getDerivedColumnAlias(1), is("GROUP_BY_DERIVED_1"));
+        assertThat(DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(0), is("AGGREGATION_DISTINCT_DERIVED_0"));
     }
-    
+
     @Test
     public void assertIsDerivedColumn() {
         assertTrue(DerivedColumn.isDerivedColumn("AVG_DERIVED_COUNT_0"));
         assertTrue(DerivedColumn.isDerivedColumn("AVG_DERIVED_SUM_1"));
         assertTrue(DerivedColumn.isDerivedColumn("ORDER_BY_DERIVED_0"));
         assertTrue(DerivedColumn.isDerivedColumn("GROUP_BY_DERIVED_1"));
+        assertTrue(DerivedColumn.isDerivedColumn("AGGREGATION_DISTINCT_DERIVED_0"));
     }
-    
+
     @Test
     public void assertIsNotDerivedColumn() {
         assertFalse(DerivedColumn.isDerivedColumn("OTHER_DERIVED_COLUMN_0"));
-    }
-    
-    @Test
-    public void assertIsDerivedColumnName() {
-        assertTrue(DerivedColumn.isDerivedColumnName("AVG_DERIVED_COUNT_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("AVG_DERIVED_SUM_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("ORDER_BY_DERIVED_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("GROUP_BY_DERIVED_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("AGGREGATION_DISTINCT_DERIVED_"));
-    }
-    
-    @Test
-    public void assertIsNotDerivedColumnName() {
-        assertFalse(DerivedColumn.isDerivedColumnName("OTHER_DERIVED_COLUMN_0"));
     }
 }

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumnTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumnTest.java
@@ -32,7 +32,6 @@ public final class DerivedColumnTest {
         assertThat(DerivedColumn.AVG_SUM_ALIAS.getDerivedColumnAlias(1), is("AVG_DERIVED_SUM_1"));
         assertThat(DerivedColumn.ORDER_BY_ALIAS.getDerivedColumnAlias(0), is("ORDER_BY_DERIVED_0"));
         assertThat(DerivedColumn.GROUP_BY_ALIAS.getDerivedColumnAlias(1), is("GROUP_BY_DERIVED_1"));
-        assertThat(DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(0), is("AGGREGATION_DISTINCT_DERIVED_0"));
     }
 
     @Test
@@ -41,7 +40,6 @@ public final class DerivedColumnTest {
         assertTrue(DerivedColumn.isDerivedColumn("AVG_DERIVED_SUM_1"));
         assertTrue(DerivedColumn.isDerivedColumn("ORDER_BY_DERIVED_0"));
         assertTrue(DerivedColumn.isDerivedColumn("GROUP_BY_DERIVED_1"));
-        assertTrue(DerivedColumn.isDerivedColumn("AGGREGATION_DISTINCT_DERIVED_0"));
     }
 
     @Test

--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/core/rewrite/feature/sharding/token/generator/impl/AggregationDistinctTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/core/rewrite/feature/sharding/token/generator/impl/AggregationDistinctTokenGenerator.java
@@ -35,12 +35,12 @@ import java.util.LinkedList;
  * @author panjuan
  */
 public final class AggregationDistinctTokenGenerator implements CollectionSQLTokenGenerator, IgnoreForSingleRoute {
-    
+
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
         return sqlStatementContext instanceof SelectSQLStatementContext;
     }
-    
+
     @Override
     public Collection<AggregationDistinctToken> generateSQLTokens(final SQLStatementContext sqlStatementContext) {
         Collection<AggregationDistinctToken> result = new LinkedList<>();
@@ -49,10 +49,10 @@ public final class AggregationDistinctTokenGenerator implements CollectionSQLTok
         }
         return result;
     }
-    
+
     private AggregationDistinctToken generateSQLToken(final AggregationDistinctProjection projection) {
         Preconditions.checkArgument(projection.getAlias().isPresent());
-        String derivedAlias = DerivedColumn.isDerivedColumnName(projection.getAlias().get()) ? projection.getAlias().get() : null;
+        String derivedAlias = DerivedColumn.isDerivedColumn(projection.getAlias().get()) ? projection.getAlias().get() : null;
         return new AggregationDistinctToken(projection.getStartIndex(), projection.getStopIndex(), projection.getDistinctInnerExpression(), derivedAlias);
     }
 }


### PR DESCRIPTION
Fix the problem #3213

Changes proposed in this pull request:
Delete duplicate method: isDerivedColumnName