### PR TITLE
using original XADataSource directly for XA unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,7 @@
         <logback.version>1.2.0</logback.version>
         
         <hikari-cp.version>2.4.11</hikari-cp.version>
-        <alibaba.druid.version>1.1.11</alibaba.druid.version>
         <commons-dbcp2.version>2.2.0</commons-dbcp2.version>
-        <tomcat-dbcp.version>9.0.14</tomcat-dbcp.version>
         <commons-pool.version>1.6</commons-pool.version>
         <h2.version>1.4.196</h2.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
@@ -383,12 +381,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>druid</artifactId>
-                <version>${alibaba.druid.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>commons-pool</groupId>
                 <artifactId>commons-pool</artifactId>
                 <version>${commons-pool.version}</version>
@@ -404,12 +396,6 @@
                         <artifactId>commons-pool</artifactId>
                     </exclusion>
                 </exclusions>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-dbcp</artifactId>
-                <version>${tomcat-dbcp.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/pom.xml
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/pom.xml
@@ -60,14 +60,6 @@
             <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-dbcp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>druid</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSource.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSource.java
@@ -47,6 +47,14 @@ public final class SingleXADataSource extends AbstractUnsupportedSingleXADataSou
     
     private final boolean isOriginalXADataSource;
     
+    public SingleXADataSource(final DatabaseType databaseType, final String resourceName, final XADataSource xaDataSource) {
+        this.databaseType = databaseType;
+        this.resourceName = resourceName;
+        this.xaDataSource = xaDataSource;
+        this.originalDataSource = null;
+        this.isOriginalXADataSource = true;
+    }
+    
     public SingleXADataSource(final DatabaseType databaseType, final String resourceName, final DataSource dataSource) {
         this.databaseType = databaseType;
         this.resourceName = resourceName;

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/XAShardingTransactionManagerTest.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/XAShardingTransactionManagerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.transaction.xa;
 
-import com.alibaba.druid.pool.xa.DruidXADataSource;
 import com.atomikos.jdbc.AtomikosDataSourceBean;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.SneakyThrows;
@@ -37,7 +36,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.sql.DataSource;
 import javax.sql.XADataSource;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
@@ -86,24 +84,15 @@ public final class XAShardingTransactionManagerTest {
     }
     
     @Test
-    public void assertRegisterXATransactionalDataSources() {
-        Collection<ResourceDataSource> resourceDataSources = createResourceDataSources(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("MySQL"));
-        xaShardingTransactionManager.init(DatabaseTypes.getActualDatabaseType("MySQL"), resourceDataSources);
-        for (ResourceDataSource each : resourceDataSources) {
-            verify(xaTransactionManager).registerRecoveryResource(each.getUniqueResourceName(), (XADataSource) each.getDataSource());
-        }
-    }
-    
-    @Test
     public void assertRegisterAtomikosDataSourceBeans() {
-        xaShardingTransactionManager.init(DatabaseTypes.getActualDatabaseType("MySQL"), createAtomikosDataSourceBeanResource());
+        xaShardingTransactionManager.init(DatabaseTypes.getActualDatabaseType("H2"), createAtomikosDataSourceBeanResource());
         verify(xaTransactionManager, times(0)).registerRecoveryResource(anyString(), any(XADataSource.class));
     }
     
     @Test
     public void assertRegisterNoneXATransactionalDAtaSources() {
-        Collection<ResourceDataSource> resourceDataSources = createResourceDataSources(HikariDataSource.class, DatabaseTypes.getActualDatabaseType("MySQL"));
-        xaShardingTransactionManager.init(DatabaseTypes.getActualDatabaseType("MySQL"), resourceDataSources);
+        Collection<ResourceDataSource> resourceDataSources = createResourceDataSources(DatabaseTypes.getActualDatabaseType("H2"));
+        xaShardingTransactionManager.init(DatabaseTypes.getActualDatabaseType("H2"), resourceDataSources);
         Map<String, SingleXADataSource> cachedXADatasourceMap = getCachedSingleXADataSourceMap();
         assertThat(cachedXADatasourceMap.size(), is(2));
     }
@@ -202,10 +191,10 @@ public final class XAShardingTransactionManagerTest {
         return result;
     }
     
-    private Collection<ResourceDataSource> createResourceDataSources(final Class<? extends DataSource> dataSourceClass, final DatabaseType databaseType) {
+    private Collection<ResourceDataSource> createResourceDataSources(final DatabaseType databaseType) {
         List<ResourceDataSource> result = new LinkedList<>();
-        result.add(new ResourceDataSource("ds1", DataSourceUtils.build(dataSourceClass, databaseType, "demo_ds_1")));
-        result.add(new ResourceDataSource("ds2", DataSourceUtils.build(dataSourceClass, databaseType, "demo_ds_2")));
+        result.add(new ResourceDataSource("ds1", DataSourceUtils.build(HikariDataSource.class, databaseType, "demo_ds_1")));
+        result.add(new ResourceDataSource("ds2", DataSourceUtils.build(HikariDataSource.class, databaseType, "demo_ds_2")));
         return result;
     }
     

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/fixture/DataSourceUtils.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/fixture/DataSourceUtils.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.transaction.xa.fixture;
 
-import com.alibaba.druid.pool.DruidDataSource;
-import com.alibaba.druid.pool.xa.DruidXADataSource;
 import com.atomikos.beans.PropertyUtils;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.NoArgsConstructor;
@@ -53,18 +51,6 @@ public final class DataSourceUtils {
         if (HikariDataSource.class == dataSourceClass) {
             return createHikariDataSource(databaseType, databaseName);
         }
-        if (org.apache.commons.dbcp2.BasicDataSource.class == dataSourceClass) {
-            return createBasicDataSource(databaseType, databaseName);
-        }
-        if (org.apache.tomcat.dbcp.dbcp2.BasicDataSource.class == dataSourceClass) {
-            return createTomcatDataSource(databaseType, databaseName);
-        }
-        if (DruidXADataSource.class == dataSourceClass) {
-            return createDruidXADataSource(databaseType, databaseName);
-        }
-        if (DruidDataSource.class == dataSourceClass) {
-            return createDruidDataSource(databaseType, databaseName);
-        }
         throw new UnsupportedOperationException(dataSourceClass.getClass().getName());
     }
     
@@ -80,67 +66,17 @@ public final class DataSourceUtils {
         return result;
     }
     
-    private static org.apache.commons.dbcp2.BasicDataSource createBasicDataSource(final DatabaseType databaseType, final String databaseName) {
-        org.apache.commons.dbcp2.BasicDataSource result = new org.apache.commons.dbcp2.BasicDataSource();
-        result.setUrl(getURL(databaseType, databaseName));
-        result.setUsername("root");
-        result.setPassword("root");
-        result.setMaxTotal(10);
-        result.setMinIdle(2);
-        result.setMaxWaitMillis(15 * 1000);
-        result.setMinEvictableIdleTimeMillis(40 * 1000);
-        result.setTimeBetweenEvictionRunsMillis(20 * 1000);
-        result.setMaxConnLifetimeMillis(500 * 1000);
-        return result;
-    }
-    
-    private static org.apache.tomcat.dbcp.dbcp2.BasicDataSource createTomcatDataSource(final DatabaseType databaseType, final String databaseName) {
-        org.apache.tomcat.dbcp.dbcp2.BasicDataSource result = new org.apache.tomcat.dbcp.dbcp2.BasicDataSource();
-        result.setUrl(getURL(databaseType, databaseName));
-        result.setUsername("root");
-        result.setPassword("root");
-        result.setMaxTotal(10);
-        result.setMinIdle(2);
-        result.setMaxWaitMillis(15 * 1000);
-        result.setMinEvictableIdleTimeMillis(40 * 1000);
-        result.setTimeBetweenEvictionRunsMillis(20 * 1000);
-        result.setMaxConnLifetimeMillis(500 * 1000);
-        return result;
-    }
-    
-    private static DruidXADataSource createDruidXADataSource(final DatabaseType databaseType, final String databaseName) {
-        DruidXADataSource result = new DruidXADataSource();
-        configDruidDataSource(result, databaseType, databaseName);
-        return result;
-    }
-    
-    private static DruidDataSource createDruidDataSource(final DatabaseType databaseType, final String databaseName) {
-        DruidDataSource result = new DruidDataSource();
-        configDruidDataSource(result, databaseType, databaseName);
-        return result;
-    }
-    
-    private static void configDruidDataSource(final DruidDataSource druidDataSource, final DatabaseType databaseType, final String databaseName) {
-        druidDataSource.setUrl(getURL(databaseType, databaseName));
-        druidDataSource.setUsername("root");
-        druidDataSource.setPassword("root");
-        druidDataSource.setMaxActive(10);
-        druidDataSource.setMinIdle(2);
-        druidDataSource.setMaxWait(15 * 1000);
-        druidDataSource.setMinEvictableIdleTimeMillis(40 * 1000);
-        druidDataSource.setTimeBetweenEvictionRunsMillis(20 * 1000);
-    }
-    
     /**
      * Get XA data source.
      * @param databaseType database type
+     * @param databaseName database name
      * @return XA data source
      */
     @SneakyThrows
-    public static XADataSource createXADataSource(final DatabaseType databaseType) {
+    public static XADataSource createXADataSource(final DatabaseType databaseType, final String databaseName) {
         XADataSource result = XADataSourceFactory.build(databaseType);
         XADataSourceDefinition xaDataSourceDefinition = XADataSourceDefinitionFactory.getXADataSourceDefinition(databaseType);
-        Properties xaProperties = xaDataSourceDefinition.getXAProperties(new DatabaseAccessConfiguration(getURL(databaseType, "ds1"), "root", "root"));
+        Properties xaProperties = xaDataSourceDefinition.getXAProperties(new DatabaseAccessConfiguration(getURL(databaseType, databaseName), "root", "root"));
         PropertyUtils.setProperties(result, xaProperties);
         return result;
     }

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/fixture/DataSourceUtils.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/fixture/DataSourceUtils.java
@@ -19,11 +19,19 @@ package org.apache.shardingsphere.transaction.xa.fixture;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.xa.DruidXADataSource;
+import com.atomikos.beans.PropertyUtils;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.core.config.DatabaseAccessConfiguration;
 import org.apache.shardingsphere.spi.database.DatabaseType;
+import org.apache.shardingsphere.transaction.xa.jta.datasource.XADataSourceFactory;
+import org.apache.shardingsphere.transaction.xa.jta.datasource.properties.XADataSourceDefinition;
+import org.apache.shardingsphere.transaction.xa.jta.datasource.properties.XADataSourceDefinitionFactory;
 
 import javax.sql.DataSource;
+import javax.sql.XADataSource;
+import java.util.Properties;
 
 /**
  * Data source utility.
@@ -121,6 +129,20 @@ public final class DataSourceUtils {
         druidDataSource.setMaxWait(15 * 1000);
         druidDataSource.setMinEvictableIdleTimeMillis(40 * 1000);
         druidDataSource.setTimeBetweenEvictionRunsMillis(20 * 1000);
+    }
+    
+    /**
+     * Get XA data source.
+     * @param databaseType database type
+     * @return XA data source
+     */
+    @SneakyThrows
+    public static XADataSource createXADataSource(final DatabaseType databaseType) {
+        XADataSource result = XADataSourceFactory.build(databaseType);
+        XADataSourceDefinition xaDataSourceDefinition = XADataSourceDefinitionFactory.getXADataSourceDefinition(databaseType);
+        Properties xaProperties = xaDataSourceDefinition.getXAProperties(new DatabaseAccessConfiguration(getURL(databaseType, "ds1"), "root", "root"));
+        PropertyUtils.setProperties(result, xaProperties);
+        return result;
     }
     
     private static String getURL(final DatabaseType databaseType, final String databaseName) {

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSourceTest.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSourceTest.java
@@ -38,7 +38,7 @@ public final class SingleXADataSourceTest {
     
     @Test
     public void assertBuildSingleXADataSourceOfXA() {
-        XADataSource xaDataSource = DataSourceUtils.createXADataSource(DatabaseTypes.getActualDatabaseType("H2"));
+        XADataSource xaDataSource = DataSourceUtils.createXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource actual = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", xaDataSource);
         assertThat(actual.getResourceName(), is("ds1"));
         assertThat(actual.getXaDataSource(), is(xaDataSource));
@@ -57,7 +57,7 @@ public final class SingleXADataSourceTest {
     
     @Test
     public void assertGetXAConnectionOfXA() throws SQLException {
-        XADataSource xaDataSource = DataSourceUtils.createXADataSource(DatabaseTypes.getActualDatabaseType("H2"));
+        XADataSource xaDataSource = DataSourceUtils.createXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", xaDataSource);
         SingleXAConnection actual = shardingXADataSource.getXAConnection();
         assertThat(actual.getConnection(), instanceOf(Connection.class));

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSourceTest.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSourceTest.java
@@ -58,8 +58,8 @@ public final class SingleXADataSourceTest {
     
     @Test
     public void assertGetXAConnectionOfXA() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
-        SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
+        XADataSource xaDataSource = XADataSourceFactory.build(DatabaseTypes.getActualDatabaseType("H2"));
+        SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", xaDataSource);
         SingleXAConnection actual = shardingXADataSource.getXAConnection();
         assertThat(actual.getConnection(), instanceOf(Connection.class));
     }
@@ -74,8 +74,8 @@ public final class SingleXADataSourceTest {
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetLoginTimeout() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
-        SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
+        XADataSource xaDataSource = XADataSourceFactory.build(DatabaseTypes.getActualDatabaseType("H2"));
+        SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", xaDataSource);
         shardingXADataSource.getLoginTimeout();
     }
     

--- a/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSourceTest.java
+++ b/sharding-transaction/sharding-transaction-2pc/sharding-transaction-xa/sharding-transaction-xa-core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/SingleXADataSourceTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.transaction.xa.jta.datasource;
 
-import com.alibaba.druid.pool.xa.DruidXADataSource;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.core.database.DatabaseTypes;
 import org.apache.shardingsphere.transaction.xa.fixture.DataSourceUtils;
@@ -39,10 +38,10 @@ public final class SingleXADataSourceTest {
     
     @Test
     public void assertBuildSingleXADataSourceOfXA() {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("MySQL"), "ds1");
-        SingleXADataSource actual = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("MySQL"), "ds1", dataSource);
+        XADataSource xaDataSource = DataSourceUtils.createXADataSource(DatabaseTypes.getActualDatabaseType("H2"));
+        SingleXADataSource actual = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", xaDataSource);
         assertThat(actual.getResourceName(), is("ds1"));
-        assertThat(actual.getXaDataSource(), is((XADataSource) dataSource));
+        assertThat(actual.getXaDataSource(), is(xaDataSource));
     }
     
     @Test
@@ -58,7 +57,7 @@ public final class SingleXADataSourceTest {
     
     @Test
     public void assertGetXAConnectionOfXA() throws SQLException {
-        XADataSource xaDataSource = XADataSourceFactory.build(DatabaseTypes.getActualDatabaseType("H2"));
+        XADataSource xaDataSource = DataSourceUtils.createXADataSource(DatabaseTypes.getActualDatabaseType("H2"));
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", xaDataSource);
         SingleXAConnection actual = shardingXADataSource.getXAConnection();
         assertThat(actual.getConnection(), instanceOf(Connection.class));
@@ -81,35 +80,35 @@ public final class SingleXADataSourceTest {
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertSetLogWriter() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
+        DataSource dataSource = DataSourceUtils.build(HikariDataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
         shardingXADataSource.setLogWriter(null);
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertSetLoginTimeout() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
+        DataSource dataSource = DataSourceUtils.build(HikariDataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
         shardingXADataSource.setLoginTimeout(10);
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetParentLogger() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
+        DataSource dataSource = DataSourceUtils.build(HikariDataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
         shardingXADataSource.getParentLogger();
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetLogWriter() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
+        DataSource dataSource = DataSourceUtils.build(HikariDataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
         shardingXADataSource.getLogWriter();
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetXAConnectionByUserAndPassword() throws SQLException {
-        DataSource dataSource = DataSourceUtils.build(DruidXADataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
+        DataSource dataSource = DataSourceUtils.build(HikariDataSource.class, DatabaseTypes.getActualDatabaseType("H2"), "ds1");
         SingleXADataSource shardingXADataSource = new SingleXADataSource(DatabaseTypes.getActualDatabaseType("H2"), "ds1", dataSource);
         shardingXADataSource.getXAConnection("root", "root");
     }


### PR DESCRIPTION
- remove druid & tomcat-dbcp2 dependencies
- use XADataSource to do unit test for SingleXADataSource