### PR TITLE
Fixes #4037. IN operator contains space and `\n` `\t` `\r`

### DIFF
--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/EncryptConditionEngine.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/EncryptConditionEngine.java
@@ -127,9 +127,9 @@ public final class EncryptConditionEngine {
                 expressionSegments.add(each);
             }
         }
-        return expressionSegments.isEmpty() ? Optional.<EncryptCondition>absent()
-                : Optional.of(new EncryptCondition(
-                        predicateSegment.getColumn().getName(), tableName, inRightValue.getSqlExpressions().iterator().next().getStartIndex(), predicateSegment.getStopIndex(), expressionSegments));
+        EncryptCondition encryptInCondition = new EncryptCondition(predicateSegment.getColumn().getName(), tableName,
+                inRightValue.getPredicateBracketValue().getPredicateLeftBracketValue().getStartIndex(), predicateSegment.getStopIndex(), expressionSegments);
+        return expressionSegments.isEmpty() ? Optional.<EncryptCondition>absent() : Optional.<EncryptCondition>of(encryptInCondition);
     }
     
     private boolean isSupportedOperator(final String operator) {

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptPredicateRightValueTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptPredicateRightValueTokenGenerator.java
@@ -19,15 +19,14 @@ package org.apache.shardingsphere.encrypt.rewrite.token.generator.impl;
 
 import com.google.common.base.Optional;
 import lombok.Setter;
-import org.apache.shardingsphere.core.constant.ShardingOperator;
-import org.apache.shardingsphere.sql.parser.relation.metadata.RelationMetas;
-import org.apache.shardingsphere.sql.parser.relation.statement.SQLStatementContext;
-import org.apache.shardingsphere.sql.parser.sql.statement.generic.WhereSegmentAvailable;
 import org.apache.shardingsphere.encrypt.rewrite.EncryptCondition;
 import org.apache.shardingsphere.encrypt.rewrite.EncryptConditionEngine;
 import org.apache.shardingsphere.encrypt.rewrite.aware.QueryWithCipherColumnAware;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.BaseEncryptSQLTokenGenerator;
 import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptPredicateRightValueToken;
+import org.apache.shardingsphere.sql.parser.relation.metadata.RelationMetas;
+import org.apache.shardingsphere.sql.parser.relation.statement.SQLStatementContext;
+import org.apache.shardingsphere.sql.parser.sql.statement.generic.WhereSegmentAvailable;
 import org.apache.shardingsphere.underlying.rewrite.sql.token.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.underlying.rewrite.sql.token.generator.aware.ParametersAware;
 import org.apache.shardingsphere.underlying.rewrite.sql.token.generator.aware.RelationMetasAware;
@@ -76,7 +75,7 @@ public final class EncryptPredicateRightValueTokenGenerator extends BaseEncryptS
     
     private EncryptPredicateRightValueToken generateSQLToken(final EncryptCondition encryptCondition) {
         List<Object> originalValues = encryptCondition.getValues(parameters);
-        int startIndex = encryptCondition.getOperator().equals(ShardingOperator.IN) ? encryptCondition.getStartIndex() - 1 : encryptCondition.getStartIndex();
+        int startIndex = encryptCondition.getStartIndex();
         return queryWithCipherColumn ? generateSQLTokenForQueryWithCipherColumn(encryptCondition, originalValues, startIndex)
                 : generateSQLTokenForQueryWithoutCipherColumn(encryptCondition, originalValues, startIndex);
     }

--- a/encrypt-core/encrypt-core-rewrite/src/test/resources/encrypt/select_for_query_with_cipher.xml
+++ b/encrypt-core/encrypt-core-rewrite/src/test/resources/encrypt/select_for_query_with_cipher.xml
@@ -37,23 +37,23 @@
         <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.account_id = 1 AND a.assisted_query_password = 'assisted_query_aaa' AND a.cipher_amount = 'encrypt_1000' AND a.status = 'OK'" />
     </rewrite-assertion>
 
-    <rewrite-assertion id="select_plain_for_parameters_with_in_no_space1">
+    <rewrite-assertion id="select_plain_for_parameters_with_in_has_no_left_space">
         <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in(?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
         <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in(?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
     </rewrite-assertion>
 
-    <rewrite-assertion id="select_plain_for_parameters_with_in_with_space">
+    <rewrite-assertion id="select_plain_for_parameters_with_in_has_no_left_space_and_parameter_has_left_space">
         <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in( ?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
         <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in(?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
     </rewrite-assertion>
 
-    <rewrite-assertion id="select_plain_for_parameters_with_in_with_space1">
+    <rewrite-assertion id="select_plain_for_parameters_with_in_has_no_left_space_and_parameter_has_left_newline">
         <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in(
         ?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
         <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in(?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
     </rewrite-assertion>
 
-    <rewrite-assertion id="select_plain_for_parameters_with_in_with_space2">
+    <rewrite-assertion id="select_plain_for_parameters_with_in_has_more_than_one_left_space_and_parameter_has_left_newline">
         <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in    (
         ?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
         <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in    (?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />

--- a/encrypt-core/encrypt-core-rewrite/src/test/resources/encrypt/select_for_query_with_cipher.xml
+++ b/encrypt-core/encrypt-core-rewrite/src/test/resources/encrypt/select_for_query_with_cipher.xml
@@ -36,4 +36,26 @@
         <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.account_id = 1 AND a.password = 'aaa' AND a.amount = 1000 AND a.status = 'OK'" />
         <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.account_id = 1 AND a.assisted_query_password = 'assisted_query_aaa' AND a.cipher_amount = 'encrypt_1000' AND a.status = 'OK'" />
     </rewrite-assertion>
+
+    <rewrite-assertion id="select_plain_for_parameters_with_in_no_space1">
+        <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in(?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
+        <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in(?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_plain_for_parameters_with_in_with_space">
+        <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in( ?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
+        <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in(?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_plain_for_parameters_with_in_with_space1">
+        <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in(
+        ?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
+        <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in(?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_plain_for_parameters_with_in_with_space2">
+        <input sql="SELECT a.account_id, a.password, a.amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.password in    (
+        ?, ?) AND a.amount in (?, ?)" parameters="aaa, aaa, 1000, 1000" />
+        <output sql="SELECT a.account_id, a.cipher_password, a.cipher_amount AS a, a.status AS s FROM t_account_bak AS a WHERE a.assisted_query_password in    (?, ?) AND a.cipher_amount in (?, ?)" parameters="assisted_query_aaa, assisted_query_aaa, encrypt_1000, encrypt_1000" />
+    </rewrite-assertion>
 </rewrite-assertions>

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/router/sharding/condition/generator/impl/ConditionValueInOperatorGeneratorTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/core/route/router/sharding/condition/generator/impl/ConditionValueInOperatorGeneratorTest.java
@@ -23,7 +23,10 @@ import org.apache.shardingsphere.core.strategy.route.value.ListRouteValue;
 import org.apache.shardingsphere.core.strategy.route.value.RouteValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.complex.CommonExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateBracketValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateInRightValue;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateLeftBracketValue;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateRightBracketValue;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -42,7 +45,8 @@ public final class ConditionValueInOperatorGeneratorTest {
     
     @Test
     public void assertNowExpression() {
-        PredicateInRightValue inRightValue = new PredicateInRightValue(Collections.<ExpressionSegment>singletonList(new CommonExpressionSegment(0, 0, "now()")));
+        PredicateBracketValue predicateBracketValue = new PredicateBracketValue(new PredicateLeftBracketValue(0, 1), new PredicateRightBracketValue(0, 1));
+        PredicateInRightValue inRightValue = new PredicateInRightValue(predicateBracketValue, Collections.<ExpressionSegment>singletonList(new CommonExpressionSegment(0, 0, "now()")));
         Optional<RouteValue> routeValue = generator.generate(inRightValue, column, new LinkedList<>());
         assertTrue(routeValue.isPresent());
         assertThat(((ListRouteValue) routeValue.get()).getValues().iterator().next(), instanceOf(Date.class));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/constant/Bracket.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/constant/Bracket.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.core.constant;
+
+import lombok.Getter;
+
+/**
+ * Predicate in bracket.
+ *
+ * @author chun.yang
+ */
+@Getter
+public enum Bracket {
+
+    /**
+     * in left bracket.
+     */
+    LEFT("("),
+
+    /**
+     * in right bracket.
+     */
+    RIGHT(")");
+
+    private final String value;
+
+    Bracket(final String value) {
+        this.value = value;
+    }
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/PredicateExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/PredicateExtractor.java
@@ -20,6 +20,9 @@ package org.apache.shardingsphere.sql.parser.core.extractor.impl.dml;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.shardingsphere.sql.parser.core.constant.Bracket;
 import org.apache.shardingsphere.sql.parser.core.constant.LogicalOperator;
 import org.apache.shardingsphere.sql.parser.core.constant.Paren;
 import org.apache.shardingsphere.sql.parser.core.extractor.api.OptionalSQLSegmentExtractor;
@@ -33,8 +36,11 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.AndPredica
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.OrPredicateSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.PredicateSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateBetweenRightValue;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateBracketValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateCompareRightValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateInRightValue;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateLeftBracketValue;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateRightBracketValue;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -184,11 +190,30 @@ public final class PredicateExtractor implements OptionalSQLSegmentExtractor {
                         predicateNode.getStart().getStartIndex(), predicateNode.getStop().getStopIndex(), column, new PredicateBetweenRightValue(betweenSQLExpression.get(), andSQLExpression.get())))
                 : Optional.<PredicateSegment>absent();
     }
-    
+
     private Optional<PredicateSegment> extractInPredicate(final ParserRuleContext predicateNode, final Map<ParserRuleContext, Integer> parameterMarkerIndexes, final ColumnSegment column) {
+        Optional<PredicateBracketValue> predicateBracketValue = extractBracketValue(predicateNode);
         Collection<ExpressionSegment> sqlExpressions = extractInExpressionSegments(predicateNode, parameterMarkerIndexes);
-        return sqlExpressions.isEmpty() ? Optional.<PredicateSegment>absent()
-                : Optional.of(new PredicateSegment(predicateNode.getStart().getStartIndex(), predicateNode.getStop().getStopIndex(), column, new PredicateInRightValue(sqlExpressions)));
+        PredicateSegment predicateSegment = new PredicateSegment(predicateNode.getStart().getStartIndex(), predicateNode.getStop().getStopIndex(), column,
+                new PredicateInRightValue(predicateBracketValue.get(), sqlExpressions));
+        return sqlExpressions.isEmpty() ? Optional.<PredicateSegment>absent() : Optional.of(predicateSegment);
+    }
+
+    private Optional<PredicateBracketValue> extractBracketValue(final ParserRuleContext predicateNode) {
+        PredicateLeftBracketValue predicateLeftBracketValue = null;
+        PredicateRightBracketValue predicateRightBracketValue = null;
+        for (ParseTree each : predicateNode.children) {
+            if (each instanceof TerminalNode && Bracket.LEFT.getValue().equals(each.getText())) {
+                predicateLeftBracketValue = new PredicateLeftBracketValue(((TerminalNode) each).getSymbol().getStartIndex(), ((TerminalNode) each).getSymbol().getStopIndex());
+            }
+            if (each instanceof TerminalNode && Bracket.RIGHT.getValue().equals(each.getText())) {
+                predicateRightBracketValue = new PredicateRightBracketValue(((TerminalNode) each).getSymbol().getStartIndex(), ((TerminalNode) each).getSymbol().getStopIndex());
+            }
+        }
+        if (null != predicateLeftBracketValue && null != predicateRightBracketValue) {
+            return Optional.of(new PredicateBracketValue(predicateLeftBracketValue, predicateRightBracketValue));
+        }
+        return Optional.absent();
     }
     
     private Collection<ExpressionSegment> extractInExpressionSegments(final ParserRuleContext predicateNode, final Map<ParserRuleContext, Integer> parameterMarkerIndexes) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateBracketValue.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateBracketValue.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * predicate bracket value for in.
+ * @author chun.yang
+ */
+@RequiredArgsConstructor
+@Getter
+public final class PredicateBracketValue implements PredicateRightValue {
+
+    private final PredicateLeftBracketValue predicateLeftBracketValue;
+
+    private final PredicateRightBracketValue predicateRightBracketValue;
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateInRightValue.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateInRightValue.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 @RequiredArgsConstructor
 @Getter
 public final class PredicateInRightValue implements PredicateRightValue {
-    
+
+    private final PredicateBracketValue predicateBracketValue;
+
     private final Collection<ExpressionSegment> sqlExpressions;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateLeftBracketValue.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateLeftBracketValue.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Predicate left bracket value for IN operator.
+ *
+ * @author chun.yang
+ */
+@RequiredArgsConstructor
+@Getter
+public final class PredicateLeftBracketValue implements PredicateRightValue {
+
+    private final int startIndex;
+
+    private final int stopIndex;
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateRightBracketValue.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/predicate/value/PredicateRightBracketValue.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Predicate right bracket value for IN operator.
+ *
+ * @author chun.yang
+ */
+@RequiredArgsConstructor
+@Getter
+public final class PredicateRightBracketValue implements PredicateRightValue {
+
+    private final int startIndex;
+
+    private final int stopIndex;
+}


### PR DESCRIPTION
Fixes #4037.

Changes proposed in this pull request:
- parse the IN operator bracket's index for encrypt rewirte
- fixes encrypt statement IN operator  contains space and `\n` `\t` `\r`
