### PR TITLE
#3138, improved coverage for sharding-core-preprocessor

### DIFF
--- a/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/statement/impl/SelectSQLStatementContextTest.java
+++ b/sharding-core/sharding-core-preprocessor/src/test/java/org/apache/shardingsphere/core/preprocessor/statement/impl/SelectSQLStatementContextTest.java
@@ -18,9 +18,11 @@
 package org.apache.shardingsphere.core.preprocessor.statement.impl;
 
 import com.google.common.collect.Lists;
+import org.apache.shardingsphere.core.metadata.table.TableMetas;
 import org.apache.shardingsphere.core.preprocessor.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.core.preprocessor.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.core.preprocessor.segment.select.projection.Projection;
+import org.apache.shardingsphere.core.preprocessor.segment.select.projection.impl.AggregationProjection;
 import org.apache.shardingsphere.core.preprocessor.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.core.preprocessor.segment.select.orderby.OrderByContext;
 import org.apache.shardingsphere.core.preprocessor.segment.select.orderby.OrderByItem;
@@ -35,6 +37,7 @@ import org.apache.shardingsphere.core.parse.sql.segment.dml.order.item.OrderByIt
 import org.apache.shardingsphere.core.parse.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.core.parse.sql.statement.dml.SelectStatement;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,9 +45,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class SelectSQLStatementContextTest {
     
@@ -118,6 +124,37 @@ public final class SelectSQLStatementContextTest {
         selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
         SelectSQLStatementContext selectSQLStatementContext = new SelectSQLStatementContext(null, "", Collections.emptyList(), selectStatement);
         assertFalse(selectSQLStatementContext.isSameGroupByAndOrderByItems());
+    }
+    
+    @Test
+    public void assertSetIndexWhenAggregationProjectionsPresent() {
+        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
+        AggregationProjection aggregationProjection = mock(AggregationProjection.class);
+        when(projectionsContext.getAggregationProjections()).thenReturn(Collections.singletonList(aggregationProjection));
+        when(aggregationProjection.getDerivedAggregationProjections()).thenReturn(Collections.singletonList(aggregationProjection));
+        when(aggregationProjection.getColumnLabel()).thenReturn("id");
+        SelectSQLStatementContext selectSQLStatementContext = new SelectSQLStatementContext(
+                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), projectionsContext, null);
+        Map<String, Integer> columnLabelIndexMap = new HashMap<>();
+        columnLabelIndexMap.put("id", 3);
+        selectSQLStatementContext.setIndexes(columnLabelIndexMap);
+        assertThat(selectSQLStatementContext.getOrderByContext().getItems().iterator().next().getIndex(), is(3));
+    }
+    
+    @Test
+    public void assertGetColumnLabelsWhenResultIsEmpty() {
+        SelectSQLStatementContext selectSQLStatementContext = new SelectSQLStatementContext(
+                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), mock(ProjectionsContext.class), null);
+        assertTrue(selectSQLStatementContext.getColumnLabels(mock(TableMetas.class)).isEmpty());
+    }
+    
+    @Test
+    public void assertGetColumnLabelsWhenResultIsNotEmpty() {
+        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
+        when(projectionsContext.getColumnLabels((TableMetas) any(), ArgumentMatchers.<TableSegment>anyCollection())).thenReturn(Collections.singletonList("result"));
+        SelectSQLStatementContext selectSQLStatementContext = new SelectSQLStatementContext(
+                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), projectionsContext, null);
+        assertFalse(selectSQLStatementContext.getColumnLabels(mock(TableMetas.class)).isEmpty());
     }
     
     private OrderByContext createOrderBy(final String type) {


### PR DESCRIPTION
For #3138 .

Changes proposed in this pull request:
- assertSetIndexWhenAggregationProjectionsPresent
- assertGetColumnLabelsWhenResultIsEmpty
- assertGetColumnLabelsWhenResultIsNotEmpty

