### PR TITLE
Call setWasNull in GroupByStreamMergedResult

### DIFF
--- a/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
+++ b/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
@@ -129,11 +129,15 @@ public final class GroupByStreamMergedResult extends OrderByStreamMergedResult {
     
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) {
-        return currentRow.get(columnIndex - 1);
+        Object object = currentRow.get(columnIndex - 1);
+        setWasNull(null == object);
+        return object;
     }
     
     @Override
     public Object getCalendarValue(final int columnIndex, final Class<?> type, final Calendar calendar) {
-        return currentRow.get(columnIndex - 1);
+        Object object = currentRow.get(columnIndex - 1);
+        setWasNull(null == object);
+        return object;
     }
 }

--- a/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
+++ b/sharding-core/sharding-core-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
@@ -129,15 +129,15 @@ public final class GroupByStreamMergedResult extends OrderByStreamMergedResult {
     
     @Override
     public Object getValue(final int columnIndex, final Class<?> type) {
-        Object object = currentRow.get(columnIndex - 1);
-        setWasNull(null == object);
-        return object;
+        Object result = currentRow.get(columnIndex - 1);
+        setWasNull(null == result);
+        return result;
     }
     
     @Override
     public Object getCalendarValue(final int columnIndex, final Class<?> type, final Calendar calendar) {
-        Object object = currentRow.get(columnIndex - 1);
-        setWasNull(null == object);
-        return object;
+        Object result = currentRow.get(columnIndex - 1);
+        setWasNull(null == result);
+        return result;
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Set wasNull field which had wrong value when doing a LEFT JOIN FETCH via Hibernate resulting in trying getting an Entity with ID 0.

See https://github.com/apache/incubator-shardingsphere/pull/4173
