### PR TITLE
[LICENSE FIX] Update the license file for maven wrapper

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,20 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+=======================================================================
+Apache ShardingSphere Subcomponents:
+
+The Apache ShardingSphere project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.
+
+========================================================================
+Apache 2.0 licenses
+========================================================================
+
+The following components are provided under the Apache License. See project link for details.
+The text of each license is the standard Apache 2.0 license.
+
+    Maven Wrapper(mvnw, mvnw.cmd files in root path), https://github.com/takari/maven-wrapper   Apache 2.0


### PR DESCRIPTION
This is the additional fix for #3356. Maven wrapper is in Apache 2.0 license now, and as it will release with the source code, the source code LICENSE file should be fixed.

@terrymanu Is my modified file as the source release LICENSE file in the official release process?