### PR TITLE
#3138, improved coverage for sharding-core-preprocessor

### DIFF
--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/pagination/engine/TopPaginationContextEngineTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/pagination/engine/TopPaginationContextEngineTest.java
@@ -18,6 +18,9 @@
 package org.apache.shardingsphere.core.preprocessor.segment.select.pagination.engine;
 
 import com.google.common.base.Optional;
+import org.apache.shardingsphere.core.parse.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.core.parse.sql.segment.dml.pagination.rownum.ParameterMarkerRowNumberValueSegment;
+import org.apache.shardingsphere.core.parse.sql.segment.dml.predicate.value.PredicateInRightValue;
 import org.apache.shardingsphere.core.preprocessor.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.core.preprocessor.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.core.parse.sql.segment.dml.column.ColumnSegment;
@@ -35,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -71,6 +75,47 @@ public final class TopPaginationContextEngineTest {
         assertCreatePaginationContextWhenRowNumberPredicatePresentAndWithGivenOperator(">=");
     }
     
+    @Test
+    public void assertCreatePaginationContextWhenPredicateInRightValue() {
+        String name = "rowNumberAlias";
+        ColumnSegment columnSegment = new ColumnSegment(0, 10, name);
+        PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, mock(PredicateInRightValue.class));
+        AndPredicate andPredicate = new AndPredicate();
+        andPredicate.getPredicates().add(predicateSegment);
+        Collection<AndPredicate> andPredicates = Collections.singleton(andPredicate);
+        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
+        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
+        PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(new TopSegment(0, 10, "text", null, name), andPredicates, Collections.emptyList());
+        Optional<PaginationValueSegment> paginationValueSegmentOptional = paginationContext.getOffsetSegment();
+        assertFalse(paginationValueSegmentOptional.isPresent());
+        assertFalse(paginationContext.getRowCountSegment().isPresent());
+    }
+    
+    @Test
+    public void assertCreatePaginationContextWhenParameterMarkerRowNumberValueSegment() {
+        String name = "rowNumberAlias";
+        ColumnSegment columnSegment = new ColumnSegment(0, 10, name);
+        PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
+        when(predicateCompareRightValue.getOperator()).thenReturn(">");
+        when(predicateCompareRightValue.getExpression()).thenReturn(new ParameterMarkerExpressionSegment(0, 10, 0));
+        PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, predicateCompareRightValue);
+        AndPredicate andPredicate = new AndPredicate();
+        andPredicate.getPredicates().add(predicateSegment);
+        Collection<AndPredicate> andPredicates = Collections.singleton(andPredicate);
+        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
+        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
+        PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(new TopSegment(0, 10, "text", null, name), andPredicates, Collections.<Object>singletonList(1));
+        Optional<PaginationValueSegment> paginationValueSegmentOptional = paginationContext.getOffsetSegment();
+        assertTrue(paginationValueSegmentOptional.isPresent());
+        PaginationValueSegment paginationValueSegment = paginationValueSegmentOptional.get();
+        assertThat(paginationValueSegment, instanceOf(ParameterMarkerRowNumberValueSegment.class));
+        ParameterMarkerRowNumberValueSegment parameterMarkerRowNumberValueSegment = (ParameterMarkerRowNumberValueSegment) paginationValueSegment;
+        assertThat(parameterMarkerRowNumberValueSegment.getStartIndex(), is(0));
+        assertThat(parameterMarkerRowNumberValueSegment.getStopIndex(), is(10));
+        assertThat(parameterMarkerRowNumberValueSegment.getParameterIndex(), is(0));
+        assertFalse(paginationContext.getRowCountSegment().isPresent());
+    }
+    
     private void assertCreatePaginationContextWhenRowNumberPredicatePresentAndWithGivenOperator(final String operator) {
         String name = "rowNumberAlias";
         ColumnSegment columnSegment = new ColumnSegment(0, 10, name);
@@ -82,15 +127,12 @@ public final class TopPaginationContextEngineTest {
         andPredicate.getPredicates().add(predicateSegment);
         Collection<AndPredicate> andPredicates = Collections.singleton(andPredicate);
         ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        String rowNumberAlias = "predicateRowNumberAlias";
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of(rowNumberAlias));
-        List<Object> parameters = Collections.emptyList();
-        TopSegment topSegment = new TopSegment(0, 10, "text", null, name);
-        PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(topSegment, andPredicates, parameters);
+        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
+        PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(new TopSegment(0, 10, "text", null, name), andPredicates, Collections.emptyList());
         Optional<PaginationValueSegment> paginationValueSegmentOptional = paginationContext.getOffsetSegment();
         assertTrue(paginationValueSegmentOptional.isPresent());
         PaginationValueSegment paginationValueSegment = paginationValueSegmentOptional.get();
-        assertTrue(paginationValueSegment instanceof NumberLiteralRowNumberValueSegment);
+        assertThat(paginationValueSegment, instanceOf(NumberLiteralRowNumberValueSegment.class));
         NumberLiteralRowNumberValueSegment numberLiteralRowNumberValueSegment = (NumberLiteralRowNumberValueSegment) paginationValueSegment;
         assertThat(numberLiteralRowNumberValueSegment.getStartIndex(), is(0));
         assertThat(numberLiteralRowNumberValueSegment.getStopIndex(), is(10));

--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/segment/select/projection/engine/ProjectionEngineTest.java
@@ -91,4 +91,20 @@ public final class ProjectionEngineTest {
         assertThat(projection.get(), instanceOf(AggregationProjection.class));
     }
     
+    @Test
+    public void assertProjectionCreatedWhenSelectItemSegmentInstanceOfAggregationDistinctSelectItemSegmentAndAggregationTypeIsAvg() {
+        AggregationDistinctSelectItemSegment aggregationDistinctSelectItemSegment = new AggregationDistinctSelectItemSegment(0, 10, "text", AggregationType.AVG, 0, "distinctExpression");
+        Optional<Projection> projection = new ProjectionEngine().createProjection("select count(1) from table_1", aggregationDistinctSelectItemSegment);
+        assertTrue(projection.isPresent());
+        assertThat(projection.get(), instanceOf(AggregationDistinctProjection.class));
+    }
+    
+    @Test
+    public void assertProjectionCreatedWhenSelectItemSegmentInstanceOfAggregationSelectItemSegmentAndAggregationTypeIsAvg() {
+        AggregationSelectItemSegment aggregationSelectItemSegment = new AggregationSelectItemSegment(0, 10, "text", AggregationType.AVG, 0);
+        Optional<Projection> projection = new ProjectionEngine().createProjection("select count(1) from table_1", aggregationSelectItemSegment);
+        assertTrue(projection.isPresent());
+        assertThat(projection.get(), instanceOf(AggregationProjection.class));
+    }
+    
 }


### PR DESCRIPTION
For #3138

Changes proposed in this pull request:
- TopPaginationContextEngineTest#assertCreatePaginationContextWhenPredicateInRightValue added
- for class of ProjectionEngineTest, assertProjectionCreatedWhenSelectItemSegmentInstanceOfAggregationDistinctSelectItemSegmentAndAggregationTypeIsAvg and assertProjectionCreatedWhenSelectItemSegmentInstanceOfAggregationSelectItemSegmentAndAggregationTypeIsAvg added
