### PR TITLE
Call setWasNull in GroupByStreamMergedResult

### DIFF
--- a/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
+++ b/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
@@ -129,11 +129,15 @@ public final class GroupByStreamMergedResult extends OrderByStreamMergedResult {
     
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) {
-        return currentRow.get(columnIndex - 1);
+        Object object = currentRow.get(columnIndex - 1);
+        setWasNull(object == null);
+        return object;
     }
     
     @Override
     public Object getCalendarValue(final int columnIndex, final Class<?> type, final Calendar calendar) {
-        return currentRow.get(columnIndex - 1);
+        Object object = currentRow.get(columnIndex - 1);
+        setWasNull(object == null);
+        return object;
     }
 }

--- a/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
+++ b/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
@@ -130,14 +130,14 @@ public final class GroupByStreamMergedResult extends OrderByStreamMergedResult {
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) {
         Object object = currentRow.get(columnIndex - 1);
-        setWasNull(object == null);
+        setWasNull(null == object);
         return object;
     }
     
     @Override
     public Object getCalendarValue(final int columnIndex, final Class<?> type, final Calendar calendar) {
         Object object = currentRow.get(columnIndex - 1);
-        setWasNull(object == null);
+        setWasNull(null == object);
         return object;
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Set wasNull field which had wrong value when doing a LEFT JOIN FETCH via Hibernate resulting in trying getting an Entity with ID 0.

 See demo application
[demoapp.zip](https://github.com/apache/incubator-shardingsphere/files/4159223/demoapp.zip)
