### PR TITLE
 add Math.abs to avoid negative number

### DIFF
--- a/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/execute/executor/channel/RealtimeSyncChannel.java
+++ b/sharding-scaling/sharding-scaling-core/src/main/java/org/apache/shardingsphere/shardingscaling/core/execute/executor/channel/RealtimeSyncChannel.java
@@ -90,7 +90,7 @@ public class RealtimeSyncChannel implements Channel {
             }
             // hash by table name
             DataRecord dataRecord = (DataRecord) record;
-            String index = Integer.toString(dataRecord.getTableName().hashCode() % channelNumber);
+            String index = Integer.toString(Math.abs(dataRecord.getTableName().hashCode()) % channelNumber);
             channels.get(index).pushRecord(dataRecord);
         } else if (PlaceholderRecord.class.equals(record.getClass())) {
             if (0 < ackCallbacks.size()) {


### PR DESCRIPTION
Changes proposed in this pull request:
- hashCode maybe negative number,this will be made mistake when assign channel for `RealtimeSyncChannel`

