### PR TITLE
QueryHeader load logic table metadata

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
@@ -382,7 +382,7 @@ public class ShardingRule implements BaseRule {
     }
     
     /**
-     * Get logic table names base on actual table name.
+     * Get logic table names based on actual table name.
      *
      * @param actualTableName actual table name
      * @return logic table name

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
@@ -71,7 +71,7 @@ public final class QueryHeader {
         String actualTableName = resultSetMetaData.getTableName(columnIndex);
         if (null != actualTableName && logicSchema instanceof ShardingSchema) {
             Collection<String> logicTableNames = logicSchema.getShardingRule().getLogicTableNames(actualTableName);
-            table = logicTableNames.isEmpty()? "" : logicTableNames.iterator().next();
+            table = logicTableNames.isEmpty() ? "" : logicTableNames.iterator().next();
             TableMetaData tableMetaData = logicSchema.getMetaData().getTables().get(table);
             primaryKey = null != tableMetaData && tableMetaData.getColumns().get(resultSetMetaData.getColumnName(columnIndex).toLowerCase())
                     .isPrimaryKey();

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.underlying.common.metadata.table.TableMetaData;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.Collection;
 
 /**
  * Query header.
@@ -69,7 +70,8 @@ public final class QueryHeader {
         autoIncrement = resultSetMetaData.isAutoIncrement(columnIndex);
         String actualTableName = resultSetMetaData.getTableName(columnIndex);
         if (null != actualTableName && logicSchema instanceof ShardingSchema) {
-            table = logicSchema.getShardingRule().getLogicTableNames(actualTableName).iterator().next();
+            Collection<String> logicTableNames = logicSchema.getShardingRule().getLogicTableNames(actualTableName);
+            table = logicTableNames.isEmpty()? null : logicTableNames.iterator().next();
             TableMetaData tableMetaData = logicSchema.getMetaData().getTables().get(table);
             primaryKey = null != tableMetaData && tableMetaData.getColumns().get(resultSetMetaData.getColumnName(columnIndex).toLowerCase())
                     .isPrimaryKey();

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
@@ -71,7 +71,7 @@ public final class QueryHeader {
         String actualTableName = resultSetMetaData.getTableName(columnIndex);
         if (null != actualTableName && logicSchema instanceof ShardingSchema) {
             Collection<String> logicTableNames = logicSchema.getShardingRule().getLogicTableNames(actualTableName);
-            table = logicTableNames.isEmpty()? null : logicTableNames.iterator().next();
+            table = logicTableNames.isEmpty()? "" : logicTableNames.iterator().next();
             TableMetaData tableMetaData = logicSchema.getMetaData().getTables().get(table);
             primaryKey = null != tableMetaData && tableMetaData.getColumns().get(resultSetMetaData.getColumnName(columnIndex).toLowerCase())
                     .isPrimaryKey();

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeader.java
@@ -21,10 +21,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.shardingproxy.backend.schema.LogicSchema;
 import org.apache.shardingsphere.shardingproxy.backend.schema.impl.ShardingSchema;
+import org.apache.shardingsphere.underlying.common.metadata.table.TableMetaData;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.Collection;
 
 /**
  * Query header.
@@ -58,29 +58,25 @@ public final class QueryHeader {
     private final boolean autoIncrement;
     
     public QueryHeader(final ResultSetMetaData resultSetMetaData, final LogicSchema logicSchema, final int columnIndex) throws SQLException {
-        this.schema = logicSchema.getName();
-        String actualTableName = null == resultSetMetaData.getTableName(columnIndex) ? "" : resultSetMetaData.getTableName(columnIndex);
-        if (logicSchema instanceof ShardingSchema) {
-            Collection<String> tableNames = logicSchema.getShardingRule().getLogicTableNames(actualTableName);
-            this.table = tableNames.isEmpty() ? "" : tableNames.iterator().next();
-            if (logicSchema.getMetaData().getTables().containsTable(actualTableName)) {
-                this.primaryKey = logicSchema.getMetaData().getTables().get(actualTableName).getColumns()
-                        .get(resultSetMetaData.getColumnName(columnIndex).toLowerCase()).isPrimaryKey();
-            } else {
-                this.primaryKey = false;
-            }
+        schema = logicSchema.getName();
+        columnLabel = resultSetMetaData.getColumnLabel(columnIndex);
+        columnName = resultSetMetaData.getColumnName(columnIndex);
+        columnLength = resultSetMetaData.getColumnDisplaySize(columnIndex);
+        columnType = resultSetMetaData.getColumnType(columnIndex);
+        decimals = resultSetMetaData.getScale(columnIndex);
+        signed = resultSetMetaData.isSigned(columnIndex);
+        notNull = resultSetMetaData.isNullable(columnIndex) == ResultSetMetaData.columnNoNulls;
+        autoIncrement = resultSetMetaData.isAutoIncrement(columnIndex);
+        String actualTableName = resultSetMetaData.getTableName(columnIndex);
+        if (null != actualTableName && logicSchema instanceof ShardingSchema) {
+            table = logicSchema.getShardingRule().getLogicTableNames(actualTableName).iterator().next();
+            TableMetaData tableMetaData = logicSchema.getMetaData().getTables().get(table);
+            primaryKey = null != tableMetaData && tableMetaData.getColumns().get(resultSetMetaData.getColumnName(columnIndex).toLowerCase())
+                    .isPrimaryKey();
         } else {
-            this.table = actualTableName;
-            this.primaryKey = false;
+            table = actualTableName;
+            primaryKey = false;
         }
-        this.columnLabel = resultSetMetaData.getColumnLabel(columnIndex);
-        this.columnName = resultSetMetaData.getColumnName(columnIndex);
-        this.columnLength = resultSetMetaData.getColumnDisplaySize(columnIndex);
-        this.columnType = resultSetMetaData.getColumnType(columnIndex);
-        this.decimals = resultSetMetaData.getScale(columnIndex);
-        this.signed = resultSetMetaData.isSigned(columnIndex);
-        this.notNull = resultSetMetaData.isNullable(columnIndex) == ResultSetMetaData.columnNoNulls;
-        this.autoIncrement = resultSetMetaData.isAutoIncrement(columnIndex);
     }
     
     /**

--- a/sharding-proxy/sharding-proxy-backend/src/test/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeaderTest.java
+++ b/sharding-proxy/sharding-proxy-backend/src/test/java/org/apache/shardingsphere/shardingproxy/backend/response/query/QueryHeaderTest.java
@@ -111,8 +111,7 @@ public final class QueryHeaderTest {
         ShardingSchema result = mock(ShardingSchema.class);
         ColumnMetaData columnMetaData = new ColumnMetaData("order_id", "int", true);
         TableMetas tableMetas = mock(TableMetas.class);
-        when(tableMetas.get("t_order")).thenReturn(new TableMetaData(Collections.singletonList(columnMetaData), Collections.singletonList("order_id")));
-        when(tableMetas.containsTable("t_order")).thenReturn(true);
+        when(tableMetas.get("t_logic_order")).thenReturn(new TableMetaData(Collections.singletonList(columnMetaData), Collections.singletonList("order_id")));
         ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
         when(metaData.getTables()).thenReturn(tableMetas);
         DataSourceMetas dataSourceMetas = mock(DataSourceMetas.class);


### PR DESCRIPTION
Fixes #3905.

`QueryHeader` constructor gets column by index based on actual table metadata, not logic table. This would cause that after altering table with operation that add column, execute select operation could get null column which occurs NullPointerException.

Changes proposed in this pull request:
- `QueryHeader` constructor gets column by index based on logic table metadata.
