### PR TITLE
PostgreSQL current user

### DIFF
--- a/sharding-sql-test/src/main/resources/sql/supported/dql/select.xml
+++ b/sharding-sql-test/src/main/resources/sql/supported/dql/select.xml
@@ -55,4 +55,5 @@
     <sql-case id="select_with_mod_function" value="SELECT * FROM t_order WHERE MOD(order_id, 1) = 1" db-types="MySQL" />
     <sql-case id="select_with_date_format_function" value="SELECT * FROM t_order WHERE DATE_FORMAT(current_date, '%Y-%m-%d') = '2019-12-18'" db-types="MySQL" />
     <sql-case id="select_with_spatial_function" value="SELECT * FROM t_order WHERE ST_DISTANCE_SPHERE(POINT(113.358772, 23.1273723), POINT(user_id,order_id)) != 0" db-types="MySQL" />
+    <sql-case id="select_current_user" value="SELECT CURRENT_USER" db-types="PostgreSQL"/>
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -203,6 +203,7 @@ simpleExpr
     | EXISTS? subquery
     | LBE_ identifier expr RBE_
     | caseExpression_
+    | CURRENT_USER
     ;
 
 functionCall

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/dml/select.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/dml/select.xml
@@ -1048,4 +1048,12 @@
             </shorthand-select-items>
         </select-items>
     </parser-result>
+
+    <parser-result sql-case-id="select_current_user">
+        <select-items start-index="7" stop-index="19">
+            <expression-items>
+                <expression-item start-index="7" stop-index="19" text="CURRENT_USER"/>
+            </expression-items>
+        </select-items>
+    </parser-result>
 </parser-result-sets>


### PR DESCRIPTION
Fixes #3990.

PostgreSQLParser doesn't support `SELECT CURRENT_USER`, because `simpleExpr` of select statment lack of `CURRENT_USER` keyword.

Changes proposed in this pull request:
- add `CURRENT_USER` to `simpleExpr`, not `functionCall`.
