### PR TITLE
fix XA of sharding-jdbc could not compatible with postgresql

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/connection/ShardingConnection.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/connection/ShardingConnection.java
@@ -142,7 +142,6 @@ public final class ShardingConnection extends AbstractConnectionAdapter {
             return;
         }
         if (!autoCommit && !shardingTransactionManager.isInTransaction()) {
-            recordMethodInvocation(Connection.class, "setAutoCommit", new Class[]{boolean.class}, new Object[]{true});
             closeCachedConnections();
             shardingTransactionManager.begin();
         }


### PR DESCRIPTION
JDBC driver of PostgreSQL will `set autoCommit=false` after starting XA transaction, this replay operation will lead PGConnectoin start a commit internal.

 so we should move the replay to ShardingTransactionMananger internal, Seata and Atomikos have supported well. SagaBaseTransactionMananger also need to change the connection configuration by itselef later.