### PR TITLE
Get ciphertext column as a string

### DIFF
--- a/encrypt-core/encrypt-core-merge/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
+++ b/encrypt-core/encrypt-core-merge/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
@@ -44,15 +44,15 @@ public final class EncryptMergedResult implements MergedResult {
     public boolean next() throws SQLException {
         return mergedResult.next();
     }
-    
+
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) throws SQLException {
-        Object value = mergedResult.getValue(columnIndex, type);
-        if (null == value || !queryWithCipherColumn) {
-            return value;
+        Optional<Encryptor> encryptor;
+        if (!queryWithCipherColumn || !(encryptor = metaData.findEncryptor(columnIndex)).isPresent()) {
+            return mergedResult.getValue(columnIndex, type);
         }
-        Optional<Encryptor> encryptor = metaData.findEncryptor(columnIndex);
-        return encryptor.isPresent() ? encryptor.get().decrypt(value.toString()) : value;
+        String ciphertext = (String) mergedResult.getValue(columnIndex, String.class);
+        return null == ciphertext ? null : encryptor.get().decrypt(ciphertext);
     }
     
     @Override

--- a/encrypt-core/encrypt-core-merge/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
+++ b/encrypt-core/encrypt-core-merge/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
@@ -44,7 +44,7 @@ public final class EncryptMergedResult implements MergedResult {
     public boolean next() throws SQLException {
         return mergedResult.next();
     }
-
+    
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) throws SQLException {
         if (!queryWithCipherColumn) {

--- a/encrypt-core/encrypt-core-merge/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
+++ b/encrypt-core/encrypt-core-merge/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
@@ -47,8 +47,11 @@ public final class EncryptMergedResult implements MergedResult {
 
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) throws SQLException {
-        Optional<Encryptor> encryptor;
-        if (!queryWithCipherColumn || !(encryptor = metaData.findEncryptor(columnIndex)).isPresent()) {
+        if (!queryWithCipherColumn) {
+            return mergedResult.getValue(columnIndex, type);
+        }
+        Optional<Encryptor> encryptor = metaData.findEncryptor(columnIndex);
+        if (!encryptor.isPresent()) {
             return mergedResult.getValue(columnIndex, type);
         }
         String ciphertext = (String) mergedResult.getValue(columnIndex, String.class);


### PR DESCRIPTION
Encrypt the field, and take the value of string type directly. For example, after digital encryption, the database can be saved as varchar, and the corresponding field of bean can still be number


please see https://github.com/apache/incubator-shardingsphere/pull/3934