### PR TITLE
Refactor ColumnMetaData class, remove "notNull", "autoIncrement" fields. 

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/metadata/column/ColumnMetaData.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/metadata/column/ColumnMetaData.java
@@ -38,8 +38,4 @@ public class ColumnMetaData {
     private final String dataType;
     
     private final boolean primaryKey;
-
-    private final boolean notNull;
-
-    private final boolean autoIncrement;
 }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/metadata/column/EncryptColumnMetaData.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/metadata/column/EncryptColumnMetaData.java
@@ -37,9 +37,9 @@ public final class EncryptColumnMetaData extends ColumnMetaData {
     
     private final String assistedQueryColumnName;
     
-    public EncryptColumnMetaData(final String name, final String dataType, final boolean primaryKey, final boolean notNull, final boolean autoIncrement,
-                                 final String cipherColumnName, final String plainColumnName, final String assistedQueryColumnName) {
-        super(name, dataType, primaryKey, notNull, autoIncrement);
+    public EncryptColumnMetaData(final String name, final String dataType, final boolean primaryKey, final String cipherColumnName, 
+                                 final String plainColumnName, final String assistedQueryColumnName) {
+        super(name, dataType, primaryKey);
         this.cipherColumnName = cipherColumnName;
         this.plainColumnName = plainColumnName;
         this.assistedQueryColumnName = assistedQueryColumnName;

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/metadata/column/ShardingGeneratedKeyColumnMetaData.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/metadata/column/ShardingGeneratedKeyColumnMetaData.java
@@ -31,8 +31,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public final class ShardingGeneratedKeyColumnMetaData extends ColumnMetaData {
     
-    public ShardingGeneratedKeyColumnMetaData(final String name, final String dataType, final boolean primaryKey, 
-                                              final boolean notNull, final boolean autoIncrement) {
-        super(name, dataType, primaryKey, notNull, autoIncrement);
+    public ShardingGeneratedKeyColumnMetaData(final String name, final String dataType, final boolean primaryKey) {
+        super(name, dataType, primaryKey);
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/metadata/table/TableMetaDataTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/metadata/table/TableMetaDataTest.java
@@ -28,25 +28,13 @@ public final class TableMetaDataTest {
     
     @Test
     public void assertContainsIndex() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", true, true, true)), Collections.singleton("indexName"));
+        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", true)), Collections.singleton("indexName"));
         assertTrue(tableMetaData.containsIndex("indexName"));
     }
     
     @Test
     public void assertColumnPrimaryKey() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("id", "dataType", true, false, false)), Collections.<String>emptyList());
+        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("id", "dataType", true)), Collections.<String>emptyList());
         assertTrue(tableMetaData.getColumns().get("id").isPrimaryKey());
-    }
-    
-    @Test
-    public void assertColumnNotNull() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("id", "dataType", false, true, false)), Collections.<String>emptyList());
-        assertTrue(tableMetaData.getColumns().get("id").isNotNull());
-    }
-    
-    @Test
-    public void assertColumnAutoIncrement() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("id", "dataType", false, false, true)), Collections.<String>emptyList());
-        assertTrue(tableMetaData.getColumns().get("id").isAutoIncrement());
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/metadata/table/TableMetasTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/metadata/table/TableMetasTest.java
@@ -62,19 +62,19 @@ public final class TableMetasTest {
     
     @Test
     public void assertContainsColumn() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", false, false, false)), Collections.<String>emptyList());
+        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", false)), Collections.<String>emptyList());
         assertTrue(new TableMetas(ImmutableMap.of("tableMetaData", tableMetaData)).containsColumn("tableMetaData", "name"));
     }
     
     @Test
     public void assertGetAllColumnNamesWhenContainsKey() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", false, false, false)), Collections.<String>emptyList());
+        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", false)), Collections.<String>emptyList());
         assertThat(new TableMetas(ImmutableMap.of("tableMetaData", tableMetaData)).getAllColumnNames("tableMetaData"), is(Collections.singletonList("name")));
     }
     
     @Test
     public void assertGetAllColumnNamesWhenNotContainsKey() {
-        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", false, false, false)), Collections.<String>emptyList());
+        TableMetaData tableMetaData = new TableMetaData(Collections.singletonList(new ColumnMetaData("name", "dataType", false)), Collections.<String>emptyList());
         assertThat(new TableMetas(ImmutableMap.of("tableMetaData", tableMetaData)).getAllColumnNames("other_tableMetaData"), is(Collections.<String>emptyList()));
     }
     

--- a/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/metadata/TableMetaDataLoader.java
+++ b/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/metadata/TableMetaDataLoader.java
@@ -61,10 +61,6 @@ public final class TableMetaDataLoader {
     
     private static final String INDEX_NAME = "INDEX_NAME";
     
-    private static final String IS_NULLABLE = "IS_NULLABLE";
-    
-    private static final String IS_AUTOINCREMENT = "IS_AUTOINCREMENT";
-    
     private final DataSourceMetas dataSourceMetas;
     
     private final ShardingExecuteEngine executeEngine;
@@ -167,11 +163,8 @@ public final class TableMetaDataLoader {
                 String columnName = resultSet.getString(COLUMN_NAME);
                 String columnType = resultSet.getString(TYPE_NAME);
                 boolean isPrimaryKey = primaryKeys.contains(columnName);
-                boolean isNotNull = isPrimaryKey || !resultSet.getString(IS_NULLABLE).equalsIgnoreCase("YES");
-                String autoIncrement = resultSet.getString(IS_AUTOINCREMENT);
-                boolean isAutoIncrement = "YES".equalsIgnoreCase(autoIncrement);
                 Optional<ColumnMetaData> columnMetaData = getColumnMetaData(logicTableName, columnName, columnType, isPrimaryKey,
-                        isNotNull, isAutoIncrement, generateKeyColumnName, encryptRule, derivedColumns);
+                        generateKeyColumnName, encryptRule, derivedColumns);
                 if (columnMetaData.isPresent()) {
                     result.add(columnMetaData.get());
                 }
@@ -190,9 +183,8 @@ public final class TableMetaDataLoader {
         return result;
     }
     
-    private Optional<ColumnMetaData> getColumnMetaData(final String logicTableName, final String columnName, final String columnType, final boolean isPrimaryKey,
-            final boolean isNotNull, final boolean isAutoIncrement, final String generateKeyColumnName, 
-            final EncryptRule encryptRule, final Collection<String> derivedColumns) {
+    private Optional<ColumnMetaData> getColumnMetaData(final String logicTableName, final String columnName, final String columnType, final boolean isPrimaryKey, 
+                                                       final String generateKeyColumnName, final EncryptRule encryptRule, final Collection<String> derivedColumns) {
         if (derivedColumns.contains(columnName)) {
             return Optional.absent();
         }
@@ -200,12 +192,12 @@ public final class TableMetaDataLoader {
             String logicColumnName = encryptRule.getLogicColumn(logicTableName, columnName);
             String plainColumnName = encryptRule.findPlainColumn(logicTableName, logicColumnName).orNull();
             String assistedQueryColumnName = encryptRule.findAssistedQueryColumn(logicTableName, logicColumnName).orNull();
-            return Optional.<ColumnMetaData>of(new EncryptColumnMetaData(logicColumnName, columnType, isPrimaryKey, isNotNull, isAutoIncrement, columnName, plainColumnName, assistedQueryColumnName));
+            return Optional.<ColumnMetaData>of(new EncryptColumnMetaData(logicColumnName, columnType, isPrimaryKey, columnName, plainColumnName, assistedQueryColumnName));
         }
         if (columnName.equalsIgnoreCase(generateKeyColumnName)) {
-            return Optional.<ColumnMetaData>of(new ShardingGeneratedKeyColumnMetaData(columnName, columnType, isPrimaryKey, isNotNull, isAutoIncrement));
+            return Optional.<ColumnMetaData>of(new ShardingGeneratedKeyColumnMetaData(columnName, columnType, isPrimaryKey));
         }
-        return Optional.of(new ColumnMetaData(columnName, columnType, isPrimaryKey, isNotNull, isAutoIncrement));
+        return Optional.of(new ColumnMetaData(columnName, columnType, isPrimaryKey));
     }
     
     private Collection<String> getLogicIndexes(final Connection connection, final String catalog, final String schema, final String actualTableName) throws SQLException {

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/DatabaseTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/DatabaseTest.java
@@ -74,8 +74,8 @@ public final class DatabaseTest {
     }
 
     private ShardingSphereMetaData getMetaDataForAllRoutingSQL() {
-        ColumnMetaData idColumnMetaData = new ColumnMetaData("id", "int", true, true, true);
-        ColumnMetaData nameColumnMetaData = new ColumnMetaData("user_id", "int", false, false, false);
+        ColumnMetaData idColumnMetaData = new ColumnMetaData("id", "int", true);
+        ColumnMetaData nameColumnMetaData = new ColumnMetaData("user_id", "int", false);
         TableMetas tableMetas = mock(TableMetas.class);
         when(tableMetas.get("tesT")).thenReturn(new TableMetaData(Arrays.asList(idColumnMetaData, nameColumnMetaData), Arrays.asList("id", "user_id")));
         when(tableMetas.containsTable("tesT")).thenReturn(true);
@@ -101,8 +101,8 @@ public final class DatabaseTest {
     }
     
     private ShardingSphereMetaData getMetaDataForPagination() {
-        ColumnMetaData idColumnMetaData = new ColumnMetaData("id", "int", true, true, true);
-        ColumnMetaData nameColumnMetaData = new ColumnMetaData("user_id", "int", false, false, false);
+        ColumnMetaData idColumnMetaData = new ColumnMetaData("id", "int", true);
+        ColumnMetaData nameColumnMetaData = new ColumnMetaData("user_id", "int", false);
         TableMetas tableMetas = mock(TableMetas.class);
         when(tableMetas.get("tbl_pagination")).thenReturn(new TableMetaData(Arrays.asList(idColumnMetaData, nameColumnMetaData), Arrays.asList("id", "user_id")));
         when(tableMetas.containsTable("tbl_pagination")).thenReturn(true);

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/type/standard/AbstractSQLRouteTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/type/standard/AbstractSQLRouteTest.java
@@ -65,16 +65,16 @@ public abstract class AbstractSQLRouteTest extends AbstractRoutingEngineTest {
     
     private TableMetas buildTableMetas() {
         Map<String, TableMetaData> tableMetaDataMap = new HashMap<>(3, 1);
-        tableMetaDataMap.put("t_order", new TableMetaData(Arrays.asList(new ColumnMetaData("order_id", "int", true, true, true), 
-                new ColumnMetaData("user_id", "int", false, false, false), 
-                new ColumnMetaData("status", "int", false, false, false)), Collections.<String>emptySet()));
-        tableMetaDataMap.put("t_order_item", new TableMetaData(Arrays.asList(new ColumnMetaData("item_id", "int", true, true, true), 
-                new ColumnMetaData("order_id", "int", false, false, false),
-                new ColumnMetaData("user_id", "int", false, false, false), 
-                new ColumnMetaData("status", "varchar", false, false, false), 
-                new ColumnMetaData("c_date", "timestamp", false, false, false)), Collections.<String>emptySet()));
-        tableMetaDataMap.put("t_other", new TableMetaData(Collections.singletonList(new ColumnMetaData("order_id", "int", true, true, true)), Collections.<String>emptySet()));
-        tableMetaDataMap.put("t_category", new TableMetaData(Collections.singletonList(new ColumnMetaData("order_id", "int", true, true, true)), Collections.<String>emptySet()));
+        tableMetaDataMap.put("t_order", new TableMetaData(Arrays.asList(new ColumnMetaData("order_id", "int", true), 
+                new ColumnMetaData("user_id", "int", false), 
+                new ColumnMetaData("status", "int", false)), Collections.<String>emptySet()));
+        tableMetaDataMap.put("t_order_item", new TableMetaData(Arrays.asList(new ColumnMetaData("item_id", "int", true), 
+                new ColumnMetaData("order_id", "int", false),
+                new ColumnMetaData("user_id", "int", false), 
+                new ColumnMetaData("status", "varchar", false), 
+                new ColumnMetaData("c_date", "timestamp", false)), Collections.<String>emptySet()));
+        tableMetaDataMap.put("t_other", new TableMetaData(Collections.singletonList(new ColumnMetaData("order_id", "int", true)), Collections.<String>emptySet()));
+        tableMetaDataMap.put("t_category", new TableMetaData(Collections.singletonList(new ColumnMetaData("order_id", "int", true)), Collections.<String>emptySet()));
         return new TableMetas(tableMetaDataMap);
     }
 }

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/context/EncryptRuntimeContext.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/context/EncryptRuntimeContext.java
@@ -53,10 +53,6 @@ public final class EncryptRuntimeContext extends AbstractRuntimeContext<EncryptR
     
     private static final String INDEX_NAME = "INDEX_NAME";
 
-    private static final String IS_NULLABLE = "IS_NULLABLE";
-
-    private static final String IS_AUTOINCREMENT = "IS_AUTOINCREMENT";
-    
     private final TableMetas tableMetas;
     
     public EncryptRuntimeContext(final DataSource dataSource, final EncryptRule encryptRule, final Properties props, final DatabaseType databaseType) throws SQLException {
@@ -91,9 +87,7 @@ public final class EncryptRuntimeContext extends AbstractRuntimeContext<EncryptR
                 String columnName = resultSet.getString(COLUMN_NAME);
                 String columnType = resultSet.getString(TYPE_NAME);
                 boolean isPrimaryKey = primaryKeys.contains(columnName);
-                boolean isNotNull = isPrimaryKey || !resultSet.getBoolean(IS_NULLABLE);
-                boolean isAutoIncrement = resultSet.getBoolean(IS_AUTOINCREMENT);
-                Optional<ColumnMetaData> columnMetaData = getColumnMetaData(tableName, columnName, columnType, isPrimaryKey, isNotNull, isAutoIncrement, encryptRule, derivedColumns);
+                Optional<ColumnMetaData> columnMetaData = getColumnMetaData(tableName, columnName, columnType, isPrimaryKey, encryptRule, derivedColumns);
                 if (columnMetaData.isPresent()) {
                     result.add(columnMetaData.get());
                 }
@@ -103,7 +97,7 @@ public final class EncryptRuntimeContext extends AbstractRuntimeContext<EncryptR
     }
     
     private Optional<ColumnMetaData> getColumnMetaData(final String logicTableName, final String columnName, final String columnType, final boolean isPrimaryKey,
-                                                       final boolean isNotNull, final boolean isAutoIncrement, final EncryptRule encryptRule, final Collection<String> derivedColumns) {
+                                                       final EncryptRule encryptRule, final Collection<String> derivedColumns) {
         if (derivedColumns.contains(columnName)) {
             return Optional.absent();
         }
@@ -111,9 +105,9 @@ public final class EncryptRuntimeContext extends AbstractRuntimeContext<EncryptR
             String logicColumnName = encryptRule.getLogicColumn(logicTableName, columnName);
             String plainColumnName = encryptRule.findPlainColumn(logicTableName, logicColumnName).orNull();
             String assistedQueryColumnName = encryptRule.findAssistedQueryColumn(logicTableName, logicColumnName).orNull();
-            return Optional.<ColumnMetaData>of(new EncryptColumnMetaData(logicColumnName, columnType, isPrimaryKey, isNotNull, isAutoIncrement, columnName, plainColumnName, assistedQueryColumnName));
+            return Optional.<ColumnMetaData>of(new EncryptColumnMetaData(logicColumnName, columnType, isPrimaryKey, columnName, plainColumnName, assistedQueryColumnName));
         }
-        return Optional.of(new ColumnMetaData(columnName, columnType, isPrimaryKey, isNotNull, isAutoIncrement));
+        return Optional.of(new ColumnMetaData(columnName, columnType, isPrimaryKey));
     }
     
     private Collection<String> getPrimaryKeys(final Connection connection, final String tableName) throws SQLException {

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
@@ -65,20 +65,12 @@ public final class QueryHeader {
             if (logicSchema.getMetaData().getTables().containsTable(resultSetMetaData.getTableName(columnIndex))) {
                 this.primaryKey = logicSchema.getMetaData().getTables().get(resultSetMetaData.getTableName(columnIndex)).getColumns()
                         .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isPrimaryKey();
-                this.notNull = logicSchema.getMetaData().getTables().get(resultSetMetaData.getTableName(columnIndex)).getColumns()
-                        .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isNotNull();
-                this.autoIncrement = logicSchema.getMetaData().getTables().get(resultSetMetaData.getTableName(columnIndex)).getColumns()
-                        .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isAutoIncrement();
             } else {
                 this.primaryKey = false;
-                this.notNull = false;
-                this.autoIncrement = false;
             }
         } else {
             this.table = resultSetMetaData.getTableName(columnIndex);
             this.primaryKey = false;
-            this.notNull = false;
-            this.autoIncrement = false;
         }
         this.columnLabel = resultSetMetaData.getColumnLabel(columnIndex);
         this.columnName = resultSetMetaData.getColumnName(columnIndex);
@@ -86,6 +78,8 @@ public final class QueryHeader {
         this.columnType = resultSetMetaData.getColumnType(columnIndex);
         this.decimals = resultSetMetaData.getScale(columnIndex);
         this.signed = resultSetMetaData.isSigned(columnIndex);
+        this.notNull = resultSetMetaData.isNullable(columnIndex) == ResultSetMetaData.columnNoNulls;
+        this.autoIncrement = resultSetMetaData.isAutoIncrement(columnIndex);
     }
     
     /**

--- a/sharding-proxy/sharding-proxy-backend/src/test/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeaderTest.java
+++ b/sharding-proxy/sharding-proxy-backend/src/test/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeaderTest.java
@@ -109,7 +109,7 @@ public final class QueryHeaderTest {
     @SneakyThrows
     private ShardingSchema getShardingSchema() {
         ShardingSchema result = mock(ShardingSchema.class);
-        ColumnMetaData columnMetaData = new ColumnMetaData("order_id", "int", true, true, true);
+        ColumnMetaData columnMetaData = new ColumnMetaData("order_id", "int", true);
         TableMetas tableMetas = mock(TableMetas.class);
         when(tableMetas.get("t_order")).thenReturn(new TableMetaData(Collections.singletonList(columnMetaData), Collections.singletonList("order_id")));
         when(tableMetas.containsTable("t_order")).thenReturn(true);
@@ -134,6 +134,8 @@ public final class QueryHeaderTest {
         when(result.getColumnName(1)).thenReturn("order_id");
         when(result.getColumnType(1)).thenReturn(Types.INTEGER);
         when(result.isSigned(1)).thenReturn(true);
+        when(result.isAutoIncrement(1)).thenReturn(true);
+        when(result.isNullable(1)).thenReturn(ResultSetMetaData.columnNoNulls);
         when(result.getColumnDisplaySize(1)).thenReturn(1);
         when(result.getScale(1)).thenReturn(1);
         return result;


### PR DESCRIPTION
Fixes #3701 .

Changes proposed in this pull request:
- Refactor `ColumnMetaData`, `EncryptColumnMetaData`, `ShardingGeneratedKeyColumnMetaData` classes, remove "notNull", "autoIncrement" fields.
- Refactor `TableMetaDataLoader` and `EncryptRuntimeContext` classes, remove load "notNull", "autoIncrement" info.
- Refactor QueryHeader, get `notNull` and `autoIncrement` info by ResultSetMetaData.
- Fix unit test.
