### PR TITLE
Upgrade antlr version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <guava.version>18.0</guava.version>
         <slf4j.version>1.7.7</slf4j.version>
         
-        <antlr4.version>4.7.1</antlr4.version>
+        <antlr4.version>4.7.2</antlr4.version>
         
         <groovy.version>2.4.5</groovy.version>
         <snakeyaml.version>1.16</snakeyaml.version>


### PR DESCRIPTION
Latest version of Antlr4 maven repository is [4.7.2](https://mvnrepository.com/artifact/org.antlr/antlr4-runtime/4.7.2), and to follow the latest version.

Changes proposed in this pull request:
- Update the version of Antlr4 maven repository to 4.7.2
