### PR TITLE
Statement function strtodate

### DIFF
--- a/sharding-sql-test/src/main/java/org/apache/shardingsphere/test/sql/loader/SQLCasesLoader.java
+++ b/sharding-sql-test/src/main/java/org/apache/shardingsphere/test/sql/loader/SQLCasesLoader.java
@@ -152,7 +152,8 @@ public final class SQLCasesLoader {
         if (null == parameters || parameters.isEmpty()) {
             return sql;
         }
-        return String.format(sql.replace("?", "%s"), parameters.toArray()).replace("%%", "%").replace("'%'", "'%%'");
+        return String.format(sql.replace("%", "$").replace("?", "%s"), parameters.toArray()).replace("$", "%")
+                .replace("%%", "%").replace("'%'", "'%%'");
     }
     
     /**

--- a/sharding-sql-test/src/main/resources/sql/sharding/dml/insert.xml
+++ b/sharding-sql-test/src/main/resources/sql/sharding/dml/insert.xml
@@ -51,4 +51,5 @@
     <sql-case id="insert_with_function" value="INSERT INTO t_order(current_date, order_id, user_id) VALUES (curdate(), ?, ?)" db-types="MySQL" />
     <sql-case id="insert_with_unix_timestamp_function" value="INSERT INTO t_order(status, order_id, user_id) VALUES (unix_timestamp(?), ?, ?)" db-types="MySQL" />
     <sql-case id="insert_with_aggregation_function_column_name" value="INSERT INTO t_order (order_id, user_id, count) VALUES (?, ?, ?)" db-types="SQLServer"  />
+    <sql-case id="insert_with_str_to_date" value="INSERT INTO t_order(current_date, order_id, user_id) VALUES (?, ?, ?)" db-types="MySQL" />
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -439,7 +439,7 @@ regularFunction_
 
 regularFunctionName_
     : identifier_ | IF | CURRENT_TIMESTAMP | LOCALTIME | LOCALTIMESTAMP | NOW | REPLACE | INTERVAL | SUBSTRING | LEFT | RIGHT
-    | LOWER | UNIX_TIMESTAMP | UPPER | DATABASE
+    | LOWER | UNIX_TIMESTAMP | UPPER | DATABASE | STR_TO_DATE
     ;
 
 matchExpression_

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
@@ -1515,3 +1515,7 @@ LOWER
 UPPER
     : U P P E R
     ;
+
+STR_TO_DATE
+    : S T R UL_ T O UL_ D A T E
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sharding/dml/insert.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sharding/dml/insert.xml
@@ -731,4 +731,26 @@
             </and-condition>
         </sharding-conditions>
     </parser-result>
+
+    <parser-result sql-case-id="insert_with_str_to_date" parameters="2019-12-10, 1, 1">
+        <tables>
+            <table name="t_order" />
+        </tables>
+        <tokens>
+            <table-token start-index="12" table-name="t_order" length="7" />
+        </tokens>
+        <sharding-conditions>
+            <and-condition>
+                <condition column-name="current_date" table-name="t_order" operator="EQUAL">
+                    <value index="0" literal="2019-12-10" type="varchar" />
+                </condition>
+                <condition column-name="order_id" table-name="t_order" operator="EQUAL">
+                    <value index="1" literal="1" type="int" />
+                </condition>
+                <condition column-name="user_id" table-name="t_order" operator="EQUAL">
+                    <value index="2" literal="1" type="int" />
+                </condition>
+            </and-condition>
+        </sharding-conditions>
+    </parser-result>
 </parser-result-sets>


### PR DESCRIPTION
Fixes #3716.

DMLStatement and DQLStatement doesn't support `STR_TO_DATE` function. InsertStatement couldn't parse parameter of `STR_TO_DATE` function correctly.

Changes proposed in this pull request:
- Support `STR_TO_DATE` function in DMLStatement and DQLStatement.
- Modify method `getLiteralSQL` of `SQLCasesLoader` to support SQL which includes '%' character.
