### PR TITLE
MySQL parse insert statement function value with parameter

### DIFF
--- a/sharding-core/sharding-core-parse/sharding-core-parse-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -262,7 +262,6 @@ expr
     | notOperator_ expr
     | LP_ expr RP_
     | booleanPrimary_
-    | predicate
     ;
 
 logicalOperator

--- a/sharding-core/sharding-core-parse/sharding-core-parse-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -262,6 +262,7 @@ expr
     | notOperator_ expr
     | LP_ expr RP_
     | booleanPrimary_
+    | predicate
     ;
 
 logicalOperator
@@ -439,6 +440,7 @@ regularFunction_
 
 regularFunctionName_
     : identifier_ | IF | CURRENT_TIMESTAMP | LOCALTIME | LOCALTIMESTAMP | NOW | REPLACE | INTERVAL | SUBSTRING | LEFT | RIGHT
+    | LOWER | UNIX_TIMESTAMP
     ;
 
 matchExpression_

--- a/sharding-core/sharding-core-parse/sharding-core-parse-mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
@@ -1503,3 +1503,11 @@ RESET
 RESTART
     : R E S T A R T
     ;
+
+UNIX_TIMESTAMP
+    : U N I X UL_ T I M E S T A M P
+    ;
+
+LOWER
+    : L O W E R
+    ;

--- a/sharding-core/sharding-core-parse/sharding-core-parse-test/src/test/resources/sharding/dml/insert.xml
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-test/src/test/resources/sharding/dml/insert.xml
@@ -671,7 +671,7 @@
             <table name="emp" />
         </tables>
         <tokens>
-            <table-token start-index="12" table-name="emp" length="7" />
+            <table-token start-index="12" table-name="emp" length="3" />
         </tokens>
         <sharding-conditions>
             <and-condition>
@@ -691,4 +691,25 @@
         </sharding-conditions>
     </parser-result>
 
+    <parser-result sql-case-id="insert_with_unix_timestamp_function" parameters="2019-10-19, 1000, 10">
+        <tables>
+            <table name="t_order" />
+        </tables>
+        <tokens>
+            <table-token start-index="12" table-name="t_order" length="7" />
+        </tokens>
+        <sharding-conditions>
+            <and-condition>
+                <condition column-name="status" table-name="t_order" operator="EQUAL">
+                    <value index="0" literal="2019-10-19" type="varchar" />
+                </condition>
+                <condition column-name="order_id" table-name="t_order" operator="EQUAL">
+                    <value index="1" literal="1000" type="int" />
+                </condition>
+                <condition column-name="user_id" table-name="t_order" operator="EQUAL">
+                    <value index="2" literal="10" type="int" />
+                </condition>
+            </and-condition>
+        </sharding-conditions>
+    </parser-result>
 </parser-result-sets>

--- a/sharding-sql-test/src/main/resources/sql/sharding/dml/insert.xml
+++ b/sharding-sql-test/src/main/resources/sql/sharding/dml/insert.xml
@@ -49,4 +49,5 @@
     <sql-case id="insert_with_null_value" value="INSERT INTO t_null_value_test(col1) VALUES(null)" db-types="MySQL" />
     <sql-case id="insert_with_blob_value" value="INSERT INTO t_blob_value_test(col1) VALUES(_BINARY'This is a binary value.')" db-types="MySQL" />
     <sql-case id="insert_with_function" value="INSERT INTO t_order(current_date, order_id, user_id) VALUES (curdate(), ?, ?)" db-types="MySQL" />
+    <sql-case id="insert_with_unix_timestamp_function" value="INSERT INTO t_order(status, order_id, user_id) VALUES (unix_timestamp(?), ?, ?)" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
MySQLParser function that parses insert statement was unhandled for the condition of insert statement function value with parameter.See
Fixes #3136.

Changes proposed in this pull request:
- I modify the expr expression by add predicate and add MySQL UNIX_TIMESTAMP and LOWER regular function.
