### PR TITLE
fix proxy hang up while throwing a customize SQLException

### DIFF
--- a/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactory.java
+++ b/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactory.java
@@ -48,7 +48,7 @@ public final class MySQLErrPacketFactory {
     public static MySQLErrPacket newInstance(final int sequenceId, final Exception cause) {
         if (cause instanceof SQLException) {
             SQLException sqlException = (SQLException) cause;
-            return new MySQLErrPacket(sequenceId, sqlException.getErrorCode(), sqlException.getSQLState() != null ? sqlException.getSQLState() : "", sqlException.getMessage());
+            return new MySQLErrPacket(sequenceId, sqlException.getErrorCode(), null != sqlException.getSQLState() ? sqlException.getSQLState() : "", sqlException.getMessage());
         }
         if (cause instanceof ShardingCTLException) {
             ShardingCTLException shardingCTLException = (ShardingCTLException) cause;

--- a/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactory.java
+++ b/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactory.java
@@ -48,7 +48,7 @@ public final class MySQLErrPacketFactory {
     public static MySQLErrPacket newInstance(final int sequenceId, final Exception cause) {
         if (cause instanceof SQLException) {
             SQLException sqlException = (SQLException) cause;
-            return new MySQLErrPacket(sequenceId, sqlException.getErrorCode(), sqlException.getSQLState(), sqlException.getMessage());
+            return new MySQLErrPacket(sequenceId, sqlException.getErrorCode(), sqlException.getSQLState() != null ? sqlException.getSQLState() : "", sqlException.getMessage());
         }
         if (cause instanceof ShardingCTLException) {
             ShardingCTLException shardingCTLException = (ShardingCTLException) cause;

--- a/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactory.java
+++ b/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactory.java
@@ -48,7 +48,8 @@ public final class MySQLErrPacketFactory {
     public static MySQLErrPacket newInstance(final int sequenceId, final Exception cause) {
         if (cause instanceof SQLException) {
             SQLException sqlException = (SQLException) cause;
-            return new MySQLErrPacket(sequenceId, sqlException.getErrorCode(), null != sqlException.getSQLState() ? sqlException.getSQLState() : "", sqlException.getMessage());
+            return null != sqlException.getSQLState() ? new MySQLErrPacket(sequenceId, sqlException.getErrorCode(), sqlException.getSQLState(), sqlException.getMessage())
+                : new MySQLErrPacket(sequenceId, MySQLServerErrorCode.ER_INTERNAL_ERROR, sqlException.getCause().getMessage());
         }
         if (cause instanceof ShardingCTLException) {
             ShardingCTLException shardingCTLException = (ShardingCTLException) cause;

--- a/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -45,9 +45,9 @@ public final class MySQLErrPacketFactoryTest {
     public void assertNewInstanceWithSQLExceptionOfNullSqlState() {
         MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new SQLException(new RuntimeException("No reason")));
         assertThat(actual.getSequenceId(), is(1));
-        assertThat(actual.getErrorCode(), is(0));
-        assertThat(actual.getSqlState(), is(""));
-        assertThat(actual.getErrorMessage(), is("java.lang.RuntimeException: No reason"));
+        assertThat(actual.getErrorCode(), is(1815));
+        assertThat(actual.getSqlState(), is("HY000"));
+        assertThat(actual.getErrorMessage(), is("Internal error: No reason"));
     }
     
     @Test

--- a/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/sharding-proxy/sharding-proxy-frontend/sharding-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/shardingproxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -42,6 +42,15 @@ public final class MySQLErrPacketFactoryTest {
     }
     
     @Test
+    public void assertNewInstanceWithSQLExceptionOfNullSqlState() {
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new SQLException(new RuntimeException("No reason")));
+        assertThat(actual.getSequenceId(), is(1));
+        assertThat(actual.getErrorCode(), is(0));
+        assertThat(actual.getSqlState(), is(""));
+        assertThat(actual.getErrorMessage(), is("java.lang.RuntimeException: No reason"));
+    }
+    
+    @Test
     public void assertNewInstanceWithInvalidShardingCTLFormatException() {
         MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new InvalidShardingCTLFormatException("test"));
         assertThat(actual.getSequenceId(), is(1));

--- a/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/mysql/constant/MySQLServerErrorCode.java
+++ b/sharding-proxy/sharding-proxy-transport/sharding-proxy-transport-mysql/src/main/java/org/apache/shardingsphere/shardingproxy/transport/mysql/constant/MySQLServerErrorCode.java
@@ -40,6 +40,8 @@ public enum MySQLServerErrorCode implements SQLErrorCode {
     
     ER_BAD_DB_ERROR(1049, "42000", "Unknown database '%s'"),
     
+    ER_INTERNAL_ERROR(1815, "HY000", "Internal error: %s"),
+    
     ER_ERROR_ON_MODIFYING_GTID_EXECUTED_TABLE(3176, "HY000", 
             "Please do not modify the %s table with an XA transaction. This is an internal system table used to store GTIDs for committed transactions. " 
                     + "Although modifying it can lead to an inconsistent GTID state, if neccessary you can modify it with a non-XA transaction.");


### PR DESCRIPTION
After proxy throw a customize SQLException, proxy will hang up with error packet since SQLSate is null