### PR TITLE
fixes execute "SHOW VARIABLES LIKE 'lower_case_%'" NullPointerException bug.(#3397)

### DIFF
--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
@@ -62,17 +62,17 @@ public final class QueryHeader {
         if (logicSchema instanceof ShardingSchema) {
             Collection<String> tableNames = logicSchema.getShardingRule().getLogicTableNames(resultSetMetaData.getTableName(columnIndex));
             this.table = tableNames.isEmpty() ? "" : tableNames.iterator().next();
-            if (resultSetMetaData.getTableName(columnIndex).isEmpty()) {
-                this.primaryKey = false;
-                this.notNull = false;
-                this.autoIncrement = false;
-            } else {
+            if (logicSchema.getMetaData().getTables().containsTable(resultSetMetaData.getTableName(columnIndex))) {
                 this.primaryKey = logicSchema.getMetaData().getTables().get(resultSetMetaData.getTableName(columnIndex)).getColumns()
                         .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isPrimaryKey();
                 this.notNull = logicSchema.getMetaData().getTables().get(resultSetMetaData.getTableName(columnIndex)).getColumns()
                         .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isNotNull();
                 this.autoIncrement = logicSchema.getMetaData().getTables().get(resultSetMetaData.getTableName(columnIndex)).getColumns()
                         .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isAutoIncrement();
+            } else {
+                this.primaryKey = false;
+                this.notNull = false;
+                this.autoIncrement = false;
             }
         } else {
             this.table = resultSetMetaData.getTableName(columnIndex);

--- a/sharding-proxy/sharding-proxy-backend/src/test/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeaderTest.java
+++ b/sharding-proxy/sharding-proxy-backend/src/test/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeaderTest.java
@@ -112,6 +112,7 @@ public final class QueryHeaderTest {
         ColumnMetaData columnMetaData = new ColumnMetaData("order_id", "int", true, true, true);
         TableMetas tableMetas = mock(TableMetas.class);
         when(tableMetas.get("t_order")).thenReturn(new TableMetaData(Arrays.asList(columnMetaData), Arrays.asList("order_id")));
+        when(tableMetas.containsTable("t_order")).thenReturn(true);
         ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
         when(metaData.getTables()).thenReturn(tableMetas);
         DataSourceMetas dataSourceMetas = mock(DataSourceMetas.class);


### PR DESCRIPTION
Fixes #3397 .

Changes proposed in this pull request:
- when execute "SHOW VARIABLES LIKE 'lower_case_%'", return right value.
