### PR TITLE
#3138 improved coverage for sharding core preprocessor

### DIFF
--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/ProjectionsContextTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/ProjectionsContextTest.java
@@ -42,8 +42,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class ProjectionsContextTest {
     

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/ProjectionsContextTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/ProjectionsContextTest.java
@@ -42,6 +42,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class ProjectionsContextTest {
     

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -17,8 +17,11 @@
 
 package org.apache.shardingsphere.core.preprocessor.segment.select.projection.engine;
 
+import org.apache.shardingsphere.core.parse.sql.segment.dml.order.item.IndexOrderByItemSegment;
+import org.apache.shardingsphere.core.parse.sql.segment.dml.order.item.TextOrderByItemSegment;
 import org.apache.shardingsphere.core.preprocessor.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.core.preprocessor.segment.select.orderby.OrderByContext;
+import org.apache.shardingsphere.core.preprocessor.segment.select.orderby.OrderByItem;
 import org.apache.shardingsphere.core.preprocessor.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.core.parse.sql.segment.dml.item.SelectItemSegment;
 import org.apache.shardingsphere.core.parse.sql.segment.dml.item.SelectItemsSegment;
@@ -57,6 +60,42 @@ public final class ProjectionsContextEngineTest {
         shorthandSelectItemSegment.setOwner(owner);
         when(selectItemsSegment.getSelectItems()).thenReturn(Collections.<SelectItemSegment>singleton(shorthandSelectItemSegment));
         ProjectionsContext projectionsContext = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
+        assertNotNull(projectionsContext);
+    }
+    
+    @Test
+    public void assertProjectionsContextCreatedProperlyWhenOrderByContextOrderItemsPresent() {
+        SelectStatement selectStatement = mock(SelectStatement.class);
+        SelectItemsSegment selectItemsSegment = mock(SelectItemsSegment.class);
+        when(selectStatement.getSelectItems()).thenReturn(selectItemsSegment);
+        ShorthandSelectItemSegment shorthandSelectItemSegment = new ShorthandSelectItemSegment(0, 10, "text");
+        TableSegment owner = new TableSegment(0, 10, "name");
+        owner.setOwner(new SchemaSegment(0, 10, "name"));
+        shorthandSelectItemSegment.setOwner(owner);
+        when(selectItemsSegment.getSelectItems()).thenReturn(Collections.<SelectItemSegment>singleton(shorthandSelectItemSegment));
+        OrderByContext orderByContext = mock(OrderByContext.class);
+        OrderByItem orderByItem = mock(OrderByItem.class);
+        when(orderByItem.getSegment()).thenReturn(mock(IndexOrderByItemSegment.class));
+        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
+        ProjectionsContext projectionsContext = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        assertNotNull(projectionsContext);
+    }
+    
+    @Test
+    public void assertProjectionsContextCreatedProperlyWhenOrderByItemSegmentNotInstanceOfIndexOrderByItemSegment() {
+        SelectStatement selectStatement = mock(SelectStatement.class);
+        SelectItemsSegment selectItemsSegment = mock(SelectItemsSegment.class);
+        when(selectStatement.getSelectItems()).thenReturn(selectItemsSegment);
+        ShorthandSelectItemSegment shorthandSelectItemSegment = new ShorthandSelectItemSegment(0, 10, "text");
+        TableSegment owner = new TableSegment(0, 10, "name");
+        owner.setOwner(new SchemaSegment(0, 10, "name"));
+        shorthandSelectItemSegment.setOwner(owner);
+        when(selectItemsSegment.getSelectItems()).thenReturn(Collections.<SelectItemSegment>singleton(shorthandSelectItemSegment));
+        OrderByContext orderByContext = mock(OrderByContext.class);
+        OrderByItem orderByItem = mock(OrderByItem.class);
+        when(orderByItem.getSegment()).thenReturn(mock(TextOrderByItemSegment.class));
+        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
+        ProjectionsContext projectionsContext = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
         assertNotNull(projectionsContext);
     }
 }

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -82,7 +82,7 @@ public final class ProjectionsContextEngineTest {
     }
     
     @Test
-    public void assertProjectionsContextCreatedProperlyWhenOrderByItemSegmentNotInstanceOfIndexOrderByItemSegment() {
+    public void assertCreateProjectionsContextWithoutIndexOrderByItemSegment() {
         SelectStatement selectStatement = mock(SelectStatement.class);
         SelectItemsSegment selectItemsSegment = mock(SelectItemsSegment.class);
         when(selectStatement.getSelectItems()).thenReturn(selectItemsSegment);

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -64,7 +64,7 @@ public final class ProjectionsContextEngineTest {
     }
     
     @Test
-    public void assertProjectionsContextCreatedProperlyWhenOrderByContextOrderItemsPresent() {
+    public void createProjectionsContextWhenOrderByContextOrderItemsPresent() {
         SelectStatement selectStatement = mock(SelectStatement.class);
         SelectItemsSegment selectItemsSegment = mock(SelectItemsSegment.class);
         when(selectStatement.getSelectItems()).thenReturn(selectItemsSegment);
@@ -77,8 +77,8 @@ public final class ProjectionsContextEngineTest {
         OrderByItem orderByItem = mock(OrderByItem.class);
         when(orderByItem.getSegment()).thenReturn(mock(IndexOrderByItemSegment.class));
         when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext projectionsContext = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
-        assertNotNull(projectionsContext);
+        ProjectionsContext actual = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        assertNotNull(actual);
     }
     
     @Test

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -45,8 +45,8 @@ public final class ProjectionsContextEngineTest {
         ProjectionsContextEngine projectionsContextEngine = new ProjectionsContextEngine(null);
         SelectStatement selectStatement = mock(SelectStatement.class);
         when(selectStatement.getSelectItems()).thenReturn(mock(SelectItemsSegment.class));
-        ProjectionsContext projectionsContext = projectionsContextEngine.createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
-        assertNotNull(projectionsContext);
+        ProjectionsContext actual = projectionsContextEngine.createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
+        assertNotNull(actual);
     }
     
     @Test
@@ -59,8 +59,8 @@ public final class ProjectionsContextEngineTest {
         owner.setOwner(new SchemaSegment(0, 10, "name"));
         shorthandSelectItemSegment.setOwner(owner);
         when(selectItemsSegment.getSelectItems()).thenReturn(Collections.<SelectItemSegment>singleton(shorthandSelectItemSegment));
-        ProjectionsContext projectionsContext = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
-        assertNotNull(projectionsContext);
+        ProjectionsContext actual = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
+        assertNotNull(actual);
     }
     
     @Test
@@ -95,7 +95,7 @@ public final class ProjectionsContextEngineTest {
         OrderByItem orderByItem = mock(OrderByItem.class);
         when(orderByItem.getSegment()).thenReturn(mock(TextOrderByItemSegment.class));
         when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext projectionsContext = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
-        assertNotNull(projectionsContext);
+        ProjectionsContext actual = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        assertNotNull(actual);
     }
 }

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/impl/ShorthandProjectionTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/impl/ShorthandProjectionTest.java
@@ -37,11 +37,6 @@ public final class ShorthandProjectionTest {
     }
     
     @Test
-    public void assertGetAliasWhenPresent() {
-    
-    }
-    
-    @Test
     public void assertGetColumnLabel() {
         assertTrue(new ShorthandProjection("owner").getColumnLabel().contains("*"));
     }

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/impl/ShorthandProjectionTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/impl/ShorthandProjectionTest.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.core.preprocessor.segment.select.projection.im
 
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -26,12 +28,17 @@ public final class ShorthandProjectionTest {
     
     @Test
     public void assertGetExpression() {
-        assertTrue(new ShorthandProjection("owner").getExpression().contains(".*"));
+        assertThat(new ShorthandProjection("owner").getExpression(), is("owner.*"));
     }
     
     @Test
-    public void assertGetAlias() {
+    public void assertGetAliasWhenAbsent() {
         assertFalse(new ShorthandProjection("owner").getAlias().isPresent());
+    }
+    
+    @Test
+    public void assertGetAliasWhenPresent() {
+    
     }
     
     @Test

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/impl/ShorthandProjectionTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/impl/ShorthandProjectionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.core.preprocessor.segment.select.projection.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class ShorthandProjectionTest {
+    
+    @Test
+    public void assertGetExpression() {
+        assertTrue(new ShorthandProjection("owner").getExpression().contains(".*"));
+    }
+    
+    @Test
+    public void assertGetAlias() {
+        assertFalse(new ShorthandProjection("owner").getAlias().isPresent());
+    }
+    
+    @Test
+    public void assertGetColumnLabel() {
+        assertTrue(new ShorthandProjection("owner").getColumnLabel().contains("*"));
+    }
+    
+    @Test
+    public void assertContains() {
+        assertTrue(new ShorthandProjection("owner").getOwner().isPresent());
+    }
+}

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/table/TablesContextTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/table/TablesContextTest.java
@@ -21,17 +21,22 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import org.apache.shardingsphere.core.metadata.table.TableMetas;
 import org.apache.shardingsphere.core.parse.sql.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.core.parse.sql.segment.generic.SchemaSegment;
+import org.apache.shardingsphere.core.parse.sql.segment.generic.TableAvailable;
 import org.apache.shardingsphere.core.parse.sql.segment.generic.TableSegment;
+import org.apache.shardingsphere.core.parse.sql.statement.SQLStatement;
 import org.apache.shardingsphere.core.parse.sql.statement.dml.SelectStatement;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -179,6 +184,24 @@ public final class TablesContextTest {
         TableMetas tableMetas = mock(TableMetas.class);
         when(tableMetas.containsColumn(anyString(), anyString())).thenReturn(true);
         assertTrue(new TablesContext(selectStatement).findTableName(columnSegment, tableMetas).isPresent());
+    }
+    
+    @Test
+    public void assertGetSchema() {
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.getAllSQLSegments().add(createTableSegment("table_1", "tbl_1"));
+        assertFalse(new TablesContext(selectStatement).getSchema().isPresent());
+    }
+    
+    @Test
+    public void assertInstanceCreatedWhenNoExceptionThrown() {
+        SQLStatement sqlStatement = mock(SQLStatement.class);
+        TableSegment tableSegment = new TableSegment(0, 10, "TableSegmentName");
+        SchemaSegment schemaSegment = mock(SchemaSegment.class);
+        when(schemaSegment.getName()).thenReturn("SchemaSegmentName");
+        tableSegment.setOwner(schemaSegment);
+        when(sqlStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable)tableSegment));
+        assertNotNull(new TablesContext(sqlStatement));
     }
     
     private TableSegment createTableSegment(final String tableName, final String alias) {

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/table/TablesContextTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/table/TablesContextTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -200,8 +199,8 @@ public final class TablesContextTest {
         SchemaSegment schemaSegment = mock(SchemaSegment.class);
         when(schemaSegment.getName()).thenReturn("SchemaSegmentName");
         tableSegment.setOwner(schemaSegment);
-        when(sqlStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable)tableSegment));
-        assertNotNull(new TablesContext(sqlStatement));
+        when(sqlStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable) tableSegment));
+        new TablesContext(sqlStatement);
     }
     
     private TableSegment createTableSegment(final String tableName, final String alias) {


### PR DESCRIPTION
Fixes #3138

the following test cases added:
 
-ShorthandProjectionTest
-TablesContext#getSchema, TablesContext#assertInstanceCreatedWhenNoExceptionThrown
-ProjectionsContextTest#assertGetColumnLabelsWhenGetQualifiedShorthandColumnLabelsResultEmpty