### PR TITLE
`getResultSet` should return null after `executeUpdate`

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
@@ -133,7 +133,19 @@ public final class ShardingPreparedStatement extends AbstractShardingPreparedSta
         for (Statement each : preparedStatementExecutor.getStatements()) {
             ResultSet resultSet = each.getResultSet();
             resultSets.add(resultSet);
-            queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
+            if (resultSet != null) {
+                queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
+            }
+        }
+        boolean allResultSetAreNull = true;
+        for (ResultSet resultSet: resultSets) {
+            if (resultSet != null) {
+                allResultSetAreNull = false;
+                break;
+            }
+        }
+        if (allResultSetAreNull) {
+            return null;
         }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {
             MergeEngine mergeEngine = MergeEngineFactory.newInstance(connection.getRuntimeContext().getDatabaseType(),

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
@@ -130,16 +130,14 @@ public final class ShardingPreparedStatement extends AbstractShardingPreparedSta
         }
         List<ResultSet> resultSets = new ArrayList<>(preparedStatementExecutor.getStatements().size());
         List<QueryResult> queryResults = new ArrayList<>(preparedStatementExecutor.getStatements().size());
-        boolean hasResultSets = false;
         for (Statement each : preparedStatementExecutor.getStatements()) {
             ResultSet resultSet = each.getResultSet();
             resultSets.add(resultSet);
             if (resultSet != null) {
                 queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
-                hasResultSets = true;
             }
         }
-        if (!hasResultSets) {
+        if (queryResults.isEmpty()) {
             return null;
         }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
@@ -137,9 +137,6 @@ public final class ShardingPreparedStatement extends AbstractShardingPreparedSta
                 queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
             }
         }
-        if (queryResults.isEmpty()) {
-            return null;
-        }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {
             MergeEngine mergeEngine = MergeEngineFactory.newInstance(connection.getRuntimeContext().getDatabaseType(),
                     connection.getRuntimeContext().getRule(), sqlRouteResult, connection.getRuntimeContext().getMetaData().getTables(), queryResults);

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatement.java
@@ -130,21 +130,16 @@ public final class ShardingPreparedStatement extends AbstractShardingPreparedSta
         }
         List<ResultSet> resultSets = new ArrayList<>(preparedStatementExecutor.getStatements().size());
         List<QueryResult> queryResults = new ArrayList<>(preparedStatementExecutor.getStatements().size());
+        boolean hasResultSets = false;
         for (Statement each : preparedStatementExecutor.getStatements()) {
             ResultSet resultSet = each.getResultSet();
             resultSets.add(resultSet);
             if (resultSet != null) {
                 queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
+                hasResultSets = true;
             }
         }
-        boolean allResultSetAreNull = true;
-        for (ResultSet resultSet: resultSets) {
-            if (resultSet != null) {
-                allResultSetAreNull = false;
-                break;
-            }
-        }
-        if (allResultSetAreNull) {
+        if (!hasResultSets) {
             return null;
         }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
@@ -110,16 +110,14 @@ public final class ShardingStatement extends AbstractStatementAdapter {
         }
         List<ResultSet> resultSets = new ArrayList<>(statementExecutor.getStatements().size());
         List<QueryResult> queryResults = new ArrayList<>(statementExecutor.getStatements().size());
-        boolean hasResultSets = false;
         for (Statement each : statementExecutor.getStatements()) {
             ResultSet resultSet = each.getResultSet();
             resultSets.add(resultSet);
             if (resultSet != null) {
                 queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
-                hasResultSets = true;
             }
         }
-        if (!hasResultSets) {
+        if (!queryResults.isEmpty()) {
             return null;
         }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
@@ -110,21 +110,16 @@ public final class ShardingStatement extends AbstractStatementAdapter {
         }
         List<ResultSet> resultSets = new ArrayList<>(statementExecutor.getStatements().size());
         List<QueryResult> queryResults = new ArrayList<>(statementExecutor.getStatements().size());
+        boolean hasResultSets = false;
         for (Statement each : statementExecutor.getStatements()) {
             ResultSet resultSet = each.getResultSet();
             resultSets.add(resultSet);
             if (resultSet != null) {
                 queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
+                hasResultSets = true;
             }
         }
-        boolean allResultSetAreNull = true;
-        for (ResultSet resultSet: resultSets) {
-            if (resultSet != null) {
-                allResultSetAreNull = false;
-                break;
-            }
-        }
-        if (allResultSetAreNull) {
+        if (!hasResultSets) {
             return null;
         }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
@@ -117,9 +117,6 @@ public final class ShardingStatement extends AbstractStatementAdapter {
                 queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
             }
         }
-        if (!queryResults.isEmpty()) {
-            return null;
-        }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {
             MergeEngine mergeEngine = MergeEngineFactory.newInstance(connection.getRuntimeContext().getDatabaseType(),
                     connection.getRuntimeContext().getRule(), sqlRouteResult, connection.getRuntimeContext().getMetaData().getTables(), queryResults);

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatement.java
@@ -113,7 +113,19 @@ public final class ShardingStatement extends AbstractStatementAdapter {
         for (Statement each : statementExecutor.getStatements()) {
             ResultSet resultSet = each.getResultSet();
             resultSets.add(resultSet);
-            queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
+            if (resultSet != null) {
+                queryResults.add(new StreamQueryResult(resultSet, connection.getRuntimeContext().getRule(), connection.getRuntimeContext().getProps(), sqlRouteResult.getSqlStatementContext()));
+            }
+        }
+        boolean allResultSetAreNull = true;
+        for (ResultSet resultSet: resultSets) {
+            if (resultSet != null) {
+                allResultSetAreNull = false;
+                break;
+            }
+        }
+        if (allResultSetAreNull) {
+            return null;
         }
         if (sqlRouteResult.getSqlStatementContext() instanceof SelectSQLStatementContext || sqlRouteResult.getSqlStatementContext().getSqlStatement() instanceof DALStatement) {
             MergeEngine mergeEngine = MergeEngineFactory.newInstance(connection.getRuntimeContext().getDatabaseType(),

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+
 
 public final class ShardingPreparedStatementTest extends AbstractShardingJDBCDatabaseAndTableTest {
     
@@ -203,7 +205,31 @@ public final class ShardingPreparedStatementTest extends AbstractShardingJDBCDat
             assertThat(result[2], is(4));
         }
     }
-    
+
+    @Test
+    public void assertExecuteGetResultSet() throws SQLException {
+        String sql = "UPDATE t_order SET status = ? WHERE user_id = ? AND order_id = ?";
+        try (PreparedStatement preparedStatement = getShardingDataSource().getConnection().prepareStatement(sql)) {
+            preparedStatement.setString(1, "OK");
+            preparedStatement.setInt(2, 11);
+            preparedStatement.setInt(3, 11);
+            preparedStatement.execute();
+            assertNull(preparedStatement.getResultSet());
+        }
+    }
+
+    @Test
+    public void assertExecuteUpdateGetResultSet() throws SQLException {
+        String sql = "UPDATE t_order SET status = ? WHERE user_id = ? AND order_id = ?";
+        try (PreparedStatement preparedStatement = getShardingDataSource().getConnection().prepareStatement(sql)) {
+            preparedStatement.setString(1, "OK");
+            preparedStatement.setInt(2, 11);
+            preparedStatement.setInt(3, 11);
+            preparedStatement.executeUpdate();
+            assertNull(preparedStatement.getResultSet());
+        }
+    }
+
     @Test
     public void assertClearBatch() throws SQLException {
         try (

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
@@ -29,9 +29,9 @@ import java.sql.Statement;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
 
 public final class ShardingPreparedStatementTest extends AbstractShardingJDBCDatabaseAndTableTest {
     

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingPreparedStatementTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
-
 public final class ShardingPreparedStatementTest extends AbstractShardingJDBCDatabaseAndTableTest {
     
     @Test

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatementTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 public final class ShardingStatementTest extends AbstractShardingJDBCDatabaseAndTableTest {
     
@@ -75,6 +76,24 @@ public final class ShardingStatementTest extends AbstractShardingJDBCDatabaseAnd
     public void assertQueryWithEmptyString() throws SQLException {
         try (Statement statement = getShardingDataSource().getConnection().createStatement()) {
             statement.executeQuery("");
+        }
+    }
+
+    @Test
+    public void assertExecuteGetResultSet() throws SQLException {
+        String sql = "UPDATE t_order_item SET status = '%s' WHERE user_id = %d AND order_id = %d";
+        try (Statement statement = getShardingDataSource().getConnection().createStatement()) {
+            assertFalse(statement.execute(String.format(sql, "OK", 1, 1)));
+            assertNull(statement.getResultSet());
+        }
+    }
+
+    @Test
+    public void assertExecuteUpdateGetResultSet() throws SQLException {
+        String sql = "UPDATE t_order_item SET status = '%s' WHERE user_id = %d AND order_id = %d";
+        try (Statement statement = getShardingDataSource().getConnection().createStatement()) {
+            statement.executeUpdate(String.format(sql, "OK", 1, 1));
+            assertNull(statement.getResultSet());
         }
     }
 }

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/ShardingStatementTest.java
@@ -27,9 +27,9 @@ import java.sql.Statement;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
 
 public final class ShardingStatementTest extends AbstractShardingJDBCDatabaseAndTableTest {
     


### PR DESCRIPTION
Fixes #3523.

According to the doc of  interface `Statement`, `Statement.getResultSet` should return `null` when `the result is an update count`.

```java

    /**
     *  Retrieves the current result as a <code>ResultSet</code> object.
     *  This method should be called only once per result.
     *
     * @return the current result as a <code>ResultSet</code> object or
     * <code>null</code> if the result is an update count or there are no more results
     * @exception SQLException if a database access error occurs or
     * this method is called on a closed <code>Statement</code>
     * @see #execute
     */
    ResultSet getResultSet() throws SQLException;

```