### PR TITLE
Oracle insert statement bugfix

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -48,11 +48,11 @@ conditionalInsertElsePart
     ;
 
 insertIntoClause
-    : INTO tableName (AS? alias)? columnNames?
+    : INTO tableName (AS? alias)?
     ;
 
 insertValuesClause
-    : VALUES assignmentValues (COMMA_ assignmentValues)*
+    : columnNames? VALUES assignmentValues (COMMA_ assignmentValues)*
     ;
 
 update


### PR DESCRIPTION
Fixes #3962.

`InsertValuesExtractor` could extract column segements by `InsertValuesClause` rule, but oracle insert statement `insertValuesClause` lack of `columnNames` , which cause encrypt problem for extracting column segements.

Changes proposed in this pull request:
- Put columnNames into insertValuesClause.