### PR TITLE
Encrypt statement IN operator contains space and line break

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/EncryptPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/EncryptPreparedStatementTest.java
@@ -53,6 +53,12 @@ public final class EncryptPreparedStatementTest extends AbstractEncryptJDBCDatab
     private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_SPACE = "SELECT * FROM t_query_encrypt WHERE pwd IN ( ? )";
 
     private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_LINEBREAK = "SELECT * FROM t_query_encrypt WHERE pwd IN (\n\n?\n\n)";
+
+    private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_CONSTANT = "SELECT * FROM t_query_encrypt WHERE pwd IN ('a')";
+
+    private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_CONSTANT_AND_SPACE = "SELECT * FROM t_query_encrypt WHERE pwd IN ( 'a' )";
+
+    private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_CONSTANT_AND_LINEBREAK = "SELECT * FROM t_query_encrypt WHERE pwd IN (\n\n'a'\n\n)";
     
     private static final String SELECT_SQL_FOR_CONTAINS_COLUMN = "SELECT * FROM t_encrypt_contains_column WHERE plain_pwd = ?";
     
@@ -217,6 +223,42 @@ public final class EncryptPreparedStatementTest extends AbstractEncryptJDBCDatab
     public void assertSelectWithInOperatorContainsLineBreak() throws SQLException {
         try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_LINEBREAK)) {
             statement.setObject(1, 'a');
+            ResultSetMetaData metaData = statement.executeQuery().getMetaData();
+            assertThat(metaData.getColumnCount(), is(2));
+            for (int i = 0; i < metaData.getColumnCount(); i++) {
+                assertThat(metaData.getColumnLabel(1), is("id"));
+                assertThat(metaData.getColumnLabel(2), is("pwd"));
+            }
+        }
+    }
+
+    @Test
+    public void assertSelectWithInOperatorContainsConstant() throws SQLException {
+        try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_CONSTANT)) {
+            ResultSetMetaData metaData = statement.executeQuery().getMetaData();
+            assertThat(metaData.getColumnCount(), is(2));
+            for (int i = 0; i < metaData.getColumnCount(); i++) {
+                assertThat(metaData.getColumnLabel(1), is("id"));
+                assertThat(metaData.getColumnLabel(2), is("pwd"));
+            }
+        }
+    }
+
+    @Test
+    public void assertSelectWithInOperatorContainsConstantAndSpace() throws SQLException {
+        try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_CONSTANT_AND_SPACE)) {
+            ResultSetMetaData metaData = statement.executeQuery().getMetaData();
+            assertThat(metaData.getColumnCount(), is(2));
+            for (int i = 0; i < metaData.getColumnCount(); i++) {
+                assertThat(metaData.getColumnLabel(1), is("id"));
+                assertThat(metaData.getColumnLabel(2), is("pwd"));
+            }
+        }
+    }
+
+    @Test
+    public void assertSelectWithInOperatorContainsConstantAndLineBreak() throws SQLException {
+        try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_CONSTANT_AND_LINEBREAK)) {
             ResultSetMetaData metaData = statement.executeQuery().getMetaData();
             assertThat(metaData.getColumnCount(), is(2));
             for (int i = 0; i < metaData.getColumnCount(); i++) {

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/EncryptPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/EncryptPreparedStatementTest.java
@@ -49,6 +49,8 @@ public final class EncryptPreparedStatementTest extends AbstractEncryptJDBCDatab
     private static final String SELECT_ALL_SQL = "SELECT id, cipher_pwd, assist_pwd FROM t_query_encrypt";
     
     private static final String SELECT_SQL_WITH_IN_OPERATOR = "SELECT * FROM t_query_encrypt WHERE pwd IN (?)";
+
+    private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_SPACE = "SELECT * FROM t_query_encrypt WHERE pwd IN ( ? )";
     
     private static final String SELECT_SQL_FOR_CONTAINS_COLUMN = "SELECT * FROM t_encrypt_contains_column WHERE plain_pwd = ?";
     
@@ -195,7 +197,20 @@ public final class EncryptPreparedStatementTest extends AbstractEncryptJDBCDatab
             }
         }
     }
-    
+
+    @Test
+    public void assertSelectWithInOperatorContainsSpace() throws SQLException {
+        try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_SPACE)) {
+            statement.setObject(1, 'a');
+            ResultSetMetaData metaData = statement.executeQuery().getMetaData();
+            assertThat(metaData.getColumnCount(), is(2));
+            for (int i = 0; i < metaData.getColumnCount(); i++) {
+                assertThat(metaData.getColumnLabel(1), is("id"));
+                assertThat(metaData.getColumnLabel(2), is("pwd"));
+            }
+        }
+    }
+
     @Test
     public void assertSelectWithPlainColumnForContainsColumn() throws SQLException {
         try (PreparedStatement statement = getEncryptConnectionWithProps().prepareStatement(SELECT_SQL_FOR_CONTAINS_COLUMN)) {

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/EncryptPreparedStatementTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/statement/EncryptPreparedStatementTest.java
@@ -51,6 +51,8 @@ public final class EncryptPreparedStatementTest extends AbstractEncryptJDBCDatab
     private static final String SELECT_SQL_WITH_IN_OPERATOR = "SELECT * FROM t_query_encrypt WHERE pwd IN (?)";
 
     private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_SPACE = "SELECT * FROM t_query_encrypt WHERE pwd IN ( ? )";
+
+    private static final String SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_LINEBREAK = "SELECT * FROM t_query_encrypt WHERE pwd IN (\n\n?\n\n)";
     
     private static final String SELECT_SQL_FOR_CONTAINS_COLUMN = "SELECT * FROM t_encrypt_contains_column WHERE plain_pwd = ?";
     
@@ -201,6 +203,19 @@ public final class EncryptPreparedStatementTest extends AbstractEncryptJDBCDatab
     @Test
     public void assertSelectWithInOperatorContainsSpace() throws SQLException {
         try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_SPACE)) {
+            statement.setObject(1, 'a');
+            ResultSetMetaData metaData = statement.executeQuery().getMetaData();
+            assertThat(metaData.getColumnCount(), is(2));
+            for (int i = 0; i < metaData.getColumnCount(); i++) {
+                assertThat(metaData.getColumnLabel(1), is("id"));
+                assertThat(metaData.getColumnLabel(2), is("pwd"));
+            }
+        }
+    }
+
+    @Test
+    public void assertSelectWithInOperatorContainsLineBreak() throws SQLException {
+        try (PreparedStatement statement = getEncryptConnection().prepareStatement(SELECT_SQL_WITH_IN_OPERATOR_CONTAINS_LINEBREAK)) {
             statement.setObject(1, 'a');
             ResultSetMetaData metaData = statement.executeQuery().getMetaData();
             assertThat(metaData.getColumnCount(), is(2));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/PredicateExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/PredicateExtractor.java
@@ -204,7 +204,7 @@ public final class PredicateExtractor implements OptionalSQLSegmentExtractor {
                 }
                 ExpressionSegment expressionSegment = expression.get();
                 if (i == 3 && expressionSegment instanceof ParameterMarkerExpressionSegment) {
-                    result.add(new ParameterMarkerExpressionSegment(((TerminalNodeImpl) predicateNode.getChild(2)).getSymbol().getStartIndex() + 1,
+                    result.add(new ParameterMarkerExpressionSegment(((TerminalNodeImpl) predicateNode.getChild(2)).getSymbol().getStopIndex() + 1,
                             expressionSegment.getStopIndex(), ((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex()));
                 } else {
                     result.add(expressionSegment);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/PredicateExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/PredicateExtractor.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.core.extractor.impl.dml;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.TerminalNodeImpl;
 import org.apache.shardingsphere.sql.parser.core.constant.LogicalOperator;
 import org.apache.shardingsphere.sql.parser.core.constant.Paren;
 import org.apache.shardingsphere.sql.parser.core.extractor.api.OptionalSQLSegmentExtractor;
@@ -29,6 +30,7 @@ import org.apache.shardingsphere.sql.parser.core.extractor.util.ExtractorUtils;
 import org.apache.shardingsphere.sql.parser.core.extractor.util.RuleName;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.AndPredicate;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.OrPredicateSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.PredicateSegment;
@@ -200,7 +202,13 @@ public final class PredicateExtractor implements OptionalSQLSegmentExtractor {
                 if (!expression.isPresent()) {
                     return Collections.emptyList();
                 }
-                result.add(expression.get());
+                ExpressionSegment expressionSegment = expression.get();
+                if (i == 3 && expressionSegment instanceof ParameterMarkerExpressionSegment) {
+                    result.add(new ParameterMarkerExpressionSegment(((TerminalNodeImpl) predicateNode.getChild(2)).getSymbol().getStartIndex() + 1,
+                            expressionSegment.getStopIndex(), ((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex()));
+                } else {
+                    result.add(expressionSegment);
+                }
             }
         }
         return result;

--- a/shardingsphere-underlying/shardingsphere-rewrite/shardingsphere-rewrite-engine/src/main/java/org/apache/shardingsphere/underlying/rewrite/sql/impl/AbstractSQLBuilder.java
+++ b/shardingsphere-underlying/shardingsphere-rewrite/shardingsphere-rewrite-engine/src/main/java/org/apache/shardingsphere/underlying/rewrite/sql/impl/AbstractSQLBuilder.java
@@ -44,7 +44,7 @@ public abstract class AbstractSQLBuilder implements SQLBuilder {
         }
         Collections.sort(context.getSqlTokens());
         StringBuilder result = new StringBuilder();
-        result.append(context.getSql().substring(0, context.getSqlTokens().get(0).getStartIndex()));
+        result.append(context.getSql(), 0, context.getSqlTokens().get(0).getStartIndex());
         for (SQLToken each : context.getSqlTokens()) {
             result.append(getSQLTokenText(each));
             result.append(getConjunctionText(each));


### PR DESCRIPTION
Fixes #4037.

Encrypt statement IN operator contains space and line break could extraly append `(`, because method `extractInExpressionSegments` extracts first `ParameterMarkerExpressionSegment` or `LiteralExpressionSegment` start index not depend on `TerminalNodeImpl` `(`. Therefore, first `ParameterMarkerExpressionSegment` or `LiteralExpressionSegment` start index should be set with start index of `TerminalNodeImpl` `(`.

Changes proposed in this pull request:
- Method `extractInExpressionSegments` extracts first `ParameterMarkerExpressionSegment` or `LiteralExpressionSegment` start index with `TerminalNodeImpl` `(`.