### PR TITLE
Delete duplicate method: isDerivedColumnName

### DIFF
--- a/sharding-core/sharding-core-preprocessor/src/main/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumn.java
+++ b/sharding-core/sharding-core-preprocessor/src/main/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumn.java
@@ -51,21 +51,6 @@ public enum DerivedColumn {
     }
     
     /**
-     * Judge is derived column name or not.
-     *
-     * @param columnName column name to be judged
-     * @return is derived column name or not
-     */
-    public static boolean isDerivedColumnName(final String columnName) {
-        for (DerivedColumn each : DerivedColumn.values()) {
-            if (columnName.startsWith(each.pattern)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    /**
      * Judge is derived column or not.
      *
      * @param columnName column name to be judged

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumnTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/DerivedColumnTest.java
@@ -46,18 +46,4 @@ public final class DerivedColumnTest {
     public void assertIsNotDerivedColumn() {
         assertFalse(DerivedColumn.isDerivedColumn("OTHER_DERIVED_COLUMN_0"));
     }
-    
-    @Test
-    public void assertIsDerivedColumnName() {
-        assertTrue(DerivedColumn.isDerivedColumnName("AVG_DERIVED_COUNT_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("AVG_DERIVED_SUM_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("ORDER_BY_DERIVED_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("GROUP_BY_DERIVED_"));
-        assertTrue(DerivedColumn.isDerivedColumnName("AGGREGATION_DISTINCT_DERIVED_"));
-    }
-    
-    @Test
-    public void assertIsNotDerivedColumnName() {
-        assertFalse(DerivedColumn.isDerivedColumnName("OTHER_DERIVED_COLUMN_0"));
-    }
 }

--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/core/rewrite/feature/sharding/token/generator/impl/AggregationDistinctTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/core/rewrite/feature/sharding/token/generator/impl/AggregationDistinctTokenGenerator.java
@@ -52,7 +52,7 @@ public final class AggregationDistinctTokenGenerator implements CollectionSQLTok
     
     private AggregationDistinctToken generateSQLToken(final AggregationDistinctProjection projection) {
         Preconditions.checkArgument(projection.getAlias().isPresent());
-        String derivedAlias = DerivedColumn.isDerivedColumnName(projection.getAlias().get()) ? projection.getAlias().get() : null;
+        String derivedAlias = DerivedColumn.isDerivedColumn(projection.getAlias().get()) ? projection.getAlias().get() : null;
         return new AggregationDistinctToken(projection.getStartIndex(), projection.getStopIndex(), projection.getDistinctInnerExpression(), derivedAlias);
     }
 }


### PR DESCRIPTION
Fix the problem #3213

Changes proposed in this pull request:
Delete duplicate method: isDerivedColumnName