### PR TITLE
persist SchemaNames for getChildren.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <lombok.version>1.16.4</lombok.version>
         
         <springframework.version>[4.3.6.RELEASE,5.0.0.M1)</springframework.version>
-        <spring-boot.version>[1.5.0.RELEASE,2.0.0.M1)</spring-boot.version>
+        <spring-boot.version>[1.5.20.RELEASE,2.0.0.M1)</spring-boot.version>
         
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-nacos/src/main/resources/META-INF/services/org.apache.shardingsphere.orchestration.center.api.ConfigCenter
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-nacos/src/main/resources/META-INF/services/org.apache.shardingsphere.orchestration.center.api.ConfigCenter
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.orchestration.center.instance.NacosInstance
+org.apache.shardingsphere.orchestration.center.instance.NacosConfigInstance

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-nacos/src/test/java/org/apache/shardingsphere/orchestration/center/instance/NacosConfigInstanceTest.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-nacos/src/test/java/org/apache/shardingsphere/orchestration/center/instance/NacosConfigInstanceTest.java
@@ -41,9 +41,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class NacosInstanceTest {
+public class NacosConfigInstanceTest {
     
-    private static ConfigCenter nacosConfigCenter = new NacosInstance();
+    private static ConfigCenter nacosConfigCenter = new NacosConfigInstance();
     
     private ConfigService configService = mock(ConfigService.class);
     
@@ -62,7 +62,7 @@ public class NacosInstanceTest {
     
     @SneakyThrows
     private void setConfigService(final ConfigService configService) {
-        Field configServiceField = NacosInstance.class.getDeclaredField("configService");
+        Field configServiceField = NacosConfigInstance.class.getDeclaredField("configService");
         configServiceField.setAccessible(true);
         configServiceField.set(nacosConfigCenter, configService);
     }

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/ShardingOrchestrationFacade.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/ShardingOrchestrationFacade.java
@@ -21,10 +21,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.api.config.RuleConfiguration;
@@ -39,6 +35,12 @@ import org.apache.shardingsphere.orchestration.internal.configcenter.ConfigCente
 import org.apache.shardingsphere.orchestration.internal.registry.config.service.ConfigurationService;
 import org.apache.shardingsphere.orchestration.internal.registry.listener.ShardingOrchestrationListenerManager;
 import org.apache.shardingsphere.orchestration.internal.registry.state.service.StateService;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Properties;
 
 /**
  * Sharding orchestration facade.
@@ -70,12 +72,12 @@ public final class ShardingOrchestrationFacade implements AutoCloseable {
         Preconditions.checkArgument(registryCenterName.isPresent(), "Can not find instance configuration with registry center orchestration type.");
         InstanceConfiguration registryCenterConfiguration = orchestrationConfig.getInstanceConfigurationMap().get(registryCenterName.get());
         regCenter = new RegistryCenterServiceLoader().load(registryCenterConfiguration);
-        isOverwrite = Boolean.parseBoolean(registryCenterConfiguration.getProperties().getProperty("isOverwrite"));
         stateService = new StateService(registryCenterName.get(), regCenter);
         Optional<String> configCenterName = getInstanceNameByOrchestrationType(orchestrationConfig.getInstanceConfigurationMap(), OrchestrationType.CONFIG_CENTER.getValue());
         Preconditions.checkArgument(configCenterName.isPresent(), "Can not find instance configuration with config center orchestration type.");
         InstanceConfiguration configCenterConfiguration = orchestrationConfig.getInstanceConfigurationMap().get(configCenterName.get());
         configCenter = new ConfigCenterServiceLoader().load(configCenterConfiguration);
+        isOverwrite = Boolean.parseBoolean(Objects.toString(configCenterConfiguration.getProperties().get("overwrite")));
         configService = new ConfigurationService(configCenterName.get(), configCenter);
         listenerManager = shardingSchemaNames.isEmpty()
                 ? new ShardingOrchestrationListenerManager(registryCenterName.get(), regCenter, configCenterName.get(), configCenter, configService.getAllShardingSchemaNames())

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/AuthenticationChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/AuthenticationChangedListener.java
@@ -17,15 +17,15 @@
 
 package org.apache.shardingsphere.orchestration.internal.registry.config.listener;
 
+import com.google.common.collect.Lists;
 import org.apache.shardingsphere.core.yaml.config.common.YamlAuthenticationConfiguration;
 import org.apache.shardingsphere.core.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.core.yaml.swapper.impl.AuthenticationYamlSwapper;
-
 import org.apache.shardingsphere.orchestration.center.api.ConfigCenter;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent;
-import org.apache.shardingsphere.orchestration.internal.registry.listener.PostShardingConfigCenterEventListener;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.AuthenticationChangedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.node.ConfigurationNode;
+import org.apache.shardingsphere.orchestration.internal.registry.listener.PostShardingConfigCenterEventListener;
 
 /**
  * Authentication changed listener.
@@ -36,7 +36,7 @@ import org.apache.shardingsphere.orchestration.internal.registry.config.node.Con
 public final class AuthenticationChangedListener extends PostShardingConfigCenterEventListener {
     
     public AuthenticationChangedListener(final String name, final ConfigCenter configCenter) {
-        super(configCenter, new ConfigurationNode(name).getAuthenticationPath());
+        super(configCenter, Lists.newArrayList(new ConfigurationNode(name).getAuthenticationPath()));
     }
     
     @Override

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/PropertiesChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/PropertiesChangedListener.java
@@ -17,12 +17,13 @@
 
 package org.apache.shardingsphere.orchestration.internal.registry.config.listener;
 
+import com.google.common.collect.Lists;
 import org.apache.shardingsphere.core.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.orchestration.center.api.ConfigCenter;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent;
-import org.apache.shardingsphere.orchestration.internal.registry.listener.PostShardingConfigCenterEventListener;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.PropertiesChangedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.node.ConfigurationNode;
+import org.apache.shardingsphere.orchestration.internal.registry.listener.PostShardingConfigCenterEventListener;
 
 /**
  * Properties changed listener.
@@ -33,7 +34,7 @@ import org.apache.shardingsphere.orchestration.internal.registry.config.node.Con
 public final class PropertiesChangedListener extends PostShardingConfigCenterEventListener {
     
     public PropertiesChangedListener(final String name, final ConfigCenter configCenter) {
-        super(configCenter, new ConfigurationNode(name).getPropsPath());
+        super(configCenter, Lists.newArrayList(new ConfigurationNode(name).getPropsPath()));
     }
     
     @Override

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/SchemaChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/SchemaChangedListener.java
@@ -33,22 +33,24 @@ import org.apache.shardingsphere.core.yaml.swapper.impl.ShardingRuleConfiguratio
 import org.apache.shardingsphere.orchestration.center.api.ConfigCenter;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent.ChangedType;
-import org.apache.shardingsphere.orchestration.internal.registry.config.event.MasterSlaveRuleChangedEvent;
-import org.apache.shardingsphere.orchestration.internal.registry.config.service.ConfigurationService;
-import org.apache.shardingsphere.orchestration.internal.registry.listener.PostShardingConfigCenterEventListener;
-import org.apache.shardingsphere.orchestration.internal.registry.listener.ShardingOrchestrationEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.DataSourceChangedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.EncryptRuleChangedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.IgnoredShardingOrchestrationEvent;
+import org.apache.shardingsphere.orchestration.internal.registry.config.event.MasterSlaveRuleChangedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.SchemaAddedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.SchemaDeletedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.event.ShardingRuleChangedEvent;
 import org.apache.shardingsphere.orchestration.internal.registry.config.node.ConfigurationNode;
+import org.apache.shardingsphere.orchestration.internal.registry.config.service.ConfigurationService;
+import org.apache.shardingsphere.orchestration.internal.registry.listener.PostShardingConfigCenterEventListener;
+import org.apache.shardingsphere.orchestration.internal.registry.listener.ShardingOrchestrationEvent;
 import org.apache.shardingsphere.orchestration.yaml.config.YamlDataSourceConfiguration;
 import org.apache.shardingsphere.orchestration.yaml.swapper.DataSourceConfigurationYamlSwapper;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,7 +68,7 @@ public final class SchemaChangedListener extends PostShardingConfigCenterEventLi
     private final Collection<String> existedSchemaNames = new LinkedList<>();
     
     public SchemaChangedListener(final String name, final ConfigCenter configCenter, final Collection<String> shardingSchemaNames) {
-        super(configCenter, new ConfigurationNode(name).getSchemaPath());
+        super(configCenter, new ConfigurationNode(name).getAllSchemaConfigPaths(shardingSchemaNames));
         configurationService = new ConfigurationService(name, configCenter);
         configurationNode = new ConfigurationNode(name);
         existedSchemaNames.addAll(shardingSchemaNames);

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/SchemaChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/SchemaChangedListener.java
@@ -47,10 +47,8 @@ import org.apache.shardingsphere.orchestration.internal.registry.listener.Shardi
 import org.apache.shardingsphere.orchestration.yaml.config.YamlDataSourceConfiguration;
 import org.apache.shardingsphere.orchestration.yaml.swapper.DataSourceConfigurationYamlSwapper;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/node/ConfigurationNode.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/node/ConfigurationNode.java
@@ -18,8 +18,10 @@
 package org.apache.shardingsphere.orchestration.internal.registry.config.node;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -113,6 +115,21 @@ public final class ConfigurationNode {
         Matcher matcher = pattern.matcher(configurationNodeFullPath);
         if (matcher.find()) {
             result = matcher.group(1);
+        }
+        return result;
+    }
+    
+    /**
+     * Get all schema config paths.
+     * 
+     * @param schemaNames schema names.
+     * @return config paths list.
+     */
+    public Collection<String> getAllSchemaConfigPaths(final Collection<String> schemaNames) {
+        Collection<String> result = Lists.newArrayList();
+        for (String schemaName : schemaNames) {
+            result.add(getRulePath(schemaName));
+            result.add(getDataSourcePath(schemaName));
         }
         return result;
     }

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/listener/PostShardingConfigCenterEventListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/listener/PostShardingConfigCenterEventListener.java
@@ -42,13 +42,19 @@ public abstract class PostShardingConfigCenterEventListener implements ShardingO
     
     private final ConfigCenter configCenter;
     
-    private final String watchKey;
+    private final Collection<String> watchKeys;
     
     @Override
     public final void watch(final ChangedType... watchedChangedTypes) {
         final Collection<ChangedType> watchedChangedTypeList = Arrays.asList(watchedChangedTypes);
+        for (String watchKey : watchKeys) {
+            watch(watchKey, watchedChangedTypeList);
+        }
+    }
+    
+    private void watch(final String watchKey, final Collection<ChangedType> watchedChangedTypeList) {
         configCenter.watch(watchKey, new DataChangedEventListener() {
-            
+        
             @Override
             public void onChange(final DataChangedEvent dataChangedEvent) {
                 if (watchedChangedTypeList.contains(dataChangedEvent.getChangedType())) {

--- a/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/node/ConfigurationNodeTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/node/ConfigurationNodeTest.java
@@ -21,8 +21,10 @@ import com.google.common.collect.Lists;
 import org.apache.shardingsphere.core.constant.ShardingConstant;
 import org.junit.Test;
 
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 public final class ConfigurationNodeTest {
@@ -61,6 +63,9 @@ public final class ConfigurationNodeTest {
     
     @Test
     public void assertGetAllSchemaConfigPaths() {
-        assertThat(configurationNode.getAllSchemaConfigPaths(Lists.newArrayList(ShardingConstant.LOGIC_SCHEMA_NAME)), contains("/test/config/schema/logic_db/rule", "/test/config/schema/logic_db/datasource"));
+        Collection<String> actual = configurationNode.getAllSchemaConfigPaths(Lists.newArrayList(ShardingConstant.LOGIC_SCHEMA_NAME));
+        assertThat(actual.size(), is(2));
+        assertThat(actual, hasItems("/test/config/schema/logic_db/rule"));
+        assertThat(actual, hasItems("/test/config/schema/logic_db/datasource"));
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/node/ConfigurationNodeTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/node/ConfigurationNodeTest.java
@@ -17,10 +17,12 @@
 
 package org.apache.shardingsphere.orchestration.internal.registry.config.node;
 
+import com.google.common.collect.Lists;
 import org.apache.shardingsphere.core.constant.ShardingConstant;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 public final class ConfigurationNodeTest {
@@ -55,5 +57,10 @@ public final class ConfigurationNodeTest {
     @Test
     public void assertGetSchemaName() {
         assertThat(configurationNode.getSchemaName("/test/config/schema/logic_db/rule"), is(ShardingConstant.LOGIC_SCHEMA_NAME));
+    }
+    
+    @Test
+    public void assertGetAllSchemaConfigPaths() {
+        assertThat(configurationNode.getAllSchemaConfigPaths(Lists.newArrayList(ShardingConstant.LOGIC_SCHEMA_NAME)), contains("/test/config/schema/logic_db/rule", "/test/config/schema/logic_db/datasource"));
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/service/ConfigurationServiceTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/service/ConfigurationServiceTest.java
@@ -45,7 +45,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/service/ConfigurationServiceTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/config/service/ConfigurationServiceTest.java
@@ -374,7 +374,7 @@ public final class ConfigurationServiceTest {
     
     @Test
     public void assertGetAllShardingSchemaNames() {
-        when(regCenter.getChildrenKeys("/test/config/schema")).thenReturn(Arrays.asList("sharding_db", "masterslave_db"));
+        when(regCenter.get("/test/config/schema")).thenReturn("sharding_db,masterslave_db");
         ConfigurationService configurationService = new ConfigurationService("test", regCenter);
         Collection<String> actual = configurationService.getAllShardingSchemaNames();
         assertThat(actual.size(), is(2));

--- a/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/listener/PostShardingConfigCenterEventListenerTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/test/java/org/apache/shardingsphere/orchestration/internal/registry/listener/PostShardingConfigCenterEventListenerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.orchestration.internal.registry.listener;
 
+import com.google.common.collect.Lists;
 import org.apache.shardingsphere.orchestration.center.api.ConfigCenter;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEventListener;
@@ -38,7 +39,7 @@ public final class PostShardingConfigCenterEventListenerTest {
     
     @Test
     public void assertWatch() {
-        PostShardingConfigCenterEventListener postShardingConfigCenterEventListener = new PostShardingConfigCenterEventListener(configCenter, "test") {
+        PostShardingConfigCenterEventListener postShardingConfigCenterEventListener = new PostShardingConfigCenterEventListener(configCenter, Lists.newArrayList("test")) {
             
             @Override
             protected ShardingOrchestrationEvent createShardingOrchestrationEvent(final DataChangedEvent event) {

--- a/sharding-proxy/sharding-proxy-bootstrap/pom.xml
+++ b/sharding-proxy/sharding-proxy-bootstrap/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>sharding-orchestration-center-zookeeper-curator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-opentracing</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/sharding-proxy/sharding-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/sharding-proxy/sharding-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -22,12 +22,18 @@
 ######################################################################################################
 #
 #orchestration:
-#  name: orchestration_ds
-#  overwrite: true
-#  registry:
-#    type: zookeeper
+#  orchestration_ds:
+#    orchestrationType: registry_center,config_center,distributed_lock_manager
+#    instanceType: zookeeper
 #    serverLists: localhost:2181
 #    namespace: orchestration
+#    props:
+#      overwrite: false
+#      retry-interval-milliseconds: 10
+#      time-to-live-seconds: 10
+#      max-retries: 10
+#      operation-timeout-milliseconds: 10
+#      digest: 123
 #
 #authentication:
 #  users:


### PR DESCRIPTION
For #3185 .

Changes proposed in this pull request:
- persist SchemaNames for getChildren.
- upgrade spring-boot version.
- fix server.yaml orchestration content.
