### PR TITLE
Insert clause sharding column null text judgement

### DIFF
--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/ExpressionConditionUtils.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/core/route/router/sharding/condition/ExpressionConditionUtils.java
@@ -43,6 +43,6 @@ public final class ExpressionConditionUtils {
      * @return true or false
      */
     public static boolean isNullExpression(final ExpressionSegment segment) {
-        return segment instanceof CommonExpressionSegment && ((CommonExpressionSegment) segment).getText() == null;
+        return segment instanceof CommonExpressionSegment && "null".equalsIgnoreCase(((CommonExpressionSegment) segment).getText());
     }
 }


### PR DESCRIPTION
Fixes #3884.

Method `createShardingCondition` of `InsertClauseShardingConditionEngine` couldn't handle the situation that `ExpressionSegment` of null value in literal insert SQL is `CommonExpressionSegment`, and text of `CommonExpressionSegment` is "null".

Changes proposed in this pull request:

- Method `createShardingCondition` of InsertClauseShardingConditionEngine modify null expression judgement with "null" text.