### PR TITLE
PostgreSQL parse select statement with ~~ and !~~ operator

### DIFF
--- a/sharding-core/sharding-core-parse/sharding-core-parse-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -172,6 +172,7 @@ predicate
     | bitExpr NOT? IN LP_ expr (COMMA_ expr)* RP_
     | bitExpr NOT? BETWEEN bitExpr AND predicate
     | bitExpr NOT? LIKE simpleExpr (ESCAPE simpleExpr)?
+    | bitExpr (TILDE_TILDE_ | NOT_TILDE_TILDE_) simpleExpr (ESCAPE simpleExpr)?
     | bitExpr
     ;
 

--- a/sharding-core/sharding-core-parse/sharding-core-parse-postgresql/src/main/antlr4/imports/postgresql/Symbol.g4
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-postgresql/src/main/antlr4/imports/postgresql/Symbol.g4
@@ -57,3 +57,5 @@ BQ_:                 '`';
 QUESTION_:           '?';
 AT_:                 '@';
 SEMI_:               ';';
+TILDE_TILDE_:        '~~';
+NOT_TILDE_TILDE_:    '!~~';

--- a/sharding-core/sharding-core-parse/sharding-core-parse-test/src/test/resources/sharding/dml/select.xml
+++ b/sharding-core/sharding-core-parse/sharding-core-parse-test/src/test/resources/sharding/dml/select.xml
@@ -312,6 +312,32 @@
             </aggregation-select-items>
         </select-items>
     </parser-result>
+
+    <parser-result sql-case-id="select_count_tilde_concat" parameters="'init', 1, 2, 9, 10">
+        <tables>
+            <table name="t_order" alias="o"/>
+        </tables>
+        <tokens>
+            <table-token start-index="37" table-name="t_order" length="7" />
+        </tokens>
+        <sharding-conditions>
+            <and-condition>
+                <condition column-name="user_id" table-name="t_order" operator="IN">
+                    <value index="1" literal="1" type="int" />
+                    <value index="2" literal="2" type="int" />
+                </condition>
+                <condition column-name="order_id" table-name="t_order" operator="BETWEEN">
+                    <value index="3" literal="9" type="int" />
+                    <value index="4" literal="10" type="int" />
+                </condition>
+            </and-condition>
+        </sharding-conditions>
+        <select-items start-index="7" stop-index="30">
+            <aggregation-select-items>
+                <aggregation-select-item start-index="7" stop-index="14" type="COUNT" text="count(0)" inner-expression="(0)" alias="orders_count"/>
+            </aggregation-select-items>
+        </select-items>
+    </parser-result>
     
     <parser-result sql-case-id="select_sharding_route_with_binding_tables" parameters="1, 2, 9, 10">
         <tables>

--- a/sharding-integration-test/sharding-jdbc-test/src/test/resources/integrate/cases/dql/dataset/masterslave/postgresql/select_count_tilde_concat.xml
+++ b/sharding-integration-test/sharding-jdbc-test/src/test/resources/integrate/cases/dql/dataset/masterslave/postgresql/select_count_tilde_concat.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="orders_count" />
+    </metadata>
+    <row values="4" />
+</dataset>

--- a/sharding-integration-test/sharding-jdbc-test/src/test/resources/integrate/cases/dql/dql-integrate-test-cases.xml
+++ b/sharding-integration-test/sharding-jdbc-test/src/test/resources/integrate/cases/dql/dql-integrate-test-cases.xml
@@ -72,6 +72,10 @@
     <dql-test-case sql-case-id="select_count_like_concat">
         <assertion parameters="init:String, 10:int, 11:int, 1000:int, 2901:int" expected-data-file="select_count_like_concat.xml" />
     </dql-test-case>
+
+    <dql-test-case sql-case-id="select_count_tilde_concat">
+        <assertion parameters="init:String, 10:int, 11:int, 1000:int, 2901:int" expected-data-file="select_count_tilde_concat.xml" />
+    </dql-test-case>
     
     <dql-test-case sql-case-id="select_sharding_route_with_binding_tables">
         <assertion parameters="10:int, 11:int, 1000:int, 1909:int" expected-data-file="select_sharding_route_with_binding_tables.xml" />

--- a/sharding-sql-test/src/main/resources/sql/sharding/dql/select.xml
+++ b/sharding-sql-test/src/main/resources/sql/sharding/dql/select.xml
@@ -30,6 +30,7 @@
     <sql-case id="select_equal_with_same_sharding_column" value="SELECT * FROM t_order WHERE order_id = ? AND order_id = ?" />
     <sql-case id="select_in_with_same_sharding_column" value="SELECT * FROM t_order WHERE order_id IN (?, ?) AND order_id IN (?, ?) ORDER BY order_id" />
     <sql-case id="select_count_like_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" />
+    <sql-case id="select_count_tilde_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status ~~ CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="PostgreSQL" />
     <sql-case id="select_sharding_route_with_binding_tables" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id WHERE o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ? ORDER BY i.item_id" />
     <sql-case id="select_full_route_with_binding_tables" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id ORDER BY i.item_id" />
     <!--TODO Need to verify case insensitivity of table names in sharding rule-->


### PR DESCRIPTION
PostgreSQLParser function that parses select statement was unhandled for the condition of select statement including ~~ and !~~ operator.
Fixes #3424.

Changes proposed in this pull request:

- I add ~~ and !~~ operator to bitExpr that select statement could identify these operator.