### PR TITLE
Fix encryption rules do not support uppercase fileds

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -134,7 +134,7 @@ public final class EncryptRule implements BaseRule {
      * @return plain column
      */
     public Optional<String> findPlainColumn(final String logicTable, final String logicColumn) {
-        return tables.containsKey(logicTable) ?  tables.get(logicTable).findPlainColumn(getOriginColumnName(logicTable, logicColumn)) : Optional.<String>absent();
+        return tables.containsKey(logicTable) ? tables.get(logicTable).findPlainColumn(getOriginColumnName(logicTable, logicColumn)) : Optional.<String>absent();
     }
 
     private String getOriginColumnName(final String logicTable, final String logicColumn){

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -132,11 +132,11 @@ public final class EncryptRule implements BaseRule {
      * @return plain column
      */
     public Optional<String> findPlainColumn(final String logicTable, final String logicColumn) {
-        Optional<String> originColumnName = getOriginColumnName(logicTable, logicColumn);
-        return tables.containsKey(logicTable) && originColumnName.isPresent() ? tables.get(logicTable).findPlainColumn(originColumnName.get()) : Optional.<String>absent();
+        Optional<String> originColumnName = findOriginColumnName(logicTable, logicColumn);
+        return originColumnName.isPresent() && tables.containsKey(logicTable) ? tables.get(logicTable).findPlainColumn(originColumnName.get()) : Optional.<String>absent();
     }
 
-    private Optional<String> getOriginColumnName(final String logicTable, final String logicColumn) {
+    private Optional<String> findOriginColumnName(final String logicTable, final String logicColumn) {
         for (String each : tables.get(logicTable).getLogicColumns()) {
             if (logicColumn.equalsIgnoreCase(each)) {
                 return Optional.of(each);

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -39,11 +39,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * Encrypt rule.
  *
  * @author panjuan
+ * @since 1.8
  */
 public final class EncryptRule implements BaseRule {
     
@@ -132,7 +134,11 @@ public final class EncryptRule implements BaseRule {
      * @return plain column
      */
     public Optional<String> findPlainColumn(final String logicTable, final String logicColumn) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).findPlainColumn(logicColumn) : Optional.<String>absent();
+        return tables.containsKey(logicTable) ?  tables.get(logicTable).findPlainColumn(getOriginColumnName(logicTable, logicColumn)) : Optional.<String>absent();
+    }
+
+    private String getOriginColumnName(final String logicTable, final String logicColumn){
+        return tables.get(logicTable).getPlainColumns().stream().collect(Collectors.toMap(String::toLowerCase, it->it)).get(logicColumn.toLowerCase());
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -132,16 +132,17 @@ public final class EncryptRule implements BaseRule {
      * @return plain column
      */
     public Optional<String> findPlainColumn(final String logicTable, final String logicColumn) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).findPlainColumn(getOriginColumnName(logicTable, logicColumn)) : Optional.<String>absent();
+        Optional<String> originColumnName = getOriginColumnName(logicTable, logicColumn);
+        return tables.containsKey(logicTable) && originColumnName.isPresent() ? tables.get(logicTable).findPlainColumn(originColumnName.get()) : Optional.<String>absent();
     }
 
-    private String getOriginColumnName(final String logicTable, final String logicColumn) {
+    private Optional<String> getOriginColumnName(final String logicTable, final String logicColumn) {
         for (String each : tables.get(logicTable).getLogicColumns()) {
             if (logicColumn.equalsIgnoreCase(each)) {
-                return each;
+                return Optional.of(each);
             }
         }
-        return logicColumn;
+        return Optional.absent();
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -135,10 +135,10 @@ public final class EncryptRule implements BaseRule {
         return tables.containsKey(logicTable) ? tables.get(logicTable).findPlainColumn(getOriginColumnName(logicTable, logicColumn)) : Optional.<String>absent();
     }
 
-    private String getOriginColumnName(final String logicTable, final String logicColumn){
+    private String getOriginColumnName(final String logicTable, final String logicColumn) {
         String result = logicColumn;
         for (String each : tables.get(logicTable).getLogicColumns()) {
-            if (logicColumn.equals(each.toLowerCase())){
+            if (logicColumn.equals(each.toLowerCase())) {
                 result = each;
                 break;
             }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -136,14 +136,12 @@ public final class EncryptRule implements BaseRule {
     }
 
     private String getOriginColumnName(final String logicTable, final String logicColumn) {
-        String result = logicColumn;
         for (String each : tables.get(logicTable).getLogicColumns()) {
-            if (logicColumn.equals(each.toLowerCase())) {
-                result = each;
-                break;
+            if (logicColumn.equalsIgnoreCase(each)) {
+                return each;
             }
         }
-        return result;
+        return logicColumn;
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/EncryptRule.java
@@ -39,13 +39,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 /**
  * Encrypt rule.
  *
  * @author panjuan
- * @since 1.8
  */
 public final class EncryptRule implements BaseRule {
     
@@ -138,7 +136,14 @@ public final class EncryptRule implements BaseRule {
     }
 
     private String getOriginColumnName(final String logicTable, final String logicColumn){
-        return tables.get(logicTable).getPlainColumns().stream().collect(Collectors.toMap(String::toLowerCase, it->it)).get(logicColumn.toLowerCase());
+        String result = logicColumn;
+        for (String each : tables.get(logicTable).getLogicColumns()) {
+            if (logicColumn.equals(each.toLowerCase())){
+                result = each;
+                break;
+            }
+        }
+        return result;
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -153,19 +153,17 @@ public final class EncryptTable {
      * @return optional of sharding encryptor
      */
     public Optional<String> findShardingEncryptor(final String logicColumn) {
-        final String originLogicColumnName = getOriginLogicColumnName(logicColumn);
-        return columns.containsKey(originLogicColumnName) ? Optional.of(columns.get(originLogicColumnName).getEncryptor()) : Optional.<String>absent();
+        String originLogicColumnName = getOriginLogicColumnName(logicColumn);
+        return columns.containsKey(originLogicColumnName) ? Optional.of(columns.get(getOriginLogicColumnName(logicColumn)).getEncryptor()) : Optional.<String>absent();
     }
 
     private String getOriginLogicColumnName(final String logicColumn) {
-        String result = logicColumn;
         for (String each : columns.keySet()) {
-            if (logicColumn.equals(each.toLowerCase())) {
-                result = each;
-                break;
+            if (logicColumn.equalsIgnoreCase(each)) {
+                return each;
             }
         }
-        return result;
+        return logicColumn;
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -29,7 +29,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 /**
  * Encryptor table.
@@ -160,7 +159,14 @@ public final class EncryptTable {
     }
 
     private String getOriginLogicColumnName(final String logicColumn){
-        return columns.keySet().stream().collect(Collectors.toMap(String::toLowerCase, it->it)).get(logicColumn.toLowerCase());
+        String result = logicColumn;
+        for (String each : columns.keySet()) {
+            if (logicColumn.equals(each.toLowerCase())){
+                result = each;
+                break;
+            }
+        }
+        return result;
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -157,10 +157,10 @@ public final class EncryptTable {
         return columns.containsKey(originLogicColumnName) ? Optional.of(columns.get(originLogicColumnName).getEncryptor()) : Optional.<String>absent();
     }
 
-    private String getOriginLogicColumnName(final String logicColumn){
+    private String getOriginLogicColumnName(final String logicColumn) {
         String result = logicColumn;
         for (String each : columns.keySet()) {
-            if (logicColumn.equals(each.toLowerCase())){
+            if (logicColumn.equals(each.toLowerCase())) {
                 result = each;
                 break;
             }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -34,7 +34,6 @@ import java.util.Map.Entry;
  * Encryptor table.
  *
  * @author panjuan
- * @since 1.8
  */
 public final class EncryptTable {
     

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -29,11 +29,13 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * Encryptor table.
  *
  * @author panjuan
+ * @since 1.8
  */
 public final class EncryptTable {
     
@@ -153,7 +155,12 @@ public final class EncryptTable {
      * @return optional of sharding encryptor
      */
     public Optional<String> findShardingEncryptor(final String logicColumn) {
-        return columns.containsKey(logicColumn) ? Optional.of(columns.get(logicColumn).getEncryptor()) : Optional.<String>absent();
+        final String originLogicColumnName = getOriginLogicColumnName(logicColumn);
+        return columns.containsKey(originLogicColumnName) ? Optional.of(columns.get(originLogicColumnName).getEncryptor()) : Optional.<String>absent();
+    }
+
+    private String getOriginLogicColumnName(final String logicColumn){
+        return columns.keySet().stream().collect(Collectors.toMap(String::toLowerCase, it->it)).get(logicColumn.toLowerCase());
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -153,17 +153,17 @@ public final class EncryptTable {
      * @return optional of sharding encryptor
      */
     public Optional<String> findShardingEncryptor(final String logicColumn) {
-        String originLogicColumnName = getOriginLogicColumnName(logicColumn);
-        return columns.containsKey(originLogicColumnName) ? Optional.of(columns.get(getOriginLogicColumnName(logicColumn)).getEncryptor()) : Optional.<String>absent();
+        Optional<String> originLogicColumnName = getOriginLogicColumnName(logicColumn);
+        return originLogicColumnName.isPresent() && columns.containsKey(originLogicColumnName.get()) ? Optional.of(columns.get(originLogicColumnName.get()).getEncryptor()) : Optional.<String>absent();
     }
 
-    private String getOriginLogicColumnName(final String logicColumn) {
+    private Optional<String> getOriginLogicColumnName(final String logicColumn) {
         for (String each : columns.keySet()) {
             if (logicColumn.equalsIgnoreCase(each)) {
-                return each;
+                return Optional.of(each);
             }
         }
-        return logicColumn;
+        return Optional.absent();
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/encrypt/EncryptTable.java
@@ -153,11 +153,11 @@ public final class EncryptTable {
      * @return optional of sharding encryptor
      */
     public Optional<String> findShardingEncryptor(final String logicColumn) {
-        Optional<String> originLogicColumnName = getOriginLogicColumnName(logicColumn);
+        Optional<String> originLogicColumnName = findOriginLogicColumnName(logicColumn);
         return originLogicColumnName.isPresent() && columns.containsKey(originLogicColumnName.get()) ? Optional.of(columns.get(originLogicColumnName.get()).getEncryptor()) : Optional.<String>absent();
     }
 
-    private Optional<String> getOriginLogicColumnName(final String logicColumn) {
+    private Optional<String> findOriginLogicColumnName(final String logicColumn) {
         for (String each : columns.keySet()) {
             if (logicColumn.equalsIgnoreCase(each)) {
                 return Optional.of(each);

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/EncryptRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/EncryptRuleTest.java
@@ -24,7 +24,11 @@ import org.apache.shardingsphere.api.config.encrypt.EncryptorRuleConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -45,12 +49,12 @@ public final class EncryptRuleTest {
     @Before
     public void setUp() {
         Properties props = new Properties();
-        EncryptorRuleConfiguration encryptorConfig = new EncryptorRuleConfiguration("assistedTest", props);
         EncryptColumnRuleConfiguration columnConfig = new EncryptColumnRuleConfiguration("plain_pwd", "cipher_pwd", "", "aes");
         EncryptColumnRuleConfiguration idNumberConfig = new EncryptColumnRuleConfiguration("plain_id_number", "cipher_id_number", "", "aes");
         Map<String, EncryptColumnRuleConfiguration> ruleConfigurationMap = new HashMap<>();
         ruleConfigurationMap.put(column, columnConfig);
         ruleConfigurationMap.put(idNumber, idNumberConfig);
+        EncryptorRuleConfiguration encryptorConfig = new EncryptorRuleConfiguration("assistedTest", props);
         EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration(ruleConfigurationMap);
         encryptRuleConfig = new EncryptRuleConfiguration();
         encryptRuleConfig.getEncryptors().put("aes", encryptorConfig);

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/EncryptRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/EncryptRuleTest.java
@@ -24,9 +24,7 @@ import org.apache.shardingsphere.api.config.encrypt.EncryptorRuleConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -39,7 +37,9 @@ public final class EncryptRuleTest {
     private final String table = "table";
     
     private final String column = "column";
-    
+
+    private final String idNumber = "idNumber";
+
     private EncryptRuleConfiguration encryptRuleConfig;
     
     @Before
@@ -47,7 +47,11 @@ public final class EncryptRuleTest {
         Properties props = new Properties();
         EncryptorRuleConfiguration encryptorConfig = new EncryptorRuleConfiguration("assistedTest", props);
         EncryptColumnRuleConfiguration columnConfig = new EncryptColumnRuleConfiguration("plain_pwd", "cipher_pwd", "", "aes");
-        EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration(Collections.singletonMap(column, columnConfig));
+        EncryptColumnRuleConfiguration idNumberConfig = new EncryptColumnRuleConfiguration("plain_id_number", "cipher_id_number", "", "aes");
+        Map<String, EncryptColumnRuleConfiguration> ruleConfigurationMap = new HashMap<>();
+        ruleConfigurationMap.put(column, columnConfig);
+        ruleConfigurationMap.put(idNumber, idNumberConfig);
+        EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration(ruleConfigurationMap);
         encryptRuleConfig = new EncryptRuleConfiguration();
         encryptRuleConfig.getEncryptors().put("aes", encryptorConfig);
         encryptRuleConfig.getTables().put(table, tableConfig);
@@ -82,6 +86,7 @@ public final class EncryptRuleTest {
     @Test
     public void assertFindPlainColumn() {
         assertTrue(new EncryptRule(encryptRuleConfig).findPlainColumn(table, column).isPresent());
+        assertTrue(new EncryptRule(encryptRuleConfig).findPlainColumn(table, idNumber.toLowerCase()).isPresent());
     }
     
     @Test(expected = NullPointerException.class)

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/EncryptRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/EncryptRuleTest.java
@@ -91,6 +91,7 @@ public final class EncryptRuleTest {
     public void assertFindPlainColumn() {
         assertTrue(new EncryptRule(encryptRuleConfig).findPlainColumn(table, column).isPresent());
         assertTrue(new EncryptRule(encryptRuleConfig).findPlainColumn(table, idNumber.toLowerCase()).isPresent());
+        assertFalse(new EncryptRule(encryptRuleConfig).findPlainColumn(table, "notExistLogicColumn").isPresent());
     }
     
     @Test(expected = NullPointerException.class)

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/encrypt/impl/EncryptTableTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/encrypt/impl/EncryptTableTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,5 +75,10 @@ public final class EncryptTableTest {
     @Test
     public void assertGetLogicAndPlainColumns() {
         assertFalse(encryptTable.getLogicAndPlainColumns().isEmpty());
+    }
+
+    @Test
+    public void assertGetShardingEncryptor(){
+        assertTrue(encryptTable.findShardingEncryptor("key").isPresent());
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/encrypt/impl/EncryptTableTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/encrypt/impl/EncryptTableTest.java
@@ -80,5 +80,6 @@ public final class EncryptTableTest {
     @Test
     public void assertGetShardingEncryptor() {
         assertTrue(encryptTable.findShardingEncryptor("key").isPresent());
+        assertFalse(encryptTable.findShardingEncryptor("notExistLogicColumn").isPresent());
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/encrypt/impl/EncryptTableTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/encrypt/impl/EncryptTableTest.java
@@ -78,7 +78,7 @@ public final class EncryptTableTest {
     }
 
     @Test
-    public void assertGetShardingEncryptor(){
+    public void assertGetShardingEncryptor() {
         assertTrue(encryptTable.findShardingEncryptor("key").isPresent());
     }
 }


### PR DESCRIPTION
Fixes #3309 
Method rewrite of class EncryptInsertValueParameterRewriter get encryptor by logic column, which is got from SQLStatementContext and formated to lower case by orm frame(like mybatis) . So if encryption rule use upper case logic column, the rewrite method can not get encryptor by it. And then Encrypt-JDBC fail to rewrite the SQL.

Changes proposed in this pull request:
The method findPlainColumn and findShardingEncryptor use the lower case logic column as parameter, and  if the encryption rule  use upper case logic column, it  cause the problem. 