### PR TITLE
Encryptor encrypt plaintext with null object

### DIFF
--- a/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/strategy/impl/AESEncryptor.java
+++ b/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/strategy/impl/AESEncryptor.java
@@ -60,6 +60,9 @@ public final class AESEncryptor implements Encryptor {
     @Override
     @SneakyThrows
     public String encrypt(final Object plaintext) {
+        if (null == plaintext) {
+            return null;
+        }
         byte[] result = getCipher(Cipher.ENCRYPT_MODE).doFinal(StringUtils.getBytesUtf8(String.valueOf(plaintext)));
         return Base64.encodeBase64String(result);
     }
@@ -70,7 +73,7 @@ public final class AESEncryptor implements Encryptor {
         if (null == ciphertext) {
             return null;
         }
-        byte[] result = getCipher(Cipher.DECRYPT_MODE).doFinal(Base64.decodeBase64(String.valueOf(ciphertext)));
+        byte[] result = getCipher(Cipher.DECRYPT_MODE).doFinal(Base64.decodeBase64(ciphertext));
         return new String(result, StandardCharsets.UTF_8);
     }
     

--- a/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/strategy/impl/MD5Encryptor.java
+++ b/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/strategy/impl/MD5Encryptor.java
@@ -46,6 +46,9 @@ public final class MD5Encryptor implements Encryptor {
     
     @Override
     public String encrypt(final Object plaintext) {
+        if (null == plaintext) {
+            return null;
+        }
         return DigestUtils.md5Hex(String.valueOf(plaintext));
     }
     


### PR DESCRIPTION
Fixes #3924.

`Encryptor` encrypts plaintext with null object could cause exception, because `String.valueOf` method with null object return "null" string, which should be regarded as null object.  Therefore, this should add null object judgement. Similar to [3925](https://github.com/apache/incubator-shardingsphere/pull/3925/files).

Changes proposed in this pull request:
- Method `encrypt` of   dd null object judgement.