### PR TITLE
Insert clause sharding column null exception

### DIFF
--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/ExpressionConditionUtils.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/ExpressionConditionUtils.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.core.route.router.sharding.condition;
 
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.complex.ComplexExpressionSegment;
 
 /**
@@ -34,5 +35,14 @@ public final class ExpressionConditionUtils {
      */
     public static boolean isNowExpression(final ExpressionSegment segment) {
         return segment instanceof ComplexExpressionSegment && "now()".equalsIgnoreCase(((ComplexExpressionSegment) segment).getText());
+    }
+
+    /**
+     * Judge null expression.
+     * @param segment ExpressionSegment
+     * @return true or false
+     */
+    public static boolean isNullExpression(final ExpressionSegment segment) {
+        return segment instanceof CommonExpressionSegment && ((CommonExpressionSegment) segment).getText() == null;
     }
 }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/engine/InsertClauseShardingConditionEngine.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.core.route.router.sharding.keygen.GeneratedKey;
 import org.apache.shardingsphere.core.route.spi.SPITimeService;
 import org.apache.shardingsphere.core.rule.ShardingRule;
 import org.apache.shardingsphere.core.strategy.route.value.ListRouteValue;
+import org.apache.shardingsphere.underlying.common.exception.ShardingSphereException;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -88,6 +89,8 @@ public final class InsertClauseShardingConditionEngine {
                     result.getRouteValues().add(new ListRouteValue<>(columnName, tableName, Collections.singletonList(getRouteValue((SimpleExpressionSegment) each, parameters))));
                 } else if (ExpressionConditionUtils.isNowExpression(each)) {
                     result.getRouteValues().add(new ListRouteValue<>(columnName, tableName, Collections.singletonList(timeService.getTime())));
+                } else if(ExpressionConditionUtils.isNullExpression(each)) {
+                    throw new ShardingSphereException("Insert clause sharding column can't be null.");
                 }
             }
         }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/engine/InsertClauseShardingConditionEngine.java
@@ -89,7 +89,7 @@ public final class InsertClauseShardingConditionEngine {
                     result.getRouteValues().add(new ListRouteValue<>(columnName, tableName, Collections.singletonList(getRouteValue((SimpleExpressionSegment) each, parameters))));
                 } else if (ExpressionConditionUtils.isNowExpression(each)) {
                     result.getRouteValues().add(new ListRouteValue<>(columnName, tableName, Collections.singletonList(timeService.getTime())));
-                } else if(ExpressionConditionUtils.isNullExpression(each)) {
+                } else if (ExpressionConditionUtils.isNullExpression(each)) {
                     throw new ShardingSphereException("Insert clause sharding column can't be null.");
                 }
             }


### PR DESCRIPTION
Fixes #3880. 

Method `createShardingCondition` of `InsertClauseShardingConditionEngine ` couldn't handle the situation that `ExpressionSegment` of null value in literal insert SQL is `CommonExpressionSegment`. Therefore, null value doesn't add to shardingValues and also not throw exception.

Changes proposed in this pull request:
- Method `createShardingCondition` of `InsertClauseShardingConditionEngine ` adds null expression judgement and throws exception.
