### PR TITLE
Fixes #4178

### DIFF
--- a/sharding-sql-test/src/main/java/org/apache/shardingsphere/test/sql/SQLCase.java
+++ b/sharding-sql-test/src/main/java/org/apache/shardingsphere/test/sql/SQLCase.java
@@ -42,6 +42,4 @@ public final class SQLCase {
     
     @XmlAttribute(name = "db-types")
     private String databaseTypes;
-    
-    private String sqlType;
 }

--- a/sharding-sql-test/src/main/java/org/apache/shardingsphere/test/sql/loader/SQLCasesLoader.java
+++ b/sharding-sql-test/src/main/java/org/apache/shardingsphere/test/sql/loader/SQLCasesLoader.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.test.sql.loader;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.test.sql.SQLCase;
@@ -173,9 +174,6 @@ public final class SQLCasesLoader {
     private Collection<Object[]> getTestParameters(final SQLCase sqlCase) {
         Collection<Object[]> result = new LinkedList<>();
         for (SQLCaseType each : SQLCaseType.values()) {
-            if (each == SQLCaseType.Placeholder && !Strings.isNullOrEmpty(sqlCase.getSqlType()) && !("dql".equals(sqlCase.getSqlType()) || "dml".equals(sqlCase.getSqlType()))) {
-                continue;
-            }
             result.addAll(getTestParameters(sqlCase, each));
         }
         return result;
@@ -193,12 +191,8 @@ public final class SQLCasesLoader {
         return result;
     }
     
-    @SuppressWarnings("unchecked")
     private static Collection<String> getDatabaseTypes(final String databaseTypes) {
-        if (Strings.isNullOrEmpty(databaseTypes)) {
-            return getALlDatabaseTypes();
-        }
-        return Arrays.asList(databaseTypes.split(","));
+        return Strings.isNullOrEmpty(databaseTypes) ? getALlDatabaseTypes() : Splitter.on(',').trimResults().splitToList(databaseTypes);
     }
     
     private static Collection<String> getALlDatabaseTypes() {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/engine/SQLParserParameterizedTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/engine/SQLParserParameterizedTest.java
@@ -38,6 +38,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Properties;
 
 import static org.junit.Assert.fail;
@@ -70,7 +71,7 @@ public final class SQLParserParameterizedTest {
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
         checkTestCases();
-        return SQL_CASES_LOADER.getSQLTestParameters();
+        return getSQLTestParameters();
     }
     
     private static void checkTestCases() {
@@ -79,6 +80,20 @@ public final class SQLParserParameterizedTest {
             allSQLCaseIDs.removeAll(SQL_PARSER_TEST_CASES_REGISTRY.getAllSQLCaseIDs());
             fail(String.format("The count of SQL cases and SQL parser cases are mismatched, missing cases are: %s", allSQLCaseIDs));
         }
+    }
+    
+    private static Collection<Object[]> getSQLTestParameters() {
+        Collection<Object[]> result = new LinkedList<>();
+        for (Object[] each : SQL_CASES_LOADER.getSQLTestParameters()) {
+            if (!isPlaceholderWithoutParameter(each)) {
+                result.add(each);
+            }
+        }
+        return result;
+    }
+    
+    private static boolean isPlaceholderWithoutParameter(final Object[] sqlTestParameter) {
+        return SQLCaseType.Placeholder == sqlTestParameter[2] && SQL_PARSER_TEST_CASES_REGISTRY.get(sqlTestParameter[0].toString()).getParameters().isEmpty();
     }
     
     @Test


### PR DESCRIPTION
Fixes #4178.

Removed 1000+ test case for parameter marker without parameters for SQL parser test engine. The test cases running time is improved 2s in my laptop (original is 14s). 