### PR TITLE
fixes QueryResultUtil#getValueByColumnType unsigned int & bigint return value.

### DIFF
--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtil.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtil.java
@@ -105,9 +105,9 @@ public final class QueryResultUtil {
             case Types.TINYINT:
             case Types.SMALLINT:
             case Types.INTEGER:
-                return resultSet.getInt(columnIndex);
+                return getIntTypeValue(resultSet, columnIndex);
             case Types.BIGINT:
-                return resultSet.getLong(columnIndex);
+                return getBigIntTypeValue(resultSet, columnIndex);
             case Types.NUMERIC:
             case Types.DECIMAL:
                 return resultSet.getBigDecimal(columnIndex);
@@ -134,5 +134,29 @@ public final class QueryResultUtil {
             default:
                 return resultSet.getObject(columnIndex);
         }
+    }
+
+    private static Object getIntTypeValue(final ResultSet resultSet, final int columnIndex) throws SQLException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        if (metaData.isSigned(columnIndex)) {
+            return resultSet.getInt(columnIndex);
+        }
+        long value = resultSet.getLong(columnIndex);
+        if (value > Integer.MAX_VALUE) {
+            return value;
+        }
+        return (int) value;
+    }
+
+    private static Object getBigIntTypeValue(final ResultSet resultSet, final int columnIndex) throws SQLException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        if (metaData.isSigned(columnIndex)) {
+            return resultSet.getLong(columnIndex);
+        }
+        BigDecimal value = resultSet.getBigDecimal(columnIndex);
+        if (new BigDecimal(Long.MAX_VALUE).compareTo(value) <= -1) {
+            return value;
+        }
+        return value.longValue();
     }
 }

--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtil.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtil.java
@@ -104,10 +104,11 @@ public final class QueryResultUtil {
                 return resultSet.getBoolean(columnIndex);
             case Types.TINYINT:
             case Types.SMALLINT:
+                return resultSet.getInt(columnIndex);
             case Types.INTEGER:
-                return getIntTypeValue(resultSet, columnIndex);
+                return metaData.isSigned(columnIndex) ? resultSet.getInt(columnIndex) : resultSet.getLong(columnIndex);
             case Types.BIGINT:
-                return getBigIntTypeValue(resultSet, columnIndex);
+                return metaData.isSigned(columnIndex) ? resultSet.getLong(columnIndex) : resultSet.getBigDecimal(columnIndex).toBigInteger();
             case Types.NUMERIC:
             case Types.DECIMAL:
                 return resultSet.getBigDecimal(columnIndex);
@@ -134,29 +135,5 @@ public final class QueryResultUtil {
             default:
                 return resultSet.getObject(columnIndex);
         }
-    }
-
-    private static Object getIntTypeValue(final ResultSet resultSet, final int columnIndex) throws SQLException {
-        ResultSetMetaData metaData = resultSet.getMetaData();
-        if (metaData.isSigned(columnIndex)) {
-            return resultSet.getInt(columnIndex);
-        }
-        long value = resultSet.getLong(columnIndex);
-        if (value > Integer.MAX_VALUE) {
-            return value;
-        }
-        return (int) value;
-    }
-
-    private static Object getBigIntTypeValue(final ResultSet resultSet, final int columnIndex) throws SQLException {
-        ResultSetMetaData metaData = resultSet.getMetaData();
-        if (metaData.isSigned(columnIndex)) {
-            return resultSet.getLong(columnIndex);
-        }
-        BigDecimal value = resultSet.getBigDecimal(columnIndex);
-        if (new BigDecimal(Long.MAX_VALUE).compareTo(value) <= -1) {
-            return value;
-        }
-        return value.longValue();
     }
 }

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/MemoryQueryResultTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/MemoryQueryResultTest.java
@@ -112,14 +112,14 @@ public final class MemoryQueryResultTest {
     public void assertGetValueWithColumnIndex() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         queryResult.next();
-        assertThat(queryResult.getValue(1, Integer.class), Is.<Object>is(1));
+        assertThat(queryResult.getValue(1, Integer.class), Is.<Object>is(Long.valueOf(1)));
     }
     
     @Test
     public void assertGetValueWithColumnLabel() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         queryResult.next();
-        assertThat(queryResult.getValue("order_id", Integer.class), Is.<Object>is(1));
+        assertThat(queryResult.getValue("order_id", Integer.class), Is.<Object>is(Long.valueOf(1)));
     }
     
     @Test
@@ -158,21 +158,21 @@ public final class MemoryQueryResultTest {
         when(metaData.isSigned(1)).thenReturn(true);
         return metaData;
     }
-    
+
     @Test
     public void assertGetCalendarValueWithColumnIndex() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         queryResult.next();
-        assertThat(queryResult.getCalendarValue(1, Integer.class, Calendar.getInstance()), Is.<Object>is(1));
+        assertThat(queryResult.getCalendarValue(1, Integer.class, Calendar.getInstance()), Is.<Object>is(Long.valueOf(1)));
     }
-    
+
     @Test
     public void assertGetCalendarValueWithColumnLabel() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         queryResult.next();
-        assertThat(queryResult.getCalendarValue("order_id", Integer.class, Calendar.getInstance()), Is.<Object>is(1));
+        assertThat(queryResult.getCalendarValue("order_id", Integer.class, Calendar.getInstance()), Is.<Object>is(Long.valueOf(1)));
     }
-    
+
     @Test
     @SneakyThrows
     public void assertGetInputStreamWithColumnIndex() {
@@ -181,7 +181,7 @@ public final class MemoryQueryResultTest {
         InputStream inputStream = queryResult.getInputStream(1, "Unicode");
         assertThat(inputStream.read(), is(getInputStream(1).read()));
     }
-    
+
     @Test
     @SneakyThrows
     public void assertGetInputStreamWithColumnLabel() {
@@ -190,7 +190,7 @@ public final class MemoryQueryResultTest {
         InputStream inputStream = queryResult.getInputStream("order_id", "Unicode");
         assertThat(inputStream.read(), is(getInputStream(1).read()));
     }
-    
+
     @SneakyThrows
     private InputStream getInputStream(final Object value) {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -200,7 +200,7 @@ public final class MemoryQueryResultTest {
         objectOutputStream.close();
         return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
     }
-    
+
     @Test
     public void assertWasNull() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
@@ -209,25 +209,25 @@ public final class MemoryQueryResultTest {
         queryResult.next();
         assertTrue(queryResult.wasNull());
     }
-    
+
     @Test
     public void assertIsCaseSensitive() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         assertFalse(queryResult.isCaseSensitive(1));
     }
-    
+
     @Test
     public void assertGetColumnCount() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         assertThat(queryResult.getColumnCount(), is(1));
     }
-    
+
     @Test
     public void assertGetColumnLabel() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         assertThat(queryResult.getColumnLabel(1), is("order_id"));
     }
-    
+
     private ResultSet getResultSet() throws SQLException {
         ResultSet result = mock(ResultSet.class);
         when(result.next()).thenReturn(true).thenReturn(false);
@@ -236,7 +236,7 @@ public final class MemoryQueryResultTest {
         doReturn(getResultSetMetaData()).when(result).getMetaData();
         return result;
     }
-    
+
     private ResultSetMetaData getResultSetMetaData() throws SQLException {
         ResultSetMetaData result = mock(ResultSetMetaData.class);
         when(result.getColumnCount()).thenReturn(1);

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/MemoryQueryResultTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/MemoryQueryResultTest.java
@@ -155,6 +155,7 @@ public final class MemoryQueryResultTest {
         when(metaData.getColumnLabel(1)).thenReturn("order_id");
         when(metaData.getColumnName(1)).thenThrow(new SQLException());
         when(metaData.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(metaData.isSigned(1)).thenReturn(true);
         return metaData;
     }
     
@@ -242,6 +243,7 @@ public final class MemoryQueryResultTest {
         when(result.getColumnLabel(1)).thenReturn("order_id");
         when(result.getColumnName(1)).thenReturn("order_id");
         when(result.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(result.isSigned(1)).thenReturn(true);
         when(result.isCaseSensitive(1)).thenReturn(false);
         return result;
     }

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/MemoryQueryResultTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/MemoryQueryResultTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
 public final class MemoryQueryResultTest {
     
     private final ShardingEncryptor shardingEncryptor = mock(ShardingEncryptor.class);
-
+    
     @Test
     public void assertConstructorWithShardingRule() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet(), getShardingRule(), new ShardingProperties(new Properties()), getSqlStatementContext());
@@ -92,7 +92,7 @@ public final class MemoryQueryResultTest {
         when(encryptTable.getCipherColumns()).thenReturn(Collections.singleton("order_id"));
         return result;
     }
-
+    
     private SQLStatementContext getSqlStatementContext() {
         SQLStatementContext result = mock(SQLStatementContext.class);
         TablesContext tablesContext = mock(TablesContext.class);
@@ -158,21 +158,21 @@ public final class MemoryQueryResultTest {
         when(metaData.isSigned(1)).thenReturn(true);
         return metaData;
     }
-
+    
     @Test
     public void assertGetCalendarValueWithColumnIndex() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         queryResult.next();
         assertThat(queryResult.getCalendarValue(1, Integer.class, Calendar.getInstance()), Is.<Object>is(Long.valueOf(1)));
     }
-
+    
     @Test
     public void assertGetCalendarValueWithColumnLabel() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         queryResult.next();
         assertThat(queryResult.getCalendarValue("order_id", Integer.class, Calendar.getInstance()), Is.<Object>is(Long.valueOf(1)));
     }
-
+    
     @Test
     @SneakyThrows
     public void assertGetInputStreamWithColumnIndex() {
@@ -181,7 +181,7 @@ public final class MemoryQueryResultTest {
         InputStream inputStream = queryResult.getInputStream(1, "Unicode");
         assertThat(inputStream.read(), is(getInputStream(1).read()));
     }
-
+    
     @Test
     @SneakyThrows
     public void assertGetInputStreamWithColumnLabel() {
@@ -190,7 +190,7 @@ public final class MemoryQueryResultTest {
         InputStream inputStream = queryResult.getInputStream("order_id", "Unicode");
         assertThat(inputStream.read(), is(getInputStream(1).read()));
     }
-
+    
     @SneakyThrows
     private InputStream getInputStream(final Object value) {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -200,7 +200,7 @@ public final class MemoryQueryResultTest {
         objectOutputStream.close();
         return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
     }
-
+    
     @Test
     public void assertWasNull() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
@@ -209,25 +209,25 @@ public final class MemoryQueryResultTest {
         queryResult.next();
         assertTrue(queryResult.wasNull());
     }
-
+    
     @Test
     public void assertIsCaseSensitive() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         assertFalse(queryResult.isCaseSensitive(1));
     }
-
+    
     @Test
     public void assertGetColumnCount() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         assertThat(queryResult.getColumnCount(), is(1));
     }
-
+    
     @Test
     public void assertGetColumnLabel() throws SQLException {
         MemoryQueryResult queryResult = new MemoryQueryResult(getResultSet());
         assertThat(queryResult.getColumnLabel(1), is("order_id"));
     }
-
+    
     private ResultSet getResultSet() throws SQLException {
         ResultSet result = mock(ResultSet.class);
         when(result.next()).thenReturn(true).thenReturn(false);
@@ -236,7 +236,7 @@ public final class MemoryQueryResultTest {
         doReturn(getResultSetMetaData()).when(result).getMetaData();
         return result;
     }
-
+    
     private ResultSetMetaData getResultSetMetaData() throws SQLException {
         ResultSetMetaData result = mock(ResultSetMetaData.class);
         when(result.getColumnCount()).thenReturn(1);

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtilTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtilTest.java
@@ -72,7 +72,7 @@ public final class QueryResultUtilTest {
         assertTrue((boolean) QueryResultUtil.getValue(resultSet, 1));
         assertTrue((boolean) QueryResultUtil.getValue(resultSet, 1, boolean.class));
     }
-
+    
     @Test
     public void assertGetValueByTinyint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.TINYINT);
@@ -80,16 +80,15 @@ public final class QueryResultUtilTest {
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(1));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(1));
     }
-
+    
     @Test
     public void assertGetValueBySmallint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.SMALLINT);
         when(resultSet.getInt(1)).thenReturn(32767);
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(32767));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(32767));
-
     }
-
+    
     @Test
     public void assertGetValueByInteger() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
@@ -98,7 +97,7 @@ public final class QueryResultUtilTest {
         assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.valueOf(Integer.MAX_VALUE)));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(Integer.MAX_VALUE));
     }
-
+    
     @Test
     public void assertGetValueByUnSignedInteger() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
@@ -108,7 +107,7 @@ public final class QueryResultUtilTest {
         assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(Integer.MAX_VALUE));
     }
-
+    
     @Test
     public void assertGetValueByBigint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
@@ -117,7 +116,7 @@ public final class QueryResultUtilTest {
         assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
         assertThat((long) QueryResultUtil.getValue(resultSet, 1, long.class), is(Long.MAX_VALUE));
     }
-
+    
     @Test
     public void assertGetValueByUnSignedBigint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
@@ -125,7 +124,7 @@ public final class QueryResultUtilTest {
         when(resultSet.getBigDecimal(1)).thenReturn(new BigDecimal(Long.MAX_VALUE));
         assertThat((BigInteger) QueryResultUtil.getValue(resultSet, 1), is(BigInteger.valueOf(Long.MAX_VALUE)));
     }
-
+    
     @Test
     public void assertGetValueByNumeric() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.NUMERIC);
@@ -133,16 +132,15 @@ public final class QueryResultUtilTest {
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1), is(BigDecimal.TEN));
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1, BigDecimal.class), is(BigDecimal.TEN));
     }
-
+    
     @Test
     public void assertGetValueByDecimal() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.DECIMAL);
         when(resultSet.getBigDecimal(1)).thenReturn(BigDecimal.TEN);
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1), is(BigDecimal.TEN));
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1, BigDecimal.class), is(BigDecimal.TEN));
-
     }
-
+    
     @Test
     public void assertGetValueByFloat() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.FLOAT);
@@ -151,16 +149,15 @@ public final class QueryResultUtilTest {
         assertThat((double) QueryResultUtil.getValue(resultSet, 1), is(Double.MAX_VALUE));
         assertThat((float) QueryResultUtil.getValue(resultSet, 1, float.class), is(Float.MAX_VALUE));
     }
-
+    
     @Test
     public void assertGetValueByDouble() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.DOUBLE);
         when(resultSet.getDouble(1)).thenReturn(Double.MAX_VALUE);
         assertThat((double) QueryResultUtil.getValue(resultSet, 1), is(Double.MAX_VALUE));
         assertThat((double) QueryResultUtil.getValue(resultSet, 1, double.class), is(Double.MAX_VALUE));
-
     }
-
+    
     @Test
     public void assertGetValueByChar() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.CHAR);
@@ -168,7 +165,7 @@ public final class QueryResultUtilTest {
         assertThat((String) QueryResultUtil.getValue(resultSet, 1), is("x"));
         assertThat((String) QueryResultUtil.getValue(resultSet, 1, String.class), is("x"));
     }
-
+    
     @Test
     public void assertGetValueByVarchar() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.VARCHAR);
@@ -176,7 +173,7 @@ public final class QueryResultUtilTest {
         assertThat((String) QueryResultUtil.getValue(resultSet, 1), is("xxxxx"));
         assertThat((String) QueryResultUtil.getValue(resultSet, 1, String.class), is("xxxxx"));
     }
-
+    
     @Test
     public void assertGetValueByLongVarchar() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.LONGVARCHAR);
@@ -184,7 +181,7 @@ public final class QueryResultUtilTest {
         assertThat((String) QueryResultUtil.getValue(resultSet, 1), is("xxxxx"));
         assertThat((String) QueryResultUtil.getValue(resultSet, 1, String.class), is("xxxxx"));
     }
-
+    
     @Test
     public void assertGetValueByBinary() throws SQLException {
         Blob blob = mock(Blob.class);
@@ -193,7 +190,7 @@ public final class QueryResultUtilTest {
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
     }
-
+    
     @Test
     public void assertGetValueByVarBinary() throws SQLException {
         Blob blob = mock(Blob.class);
@@ -201,9 +198,8 @@ public final class QueryResultUtilTest {
         when(resultSet.getBlob(1)).thenReturn(blob);
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
-
     }
-
+    
     @Test
     public void assertGetValueByLongVarBinary() throws SQLException {
         Blob blob = mock(Blob.class);
@@ -211,7 +207,6 @@ public final class QueryResultUtilTest {
         when(resultSet.getBlob(1)).thenReturn(blob);
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
-
     }
     
     @Test

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtilTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtilTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -73,66 +74,43 @@ public final class QueryResultUtilTest {
     }
 
     @Test
-    public void assertGetValueBySignedTinyint() throws SQLException {
+    public void assertGetValueByTinyint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.TINYINT);
-        when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getInt(1)).thenReturn(1);
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(1));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(1));
     }
-    
+
     @Test
-    public void assertGetValueByUnSignedTinyint() throws SQLException {
-        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.TINYINT);
-        when(resultSetMetaData.isSigned(1)).thenReturn(false);
-        when(resultSet.getLong(1)).thenReturn(Long.valueOf(1));
-        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(1));
-    }
-    
-    @Test
-    public void assertGetValueBySignedSmallint() throws SQLException {
+    public void assertGetValueBySmallint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.SMALLINT);
-        when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getInt(1)).thenReturn(32767);
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(32767));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(32767));
+
     }
 
     @Test
-    public void assertGetValueByUnSignedSmallint() throws SQLException {
-        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.SMALLINT);
-        when(resultSetMetaData.isSigned(1)).thenReturn(false);
-        when(resultSet.getLong(1)).thenReturn(Long.valueOf(32767));
-        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(32767));
-    }
-    
-    @Test
-    public void assertGetValueBySignedInteger() throws SQLException {
+    public void assertGetValueByInteger() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
         when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getInt(1)).thenReturn(Integer.MAX_VALUE);
-        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(Integer.MAX_VALUE));
+        assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.valueOf(Integer.MAX_VALUE)));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(Integer.MAX_VALUE));
     }
 
     @Test
-    public void assertGetValueByUnSignedBeyondIntegerRange() throws SQLException {
+    public void assertGetValueByUnSignedInteger() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
         when(resultSetMetaData.isSigned(1)).thenReturn(false);
         when(resultSet.getLong(1)).thenReturn(Long.MAX_VALUE);
+        when(resultSet.getInt(1)).thenReturn(Integer.MAX_VALUE);
         assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
+        assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(Integer.MAX_VALUE));
     }
 
     @Test
-    public void assertGetValueByUnSignedInIntegerRange() throws SQLException {
-        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
-        when(resultSetMetaData.isSigned(1)).thenReturn(false);
-        when(resultSet.getLong(1)).thenReturn(Long.valueOf(Integer.MAX_VALUE));
-        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(Integer.MAX_VALUE));
-    }
-    
-    @Test
-    public void assertGetValueBySignedBigint() throws SQLException {
+    public void assertGetValueByBigint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
         when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getLong(1)).thenReturn(Long.MAX_VALUE);
@@ -141,22 +119,13 @@ public final class QueryResultUtilTest {
     }
 
     @Test
-    public void assertGetValueByUnSignedBeyondBigintRange() throws SQLException {
-        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
-        when(resultSetMetaData.isSigned(1)).thenReturn(false);
-        BigDecimal bigDecimal = new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(2));
-        when(resultSet.getBigDecimal(1)).thenReturn(bigDecimal);
-        assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1), is(bigDecimal));
-    }
-
-    @Test
-    public void assertGetValueByUnSignedInBigintRange() throws SQLException {
+    public void assertGetValueByUnSignedBigint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
         when(resultSetMetaData.isSigned(1)).thenReturn(false);
         when(resultSet.getBigDecimal(1)).thenReturn(new BigDecimal(Long.MAX_VALUE));
-        assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
+        assertThat((BigInteger) QueryResultUtil.getValue(resultSet, 1), is(BigInteger.valueOf(Long.MAX_VALUE)));
     }
-    
+
     @Test
     public void assertGetValueByNumeric() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.NUMERIC);
@@ -164,16 +133,16 @@ public final class QueryResultUtilTest {
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1), is(BigDecimal.TEN));
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1, BigDecimal.class), is(BigDecimal.TEN));
     }
-    
+
     @Test
     public void assertGetValueByDecimal() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.DECIMAL);
         when(resultSet.getBigDecimal(1)).thenReturn(BigDecimal.TEN);
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1), is(BigDecimal.TEN));
         assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1, BigDecimal.class), is(BigDecimal.TEN));
-    
+
     }
-    
+
     @Test
     public void assertGetValueByFloat() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.FLOAT);
@@ -182,16 +151,16 @@ public final class QueryResultUtilTest {
         assertThat((double) QueryResultUtil.getValue(resultSet, 1), is(Double.MAX_VALUE));
         assertThat((float) QueryResultUtil.getValue(resultSet, 1, float.class), is(Float.MAX_VALUE));
     }
-    
+
     @Test
     public void assertGetValueByDouble() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.DOUBLE);
         when(resultSet.getDouble(1)).thenReturn(Double.MAX_VALUE);
         assertThat((double) QueryResultUtil.getValue(resultSet, 1), is(Double.MAX_VALUE));
         assertThat((double) QueryResultUtil.getValue(resultSet, 1, double.class), is(Double.MAX_VALUE));
-    
+
     }
-    
+
     @Test
     public void assertGetValueByChar() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.CHAR);
@@ -199,7 +168,7 @@ public final class QueryResultUtilTest {
         assertThat((String) QueryResultUtil.getValue(resultSet, 1), is("x"));
         assertThat((String) QueryResultUtil.getValue(resultSet, 1, String.class), is("x"));
     }
-    
+
     @Test
     public void assertGetValueByVarchar() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.VARCHAR);
@@ -207,7 +176,7 @@ public final class QueryResultUtilTest {
         assertThat((String) QueryResultUtil.getValue(resultSet, 1), is("xxxxx"));
         assertThat((String) QueryResultUtil.getValue(resultSet, 1, String.class), is("xxxxx"));
     }
-    
+
     @Test
     public void assertGetValueByLongVarchar() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.LONGVARCHAR);
@@ -215,7 +184,7 @@ public final class QueryResultUtilTest {
         assertThat((String) QueryResultUtil.getValue(resultSet, 1), is("xxxxx"));
         assertThat((String) QueryResultUtil.getValue(resultSet, 1, String.class), is("xxxxx"));
     }
-    
+
     @Test
     public void assertGetValueByBinary() throws SQLException {
         Blob blob = mock(Blob.class);
@@ -224,7 +193,7 @@ public final class QueryResultUtilTest {
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
     }
-    
+
     @Test
     public void assertGetValueByVarBinary() throws SQLException {
         Blob blob = mock(Blob.class);
@@ -232,8 +201,9 @@ public final class QueryResultUtilTest {
         when(resultSet.getBlob(1)).thenReturn(blob);
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
+
     }
-    
+
     @Test
     public void assertGetValueByLongVarBinary() throws SQLException {
         Blob blob = mock(Blob.class);
@@ -241,6 +211,7 @@ public final class QueryResultUtilTest {
         when(resultSet.getBlob(1)).thenReturn(blob);
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
+
     }
     
     @Test

--- a/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtilTest.java
+++ b/sharding-core/sharding-core-execute/src/test/java/org/apache/shardingsphere/core/execute/sql/execute/result/QueryResultUtilTest.java
@@ -71,39 +71,90 @@ public final class QueryResultUtilTest {
         assertTrue((boolean) QueryResultUtil.getValue(resultSet, 1));
         assertTrue((boolean) QueryResultUtil.getValue(resultSet, 1, boolean.class));
     }
-    
+
     @Test
-    public void assertGetValueByTinyint() throws SQLException {
+    public void assertGetValueBySignedTinyint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.TINYINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getInt(1)).thenReturn(1);
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(1));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(1));
     }
     
     @Test
-    public void assertGetValueBySmallint() throws SQLException {
+    public void assertGetValueByUnSignedTinyint() throws SQLException {
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.TINYINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        when(resultSet.getLong(1)).thenReturn(Long.valueOf(1));
+        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(1));
+    }
+    
+    @Test
+    public void assertGetValueBySignedSmallint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.SMALLINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getInt(1)).thenReturn(32767);
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(32767));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(32767));
-    
+    }
+
+    @Test
+    public void assertGetValueByUnSignedSmallint() throws SQLException {
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.SMALLINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        when(resultSet.getLong(1)).thenReturn(Long.valueOf(32767));
+        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(32767));
     }
     
     @Test
-    public void assertGetValueByInteger() throws SQLException {
+    public void assertGetValueBySignedInteger() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getInt(1)).thenReturn(Integer.MAX_VALUE);
         assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(Integer.MAX_VALUE));
         assertThat((int) QueryResultUtil.getValue(resultSet, 1, int.class), is(Integer.MAX_VALUE));
-    
+    }
+
+    @Test
+    public void assertGetValueByUnSignedBeyondIntegerRange() throws SQLException {
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        when(resultSet.getLong(1)).thenReturn(Long.MAX_VALUE);
+        assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void assertGetValueByUnSignedInIntegerRange() throws SQLException {
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        when(resultSet.getLong(1)).thenReturn(Long.valueOf(Integer.MAX_VALUE));
+        assertThat((int) QueryResultUtil.getValue(resultSet, 1), is(Integer.MAX_VALUE));
     }
     
     @Test
-    public void assertGetValueByBigint() throws SQLException {
+    public void assertGetValueBySignedBigint() throws SQLException {
         when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(true);
         when(resultSet.getLong(1)).thenReturn(Long.MAX_VALUE);
         assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
         assertThat((long) QueryResultUtil.getValue(resultSet, 1, long.class), is(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void assertGetValueByUnSignedBeyondBigintRange() throws SQLException {
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        BigDecimal bigDecimal = new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(2));
+        when(resultSet.getBigDecimal(1)).thenReturn(bigDecimal);
+        assertThat((BigDecimal) QueryResultUtil.getValue(resultSet, 1), is(bigDecimal));
+    }
+
+    @Test
+    public void assertGetValueByUnSignedInBigintRange() throws SQLException {
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.BIGINT);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        when(resultSet.getBigDecimal(1)).thenReturn(new BigDecimal(Long.MAX_VALUE));
+        assertThat((long) QueryResultUtil.getValue(resultSet, 1), is(Long.MAX_VALUE));
     }
     
     @Test
@@ -181,7 +232,6 @@ public final class QueryResultUtilTest {
         when(resultSet.getBlob(1)).thenReturn(blob);
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
-    
     }
     
     @Test
@@ -191,7 +241,6 @@ public final class QueryResultUtilTest {
         when(resultSet.getBlob(1)).thenReturn(blob);
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1), is(blob));
         assertThat((Blob) QueryResultUtil.getValue(resultSet, 1, Blob.class), is(blob));
-    
     }
     
     @Test


### PR DESCRIPTION
Fixes #3231 .

Changes proposed in this pull request:
- INT UNSIGNED type, if value beyond java Integer range, return Long type.
- INT UNSIGNED type, if value don't beyond java Integer range, return Integer type.
- INT SIGNED type, return Integer type.
- BIGINT UNSIGNED type, if value beyond java Long range, return BigDemical type.
- BIGINT UNSIGNED type, if value don't beyond java Long range, return Long type.
- BIGINT SIGNED type, return Long type.

@tuohai666  Please help me with the code review, Thanks.