### PR TITLE
fix #3273, route to defaultDataSource or master when the sql without tableName

### DIFF
--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/MasterSlaveRouter.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/MasterSlaveRouter.java
@@ -70,6 +70,12 @@ public final class MasterSlaveRouter {
     }
     
     private boolean isMasterRoute(final SQLStatement sqlStatement) {
-        return !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        boolean routeToMaster = !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        if (!routeToMaster) {
+            if (sqlStatement instanceof SelectStatement && ((SelectStatement) sqlStatement).getTables().isEmpty()) {
+                routeToMaster = true;
+            }
+        }
+        return routeToMaster;
     }
 }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/ShardingMasterSlaveRouter.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/masterslave/ShardingMasterSlaveRouter.java
@@ -75,7 +75,13 @@ public final class ShardingMasterSlaveRouter {
     }
     
     private boolean isMasterRoute(final SQLStatement sqlStatement) {
-        return !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        boolean routeToMaster = !(sqlStatement instanceof SelectStatement) || MasterVisitedManager.isMasterVisited() || HintManager.isMasterRouteOnly();
+        if (!routeToMaster) {
+            if (sqlStatement instanceof SelectStatement && ((SelectStatement) sqlStatement).getTables().isEmpty()) {
+                routeToMaster = true;
+            }
+        }
+        return routeToMaster;
     }
     
     private RoutingUnit createNewRoutingUnit(final String actualDataSourceName, final RoutingUnit originalTableUnit) {

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.core.route.router.sharding;
 
+import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.core.metadata.ShardingSphereMetaData;
@@ -87,6 +88,9 @@ public final class RoutingEngineFactory {
             return sqlStatement instanceof SelectStatement ? new UnicastRoutingEngine(shardingRule, tableNames) : new DatabaseBroadcastRoutingEngine(shardingRule);
         }
         if (sqlStatementContext.getSqlStatement() instanceof DMLStatement && shardingConditions.isAlwaysFalse() || tableNames.isEmpty()) {
+            if(!Strings.isNullOrEmpty(shardingRule.getShardingDataSourceNames().getDefaultDataSourceName())){
+                return new DefaultDatabaseRoutingEngine(shardingRule, tableNames);
+            }
             return new UnicastRoutingEngine(shardingRule, tableNames);
         }
         return getShardingRoutingEngine(shardingRule, sqlStatementContext, shardingConditions, tableNames);

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactory.java
@@ -88,7 +88,7 @@ public final class RoutingEngineFactory {
             return sqlStatement instanceof SelectStatement ? new UnicastRoutingEngine(shardingRule, tableNames) : new DatabaseBroadcastRoutingEngine(shardingRule);
         }
         if (sqlStatementContext.getSqlStatement() instanceof DMLStatement && shardingConditions.isAlwaysFalse() || tableNames.isEmpty()) {
-            if(!Strings.isNullOrEmpty(shardingRule.getShardingDataSourceNames().getDefaultDataSourceName())){
+            if (!Strings.isNullOrEmpty(shardingRule.getShardingDataSourceNames().getDefaultDataSourceName())) {
                 return new DefaultDatabaseRoutingEngine(shardingRule, tableNames);
             }
             return new UnicastRoutingEngine(shardingRule, tableNames);

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactoryTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/router/sharding/RoutingEngineFactoryTest.java
@@ -39,6 +39,7 @@ import org.apache.shardingsphere.core.route.type.complex.ComplexRoutingEngine;
 import org.apache.shardingsphere.core.route.type.defaultdb.DefaultDatabaseRoutingEngine;
 import org.apache.shardingsphere.core.route.type.standard.StandardRoutingEngine;
 import org.apache.shardingsphere.core.route.type.unicast.UnicastRoutingEngine;
+import org.apache.shardingsphere.core.rule.ShardingDataSourceNames;
 import org.apache.shardingsphere.core.rule.ShardingRule;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +57,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RoutingEngineFactoryTest {
-    
+
+    private static final String DEFAULT_DATASOURCE_NAME = "dataSource";
+
     @Mock
     private ShardingRule shardingRule;
     
@@ -71,6 +74,9 @@ public class RoutingEngineFactoryTest {
     
     @Mock
     private ShardingConditions shardingConditions;
+
+    @Mock
+    private ShardingDataSourceNames shardingDataSourceNames;
     
     private Collection<String> tableNames;
     
@@ -79,6 +85,7 @@ public class RoutingEngineFactoryTest {
         when(sqlStatementContext.getTablesContext()).thenReturn(tablesContext);
         tableNames = new ArrayList<>();
         when(tablesContext.getTableNames()).thenReturn(tableNames);
+        when(shardingRule.getShardingDataSourceNames()).thenReturn(shardingDataSourceNames);
     }
     
     @Test
@@ -153,6 +160,15 @@ public class RoutingEngineFactoryTest {
     public void assertNewInstanceForDefaultDataSource() {
         when(shardingRule.isAllInDefaultDataSource(tableNames)).thenReturn(true);
         SQLStatement sqlStatement = mock(SQLStatement.class);
+        when(sqlStatementContext.getSqlStatement()).thenReturn(sqlStatement);
+        RoutingEngine actual = RoutingEngineFactory.newInstance(shardingRule, shardingSphereMetaData, sqlStatementContext, shardingConditions);
+        assertThat(actual, instanceOf(DefaultDatabaseRoutingEngine.class));
+    }
+
+    @Test
+    public void assertNewInstanceForSelectDefaultDataSource() {
+        when(shardingDataSourceNames.getDefaultDataSourceName()).thenReturn(DEFAULT_DATASOURCE_NAME);
+        SQLStatement sqlStatement = mock(SelectStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(sqlStatement);
         RoutingEngine actual = RoutingEngineFactory.newInstance(shardingRule, shardingSphereMetaData, sqlStatementContext, shardingConditions);
         assertThat(actual, instanceOf(DefaultDatabaseRoutingEngine.class));


### PR DESCRIPTION
Fixes #3273.

Changes proposed in this pull request:
sharding:
With default data source, route to default data source
Without default data source, unicast route(stay the same)
Master-Slave:
route to master database