### PR TITLE
Add tomcat dbcp2 custom connection-properties support

### DIFF
--- a/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/AbstractDbcp2DataSourcePropertiesSetter.java
+++ b/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/AbstractDbcp2DataSourcePropertiesSetter.java
@@ -46,8 +46,8 @@ public abstract class AbstractDbcp2DataSourcePropertiesSetter implements DataSou
         if (PropertyUtil.containPropertyPrefix(environment, datasourcePropertiesPrefix)) {
             Map datasourceProperties = PropertyUtil.handle(environment, datasourcePropertiesPrefix, Map.class);
             Method method = dataSource.getClass().getMethod("addConnectionProperty", String.class, String.class);
-            for (Object key : datasourceProperties.keySet()) {
-                method.invoke(dataSource, key, datasourceProperties.get(key));
+            for (Object each : datasourceProperties.keySet()) {
+                method.invoke(dataSource, each, datasourceProperties.get(each));
             }
         }
     }

--- a/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/AbstractDbcp2DataSourcePropertiesSetter.java
+++ b/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/AbstractDbcp2DataSourcePropertiesSetter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spring.boot.datasource;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.spring.boot.util.PropertyUtil;
+import org.springframework.core.env.Environment;
+
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * DBCP datasource properties setter.
+ *
+ * @author xiayan
+ */
+public abstract class AbstractDbcp2DataSourcePropertiesSetter implements DataSourcePropertiesSetter {
+    
+    /**
+     * common dbcp2 add custom connection properties.
+     *
+     * @param environment environment variable
+     * @param prefix properties prefix
+     * @param dataSourceName current database name
+     * @param dataSource dataSource instance
+     */
+    @SneakyThrows(ReflectiveOperationException.class)
+    public void propertiesSet(final Environment environment, final String prefix, final String dataSourceName, final DataSource dataSource) {
+        String datasourcePropertiesPrefix = prefix + dataSourceName.trim() + ".connection-properties";
+        if (PropertyUtil.containPropertyPrefix(environment, datasourcePropertiesPrefix)) {
+            Map datasourceProperties = PropertyUtil.handle(environment, datasourcePropertiesPrefix, Map.class);
+            Method method = dataSource.getClass().getMethod("addConnectionProperty", String.class, String.class);
+            for (Object key : datasourceProperties.keySet()) {
+                method.invoke(dataSource, key, datasourceProperties.get(key));
+            }
+        }
+    }
+}

--- a/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/CommonDbcp2DataSourcePropertiesSetter.java
+++ b/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/CommonDbcp2DataSourcePropertiesSetter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spring.boot.datasource;
+
+/**
+ * DBCP2 datasource properties setter.
+ *
+ * @author xiayan
+ */
+public final class CommonDbcp2DataSourcePropertiesSetter extends AbstractDbcp2DataSourcePropertiesSetter {
+    
+    @Override
+    public String getType() {
+        return "org.apache.commons.dbcp2.BasicDataSource";
+    }
+}

--- a/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/TomcatDbcp2DataSourcePropertiesSetter.java
+++ b/sharding-spring/sharding-spring-boot-util/src/main/java/org/apache/shardingsphere/spring/boot/datasource/TomcatDbcp2DataSourcePropertiesSetter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spring.boot.datasource;
+
+/**
+ * Tomcat DBCP2 datasource properties setter.
+ *
+ * @author xiayan
+ */
+public final class TomcatDbcp2DataSourcePropertiesSetter extends AbstractDbcp2DataSourcePropertiesSetter {
+    
+    @Override
+    public String getType() {
+        return "org.apache.tomcat.dbcp.dbcp2.BasicDataSource";
+    }
+}

--- a/sharding-spring/sharding-spring-boot-util/src/main/resources/META-INF/services/org.apache.shardingsphere.spring.boot.datasource.DataSourcePropertiesSetter
+++ b/sharding-spring/sharding-spring-boot-util/src/main/resources/META-INF/services/org.apache.shardingsphere.spring.boot.datasource.DataSourcePropertiesSetter
@@ -16,3 +16,5 @@
 #
 
 org.apache.shardingsphere.spring.boot.datasource.HikariDataSourcePropertiesSetter
+org.apache.shardingsphere.spring.boot.datasource.CommonDbcp2DataSourcePropertiesSetter
+org.apache.shardingsphere.spring.boot.datasource.TomcatDbcp2DataSourcePropertiesSetter

--- a/sharding-spring/sharding-spring-boot-util/src/test/java/org/apache/shardingsphere/spring/boot/datasource/Dbcp2DataSourcePropertiesSetterTest.java
+++ b/sharding-spring/sharding-spring-boot-util/src/test/java/org/apache/shardingsphere/spring/boot/datasource/Dbcp2DataSourcePropertiesSetterTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertThat;
 
 public class Dbcp2DataSourcePropertiesSetterTest {
     
-    private final CommonDbcp2DataSourcePropertiesSetter abstractDbcp2DataSourcePropertiesSetter = new CommonDbcp2DataSourcePropertiesSetter();
+    private final CommonDbcp2DataSourcePropertiesSetter dbcp2DataSourcePropertiesSetter = new CommonDbcp2DataSourcePropertiesSetter();
     
     private final BasicDataSource dataSource = new BasicDataSource();
     
@@ -48,7 +48,7 @@ public class Dbcp2DataSourcePropertiesSetterTest {
     
     @Test
     public void assertPropertiesSet() {
-        abstractDbcp2DataSourcePropertiesSetter.propertiesSet(environment, "spring.shardingsphere.datasource.", "ds_master", dataSource);
+        dbcp2DataSourcePropertiesSetter.propertiesSet(environment, "spring.shardingsphere.datasource.", "ds_master", dataSource);
         Properties connectionProperties = (Properties) ReflectionTestUtils.getField(dataSource, "connectionProperties");
         assertThat(connectionProperties.getProperty("test"), is("test"));
         assertThat(connectionProperties.getProperty("xxx"), is("yyy"));
@@ -56,6 +56,6 @@ public class Dbcp2DataSourcePropertiesSetterTest {
     
     @Test
     public void assertGetType() {
-        assertThat(abstractDbcp2DataSourcePropertiesSetter.getType(), is("org.apache.commons.dbcp2.BasicDataSource"));
+        assertThat(dbcp2DataSourcePropertiesSetter.getType(), is("org.apache.commons.dbcp2.BasicDataSource"));
     }
 }

--- a/sharding-spring/sharding-spring-boot-util/src/test/java/org/apache/shardingsphere/spring/boot/datasource/Dbcp2DataSourcePropertiesSetterTest.java
+++ b/sharding-spring/sharding-spring-boot-util/src/test/java/org/apache/shardingsphere/spring/boot/datasource/Dbcp2DataSourcePropertiesSetterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spring.boot.datasource;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class Dbcp2DataSourcePropertiesSetterTest {
+    
+    private final CommonDbcp2DataSourcePropertiesSetter abstractDbcp2DataSourcePropertiesSetter = new CommonDbcp2DataSourcePropertiesSetter();
+    
+    private final BasicDataSource dataSource = new BasicDataSource();
+    
+    private Environment environment;
+    
+    @Before
+    public void setUp() {
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        mockEnvironment.setProperty("spring.shardingsphere.datasource.ds_master.type", "org.apache.commons.dbcp2.BasicDataSource");
+        mockEnvironment.setProperty("spring.shardingsphere.datasource.ds_master.connection-properties.test", "test");
+        mockEnvironment.setProperty("spring.shardingsphere.datasource.ds_master.connection-properties.xxx", "yyy");
+        environment = mockEnvironment;
+    }
+    
+    @Test
+    public void assertPropertiesSet() {
+        abstractDbcp2DataSourcePropertiesSetter.propertiesSet(environment, "spring.shardingsphere.datasource.", "ds_master", dataSource);
+        Properties connectionProperties = (Properties) ReflectionTestUtils.getField(dataSource, "connectionProperties");
+        assertThat(connectionProperties.getProperty("test"), is("test"));
+        assertThat(connectionProperties.getProperty("xxx"), is("yyy"));
+    }
+    
+    @Test
+    public void assertGetType() {
+        assertThat(abstractDbcp2DataSourcePropertiesSetter.getType(), is("org.apache.commons.dbcp2.BasicDataSource"));
+    }
+}


### PR DESCRIPTION
Fixes #3384.

Changes proposed in this pull request:
- Add tomcat dbcp2 custom connection-properties support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/incubator-shardingsphere/3392)
<!-- Reviewable:end -->
