### PR TITLE
fix #3273, route to defaultDataSource or master when the sql without tableName

### DIFF
--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/MasterSlaveRouter.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/MasterSlaveRouter.java
@@ -70,6 +70,12 @@ public final class MasterSlaveRouter {
     }
     
     private boolean isMasterRoute(final SQLStatement sqlStatement) {
-        return !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        boolean routeToMaster = !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        if (!routeToMaster) {
+            if (sqlStatement instanceof SelectStatement && ((SelectStatement) sqlStatement).getTables().isEmpty()) {
+                routeToMaster = true;
+            }
+        }
+        return routeToMaster;
     }
 }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/ShardingMasterSlaveRouter.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/ShardingMasterSlaveRouter.java
@@ -75,7 +75,13 @@ public final class ShardingMasterSlaveRouter {
     }
     
     private boolean isMasterRoute(final SQLStatement sqlStatement) {
-        return !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        boolean routeToMaster = !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        if (!routeToMaster) {
+            if (sqlStatement instanceof SelectStatement && ((SelectStatement) sqlStatement).getTables().isEmpty()) {
+                routeToMaster = true;
+            }
+        }
+        return routeToMaster;
     }
     
     private RoutingUnit createNewRoutingUnit(final String actualDataSourceName, final RoutingUnit originalTableUnit) {

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.core.route.router.sharding;
 
+import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.core.metadata.ShardingSphereMetaData;
@@ -87,6 +88,9 @@ public final class RoutingEngineFactory {
             return sqlStatement instanceof SelectStatement ? new UnicastRoutingEngine(shardingRule, tableNames) : new DatabaseBroadcastRoutingEngine(shardingRule);
         }
         if (sqlStatementContext.getSqlStatement() instanceof DMLStatement && shardingConditions.isAlwaysFalse() || tableNames.isEmpty()) {
+            if(!Strings.isNullOrEmpty(shardingRule.getShardingDataSourceNames().getDefaultDataSourceName())){
+                return new DefaultDatabaseRoutingEngine(shardingRule, tableNames);
+            }
             return new UnicastRoutingEngine(shardingRule, tableNames);
         }
         return getShardingRoutingEngine(shardingRule, sqlStatementContext, shardingConditions, tableNames);


### PR DESCRIPTION
fix #3273, route to defaultDataSource or master when the sql without tableName

Fixes #3273.

Changes proposed in this pull request:
sharding:
- With default data source, route to default data source
- Without default data source, unicast route(stay the same)
Master-Slave:
- route to master database
