### PR TITLE
Add support show database

### DIFF
--- a/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/core/merge/dal/DALMergeEngine.java
+++ b/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/core/merge/dal/DALMergeEngine.java
@@ -63,7 +63,7 @@ public final class DALMergeEngine implements MergeEngine {
     public MergedResult merge() throws SQLException {
         SQLStatement dalStatement = sqlStatementContext.getSqlStatement();
         if (dalStatement instanceof ShowDatabasesStatement) {
-            return new ShowDatabasesMergedResult();
+            return new ShowDatabasesMergedResult(shardingRule, queryResults);
         }
         if (dalStatement instanceof ShowTableStatusStatement) {
             return new ShowTableStatusMergedResult(shardingRule, queryResults, tableMetas);

--- a/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/core/merge/dal/show/ShowDatabasesMergedResult.java
+++ b/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/core/merge/dal/show/ShowDatabasesMergedResult.java
@@ -17,8 +17,9 @@
 
 package org.apache.shardingsphere.core.merge.dal.show;
 
-import lombok.RequiredArgsConstructor;
+import java.util.ArrayList;
 import org.apache.shardingsphere.core.constant.ShardingConstant;
+import org.apache.shardingsphere.core.execute.sql.execute.result.QueryResult;
 import org.apache.shardingsphere.core.merge.MergedResult;
 
 import java.io.InputStream;
@@ -30,21 +31,41 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
 import java.util.Collections;
 import java.util.List;
+import org.apache.shardingsphere.core.rule.ShardingRule;
 
 /**
  * Merged result for show databases.
  *
  * @author chenqingyang
  */
-@RequiredArgsConstructor
 public final class ShowDatabasesMergedResult extends LocalMergedResultAdapter implements MergedResult {
     
     private final List<String> schemas;
     
     private int currentIndex;
-    
+
     public ShowDatabasesMergedResult() {
         this(Collections.singletonList(ShardingConstant.LOGIC_SCHEMA_NAME));
+    }
+
+    //for proxy backend, just return logic database
+    public ShowDatabasesMergedResult(final List<String> schemas) {
+        this.schemas = schemas;
+        this.currentIndex = 0;
+    }
+
+    public ShowDatabasesMergedResult(final ShardingRule shardingRule, final List<QueryResult> queryResults)throws SQLException {
+        this.schemas = new ArrayList<>();
+        this.currentIndex = 0;
+        init(queryResults);
+    }
+
+    private void init(final List<QueryResult> queryResults) throws SQLException {
+        for (QueryResult queryResult : queryResults) {
+            while (queryResult.next()) {
+                this.schemas.add((String) queryResult.getValue(1, String.class));
+            }
+        }
     }
     
     @Override

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
@@ -93,10 +93,10 @@ public final class RoutingEngineFactory {
     }
     
     private static RoutingEngine getDALRoutingEngine(final ShardingRule shardingRule, final SQLStatement sqlStatement, final Collection<String> tableNames) {
-        if (sqlStatement instanceof ShowDatabasesStatement || sqlStatement instanceof UseStatement) {
+        if (sqlStatement instanceof UseStatement) {
             return new IgnoreRoutingEngine();
         }
-        if (sqlStatement instanceof SetStatement || sqlStatement instanceof ResetParameterStatement) {
+        if (sqlStatement instanceof SetStatement || sqlStatement instanceof ResetParameterStatement || sqlStatement instanceof ShowDatabasesStatement) {
             return new DatabaseBroadcastRoutingEngine(shardingRule);
         }
         if (!tableNames.isEmpty()) {

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactoryTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactoryTest.java
@@ -37,7 +37,6 @@ import org.apache.shardingsphere.core.route.type.broadcast.MasterInstanceBroadca
 import org.apache.shardingsphere.core.route.type.broadcast.TableBroadcastRoutingEngine;
 import org.apache.shardingsphere.core.route.type.complex.ComplexRoutingEngine;
 import org.apache.shardingsphere.core.route.type.defaultdb.DefaultDatabaseRoutingEngine;
-import org.apache.shardingsphere.core.route.type.ignore.IgnoreRoutingEngine;
 import org.apache.shardingsphere.core.route.type.standard.StandardRoutingEngine;
 import org.apache.shardingsphere.core.route.type.unicast.UnicastRoutingEngine;
 import org.apache.shardingsphere.core.rule.ShardingRule;
@@ -120,7 +119,7 @@ public class RoutingEngineFactoryTest {
         DALStatement dalStatement = mock(ShowDatabasesStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
         RoutingEngine actual = RoutingEngineFactory.newInstance(shardingRule, shardingSphereMetaData, sqlStatementContext, shardingConditions);
-        assertThat(actual, instanceOf(IgnoreRoutingEngine.class));
+        assertThat(actual, instanceOf(DatabaseBroadcastRoutingEngine.class));
     }
     
     @Test


### PR DESCRIPTION
Fixes #2922.

Changes proposed in this pull request:
- Make RoutingEngine route `show database` return DatabaseBroadcast
- New ShowDatabasesMergedResult construction 

Some Question
- beacuase type erasure, ShowDatabasesMergedResult constructor has a useless param
- For Proxy, Should Return authorizedSchemas or all schemas?
