### PR TITLE
Move out taskId from configuration

### DIFF
--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/ShardingScalingJob.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/ShardingScalingJob.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shardingscaling.core;
+
+import lombok.Getter;
+import org.apache.shardingsphere.shardingscaling.core.config.SyncConfiguration;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Sharding scaling out job.
+ *
+ * @author yangyi
+ */
+@Getter
+public class ShardingScalingJob {
+    
+    private final String jobId = UUID.randomUUID().toString();
+    
+    private final List<SyncConfiguration> syncConfigurations = new LinkedList<>();
+}

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/ShardingScalingJob.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/ShardingScalingJob.java
@@ -33,7 +33,7 @@ import java.util.UUID;
  */
 @Getter
 @RequiredArgsConstructor
-public class ShardingScalingJob {
+public final class ShardingScalingJob {
     
     private final String jobId = UUID.randomUUID().toString();
     

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/ShardingScalingJob.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/ShardingScalingJob.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.shardingscaling.core;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import org.apache.shardingsphere.shardingscaling.core.config.SyncConfiguration;
 
 import java.util.LinkedList;
@@ -30,9 +32,12 @@ import java.util.UUID;
  * @author yangyi
  */
 @Getter
+@RequiredArgsConstructor
 public class ShardingScalingJob {
     
     private final String jobId = UUID.randomUUID().toString();
     
     private final List<SyncConfiguration> syncConfigurations = new LinkedList<>();
+    
+    private final String jobName;
 }

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/DataSourceConfiguration.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/DataSourceConfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.shardingscaling.core.config;
 
+import org.apache.shardingsphere.spi.database.DataSourceMetaData;
 import org.apache.shardingsphere.spi.database.DatabaseType;
 
 /**
@@ -32,4 +33,11 @@ public interface DataSourceConfiguration {
      * @return database type
      */
     DatabaseType getDatabaseType();
+    
+    /**
+     * Get datasource metadata.
+     *
+     * @return datasource metadata.
+     */
+    DataSourceMetaData getDataSourceMetaData();
 }

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/JdbcDataSourceConfiguration.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/JdbcDataSourceConfiguration.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.shardingscaling.core.config;
 
 import org.apache.shardingsphere.core.database.DatabaseTypes;
+import org.apache.shardingsphere.spi.database.DataSourceInfo;
+import org.apache.shardingsphere.spi.database.DataSourceMetaData;
 import org.apache.shardingsphere.spi.database.DatabaseType;
 
 import lombok.Data;
@@ -28,7 +30,7 @@ import lombok.Data;
  * @author avalon566
  */
 @Data
-public class JdbcDataSourceConfiguration implements DataSourceConfiguration {
+public final class JdbcDataSourceConfiguration implements DataSourceConfiguration {
 
     private String jdbcUrl;
 
@@ -43,5 +45,10 @@ public class JdbcDataSourceConfiguration implements DataSourceConfiguration {
         this.username = username;
         this.password = password;
         databaseType = DatabaseTypes.getDatabaseTypeByURL(jdbcUrl);
+    }
+    
+    @Override
+    public DataSourceMetaData getDataSourceMetaData() {
+        return databaseType.getDataSourceMetaData(new DataSourceInfo(jdbcUrl, username));
     }
 }

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/RdbmsConfiguration.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/RdbmsConfiguration.java
@@ -17,7 +17,9 @@
 
 package org.apache.shardingsphere.shardingscaling.core.config;
 
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.SneakyThrows;
 
 /**
@@ -25,7 +27,9 @@ import lombok.SneakyThrows;
  *
  * @author avalon566
  */
-@Data
+@Setter
+@Getter
+@EqualsAndHashCode
 public class RdbmsConfiguration implements Cloneable {
 
     private DataSourceConfiguration dataSourceConfiguration;
@@ -33,6 +37,8 @@ public class RdbmsConfiguration implements Cloneable {
     private String tableName;
 
     private String whereCondition;
+    
+    private int spiltNum;
     
     /**
      * Clone to new rdbms configuration.

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/SyncConfiguration.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/config/SyncConfiguration.java
@@ -17,22 +17,18 @@
 
 package org.apache.shardingsphere.shardingscaling.core.config;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.UUID;
 
 /**
  * Sync configuration.
  *
  * @author avalon566
  */
-@Data
+@Getter
 @RequiredArgsConstructor
 public class SyncConfiguration {
-
-    private final String taskId = UUID.randomUUID().toString();
-
+    
     /**
      * The concurrency of writers.
      */

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/execute/engine/SyncTaskExecuteCallback.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/execute/engine/SyncTaskExecuteCallback.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.shardingscaling.core.execute.engine;
 
-import org.apache.shardingsphere.shardingscaling.core.config.SyncConfiguration;
 import org.apache.shardingsphere.shardingscaling.core.controller.ReportCallback;
 import org.apache.shardingsphere.shardingscaling.core.execute.Event;
 import org.apache.shardingsphere.shardingscaling.core.execute.EventType;
@@ -36,19 +35,19 @@ public final class SyncTaskExecuteCallback implements ExecuteCallback {
     
     private final String syncTaskType;
     
-    private final SyncConfiguration syncConfiguration;
+    private final String syncTaskId;
     
     private final ReportCallback reportCallback;
     
     @Override
     public void onSuccess() {
-        log.info("{} {} execute finish", syncTaskType, syncConfiguration.getTaskId());
-        reportCallback.onProcess(new Event(syncConfiguration.getTaskId(), EventType.FINISHED));
+        log.info("{} {} execute finish", syncTaskType, syncTaskId);
+        reportCallback.onProcess(new Event(syncTaskId, EventType.FINISHED));
     }
     
     @Override
     public void onFailure(final Throwable throwable) {
-        log.error("{} {} execute exception exit", syncTaskType, syncConfiguration.getTaskId(), throwable);
-        reportCallback.onProcess(new Event(syncConfiguration.getTaskId(), EventType.EXCEPTION_EXIT));
+        log.error("{} {} execute exception exit", syncTaskType, syncTaskId, throwable);
+        reportCallback.onProcess(new Event(syncTaskId, EventType.EXCEPTION_EXIT));
     }
 }

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/execute/engine/SyncTaskExecuteCallback.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/execute/engine/SyncTaskExecuteCallback.java
@@ -42,13 +42,13 @@ public final class SyncTaskExecuteCallback implements ExecuteCallback {
     
     @Override
     public void onSuccess() {
-        log.info("{} for table {} execute finish", syncTaskType, syncConfiguration.getReaderConfiguration().getTableName());
+        log.info("{} {} execute finish", syncTaskType, syncConfiguration.getTaskId());
         reportCallback.onProcess(new Event(syncConfiguration.getTaskId(), EventType.FINISHED));
     }
     
     @Override
     public void onFailure(final Throwable throwable) {
-        log.error("{} for table {} execute exception exit", syncTaskType, syncConfiguration.getReaderConfiguration().getTableName(), throwable);
+        log.error("{} {} execute exception exit", syncTaskType, syncConfiguration.getTaskId(), throwable);
         reportCallback.onProcess(new Event(syncConfiguration.getTaskId(), EventType.EXCEPTION_EXIT));
     }
 }

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTask.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTask.java
@@ -66,7 +66,7 @@ public class HistoryDataSyncTask implements SyncTask {
     public final void start(final ReportCallback callback) {
         final Reader reader = ReaderFactory.newInstanceJdbcReader(syncConfiguration.getReaderConfiguration());
         final Writer writer = WriterFactory.newInstance(syncConfiguration.getWriterConfiguration());
-        ExecuteUtil.execute(new MemoryChannel(), reader, Collections.singletonList(writer), new SyncTaskExecuteCallback(this.getClass().getSimpleName(), syncConfiguration, callback));
+        ExecuteUtil.execute(new MemoryChannel(), reader, Collections.singletonList(writer), new SyncTaskExecuteCallback(this.getClass().getSimpleName(), syncTaskId, callback));
     }
 
     @Override

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTask.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTask.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.shardingscaling.core.synctask;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.shardingsphere.shardingscaling.core.config.RdbmsConfiguration;
 import org.apache.shardingsphere.shardingscaling.core.config.SyncConfiguration;
 import org.apache.shardingsphere.shardingscaling.core.controller.ReportCallback;
 import org.apache.shardingsphere.shardingscaling.core.controller.SyncProgress;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.shardingscaling.core.execute.executor.reader.Re
 import org.apache.shardingsphere.shardingscaling.core.execute.executor.reader.ReaderFactory;
 import org.apache.shardingsphere.shardingscaling.core.execute.executor.writer.Writer;
 import org.apache.shardingsphere.shardingscaling.core.execute.executor.writer.WriterFactory;
+import org.apache.shardingsphere.spi.database.DataSourceMetaData;
 
 import java.util.Collections;
 
@@ -41,11 +44,20 @@ import java.util.Collections;
 public class HistoryDataSyncTask implements SyncTask {
 
     private final SyncConfiguration syncConfiguration;
+    
+    private final String syncTaskId;
 
     public HistoryDataSyncTask(final SyncConfiguration syncConfiguration) {
         this.syncConfiguration = syncConfiguration;
+        syncTaskId = generateSyncTaskId(syncConfiguration.getReaderConfiguration());
     }
-
+    
+    private String generateSyncTaskId(final RdbmsConfiguration readerConfiguration) {
+        DataSourceMetaData dataSourceMetaData = readerConfiguration.getDataSourceConfiguration().getDataSourceMetaData();
+        String result = String.format("history-%s-%s", null != dataSourceMetaData.getCatalog() ? dataSourceMetaData.getCatalog() : dataSourceMetaData.getSchema(), readerConfiguration.getTableName());
+        return null == readerConfiguration.getWhereCondition() ? result : result + "#" + readerConfiguration.getSpiltNum();
+    }
+    
     @Override
     public void prepare() {
     }

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTaskGroup.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTaskGroup.java
@@ -131,6 +131,7 @@ public class HistoryDataSyncTaskGroup implements SyncTask {
                 } else {
                     splitReaderConfig.setWhereCondition(String.format("where id between %d and %d", min, max));
                 }
+                splitReaderConfig.setSpiltNum(i);
                 result.add(new SyncConfiguration(concurrency, splitReaderConfig, RdbmsConfiguration.clone(syncConfiguration.getWriterConfiguration())));
             }
         } catch (SQLException e) {

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTaskGroup.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/HistoryDataSyncTaskGroup.java
@@ -26,6 +26,8 @@ import org.apache.shardingsphere.shardingscaling.core.execute.EventType;
 import org.apache.shardingsphere.shardingscaling.core.metadata.ColumnMetaData;
 import org.apache.shardingsphere.shardingscaling.core.util.DataSourceFactory;
 import org.apache.shardingsphere.shardingscaling.core.util.DbMetaDataUtil;
+import org.apache.shardingsphere.spi.database.DataSourceMetaData;
+
 import lombok.extern.slf4j.Slf4j;
 
 import javax.sql.DataSource;
@@ -49,9 +51,13 @@ public class HistoryDataSyncTaskGroup implements SyncTask {
     private final SyncConfiguration syncConfiguration;
 
     private final List<SyncTask> syncTasks = new LinkedList<>();
+    
+    private final String syncTaskId;
 
     public HistoryDataSyncTaskGroup(final SyncConfiguration syncConfiguration) {
         this.syncConfiguration = syncConfiguration;
+        DataSourceMetaData dataSourceMetaData = syncConfiguration.getReaderConfiguration().getDataSourceConfiguration().getDataSourceMetaData();
+        syncTaskId = String.format("historyGroup-%s", null != dataSourceMetaData.getCatalog() ? dataSourceMetaData.getCatalog() : dataSourceMetaData.getSchema());
     }
 
     @Override
@@ -151,7 +157,7 @@ public class HistoryDataSyncTaskGroup implements SyncTask {
                     events.add(event);
                     if (syncTasks.size() == events.size()) {
                         //TODO check error
-                        callback.onProcess(new Event(syncConfiguration.getTaskId(), EventType.FINISHED));
+                        callback.onProcess(new Event(syncTaskId, EventType.FINISHED));
                     }
                 }
             });

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/RealtimeDataSyncTask.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/RealtimeDataSyncTask.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.shardingscaling.core.execute.executor.reader.Re
 import org.apache.shardingsphere.shardingscaling.core.execute.executor.record.Record;
 import org.apache.shardingsphere.shardingscaling.core.execute.executor.writer.Writer;
 import org.apache.shardingsphere.shardingscaling.core.execute.executor.writer.WriterFactory;
+import org.apache.shardingsphere.spi.database.DataSourceMetaData;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,6 +47,8 @@ import java.util.List;
 public final class RealtimeDataSyncTask implements SyncTask {
 
     private final SyncConfiguration syncConfiguration;
+    
+    private final String syncTaskId;
 
     private LogPositionManager logPositionManager;
 
@@ -53,6 +56,8 @@ public final class RealtimeDataSyncTask implements SyncTask {
     
     public RealtimeDataSyncTask(final SyncConfiguration syncConfiguration) {
         this.syncConfiguration = syncConfiguration;
+        DataSourceMetaData dataSourceMetaData = syncConfiguration.getReaderConfiguration().getDataSourceConfiguration().getDataSourceMetaData();
+        syncTaskId = String.format("realtime-%s", null != dataSourceMetaData.getCatalog() ? dataSourceMetaData.getCatalog() : dataSourceMetaData.getSchema());
     }
 
     @Override

--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/RealtimeDataSyncTask.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/synctask/RealtimeDataSyncTask.java
@@ -71,7 +71,7 @@ public final class RealtimeDataSyncTask implements SyncTask {
         reader = ReaderFactory.newInstanceLogReader(syncConfiguration.getReaderConfiguration(), logPositionManager.getCurrentPosition());
         List<Writer> writers = instanceWriters();
         RealtimeSyncChannel channel = instanceChannel(writers.size());
-        ExecuteUtil.execute(channel, reader, writers, new SyncTaskExecuteCallback(this.getClass().getSimpleName(), syncConfiguration, callback));
+        ExecuteUtil.execute(channel, reader, writers, new SyncTaskExecuteCallback(this.getClass().getSimpleName(), syncTaskId, callback));
     }
     
     private List<Writer> instanceWriters() {


### PR DESCRIPTION
For #3602 .

Changes proposed in this pull request:
- Move out taskId from configuration
- Use jobId replace taskId in ShardingScalingJob
- Use syncTaskId replace taskId in DataSyncTask
