### PR TITLE
postgres execute bind parameter ERROR paser

### DIFF
--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/PostgreSQLComBindPacket.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/PostgreSQLComBindPacket.java
@@ -72,7 +72,6 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
         int parametersCount = payload.readInt2();
         List<Object> result = new ArrayList<>(parametersCount);
         for (int parameterIndex = 0; parameterIndex < parametersCount; parameterIndex++) {
-            payload.readInt4();
             PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(parameterTypes.get(parameterIndex).getColumnType());
             result.add(binaryProtocolValue.read(payload));
         }

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-postgresql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -33,7 +33,9 @@ public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBina
     
     @Override
     public Object read(final PostgreSQLPacketPayload payload) {
-        return payload.readStringNul();
+        byte[] result = new byte[payload.readInt4()];
+        payload.getByteBuf().readBytes(result);
+        return new String(result);
     }
     
     @Override


### PR DESCRIPTION
Change-Id: I6fa58c4626c5866142f44c0cbaa5ce179d1c55c9

Fixes #3235 .

Changes proposed in this pull request:
- Keep the old indentation format
