### PR TITLE
Fix assignmentValueNode get error index

### DIFF
--- a/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/core/extractor/impl/dml/update/AssignmentExtractor.java
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/core/extractor/impl/dml/update/AssignmentExtractor.java
@@ -55,7 +55,7 @@ public final class AssignmentExtractor implements OptionalSQLSegmentExtractor {
     }
     
     private ExpressionSegment getAssignmentValue(final Map<ParserRuleContext, Integer> parameterMarkerIndexes, final ParserRuleContext assignmentNode) {
-        ParserRuleContext assignmentValueNode = 3 == assignmentNode.getChildCount() ? (ParserRuleContext) assignmentNode.getChild(2) : (ParserRuleContext) assignmentNode.getChild(4);
+        ParserRuleContext assignmentValueNode = 3 == assignmentNode.getChildCount() ? (ParserRuleContext) assignmentNode.getChild(2) : (ParserRuleContext) assignmentNode.getChild(3);
         Optional<? extends ExpressionSegment> result = expressionExtractor.extract(assignmentValueNode, parameterMarkerIndexes);
         Preconditions.checkState(result.isPresent());
         return result.get();

--- a/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/core/extractor/impl/dml/update/AssignmentExtractor.java
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-common/src/main/java/org/apache/shardingsphere/core/parse/core/extractor/impl/dml/update/AssignmentExtractor.java
@@ -55,8 +55,7 @@ public final class AssignmentExtractor implements OptionalSQLSegmentExtractor {
     }
     
     private ExpressionSegment getAssignmentValue(final Map<ParserRuleContext, Integer> parameterMarkerIndexes, final ParserRuleContext assignmentNode) {
-        ParserRuleContext assignmentValueNode = 3 == assignmentNode.getChildCount() ? (ParserRuleContext) assignmentNode.getChild(2) : (ParserRuleContext) assignmentNode.getChild(3);
-        Optional<? extends ExpressionSegment> result = expressionExtractor.extract(assignmentValueNode, parameterMarkerIndexes);
+        Optional<? extends ExpressionSegment> result = expressionExtractor.extract((ParserRuleContext) assignmentNode.getChild(2), parameterMarkerIndexes);
         Preconditions.checkState(result.isPresent());
         return result.get();
     }


### PR DESCRIPTION
Fixes #3279

Changes proposed in this pull request:
- Fix get error index for nest Assignment Segment

Case 1：
```sql
update OTS_ORDER set UPDATE_DATE = now() where ID = 1;
```
then assignmentNode child size 3,  a -> CloumName; b -> = ; c -> now(), should get index 2

Case 2:
```sql
update OTS_ORDER set UPDATE_DATE = (now()+1) where ID = 1;
update OTS_ORDER set UPDATE_DATE = (now()) where ID = 1;
```

then assignmentNode child size 5,  a -> CloumName; b -> = ; c -> (;  d-> now()+1; e -> ), should get index 3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/incubator-shardingsphere/3284)
<!-- Reviewable:end -->
