### PR TITLE
fixed for ResultSet miss the plain column because of using contains to get the logicColumn when using data mask（sharding+encrypt）

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/resultset/ShardingResultSetMetaData.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/resultset/ShardingResultSetMetaData.java
@@ -128,7 +128,7 @@ public final class ShardingResultSetMetaData extends WrapperAdapter implements R
     
     private String getLogicColumn(final String actualColumn) throws SQLException {
         for (Entry<String, String> entry : logicAndActualColumns.entrySet()) {
-            if (entry.getValue().contains(actualColumn)) {
+            if (entry.getValue().equals(actualColumn)) {
                 return entry.getKey();
             }
         }


### PR DESCRIPTION
Fixes #4044.

Changes proposed in this pull request:
- use equals instead of contains to get the plain column.
