### PR TITLE
Oracle insert statement bugfix

### DIFF
--- a/sharding-sql-test/src/main/resources/sql/encrypt/insert.xml
+++ b/sharding-sql-test/src/main/resources/sql/encrypt/insert.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<sql-cases db-types="MySQL">
+<sql-cases db-types="MySQL,Oracle">
     <sql-case id="insert_without_encrypt_column" value="INSERT INTO t_encrypt(id, status) VALUES(?,?)" />
     <sql-case id="insert_with_encrypt_column" value="INSERT INTO t_encrypt VALUES(?,?,?,?)" />
     <sql-case id="insert_with_encrypt_column_in_function" value="INSERT INTO t_encrypt VALUES(?,upper(?),?,?)" />

--- a/sharding-sql-test/src/main/resources/sql/encrypt/insert.xml
+++ b/sharding-sql-test/src/main/resources/sql/encrypt/insert.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<sql-cases db-types="MySQL,Oracle">
+<sql-cases db-types="MySQL">
     <sql-case id="insert_without_encrypt_column" value="INSERT INTO t_encrypt(id, status) VALUES(?,?)" />
     <sql-case id="insert_with_encrypt_column" value="INSERT INTO t_encrypt VALUES(?,?,?,?)" />
     <sql-case id="insert_with_encrypt_column_in_function" value="INSERT INTO t_encrypt VALUES(?,upper(?),?,?)" />

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -48,11 +48,11 @@ conditionalInsertElsePart
     ;
 
 insertIntoClause
-    : INTO tableName (AS? alias)? columnNames?
+    : INTO tableName (AS? alias)?
     ;
 
 insertValuesClause
-    : VALUES assignmentValues (COMMA_ assignmentValues)*
+    : columnNames? VALUES assignmentValues (COMMA_ assignmentValues)*
     ;
 
 update


### PR DESCRIPTION
Fixes #3962.

`InsertValuesExtractor` could extract column segements by `InsertValuesClause` rule, but oracle insert statement `insertValuesClause` lack of `columnNames `, which cause encrypt problem for extracting column segements.

Changes proposed in this pull request:
- Put `columnNames` into `insertValuesClause`.
