### PR TITLE
Add class filter Constructor to restrict the illegal class from YAML

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/engine/ClassFilterConstructor.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/engine/ClassFilterConstructor.java
@@ -34,8 +34,8 @@ public final class ClassFilterConstructor extends Constructor {
     
     @Override
     protected Class<?> getClassForName(final String name) throws ClassNotFoundException {
-        for (Class<? extends Object> clz : acceptClasses) {
-            if (name.equals(clz.getName())) {
+        for (Class<? extends Object> each : acceptClasses) {
+            if (name.equals(each.getName())) {
                 return super.getClassForName(name);
             }
         }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/engine/ClassFilterConstructor.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/engine/ClassFilterConstructor.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.core.yaml.engine;
+
+import lombok.RequiredArgsConstructor;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import java.util.Collection;
+
+/**
+ * Class filter Constructor for YAML load as map.
+ *
+ * @author chenqingyang
+ */
+@RequiredArgsConstructor
+public final class ClassFilterConstructor extends Constructor {
+    
+    private final Collection<Class<?>> acceptClasses;
+    
+    @Override
+    protected Class<?> getClassForName(final String name) throws ClassNotFoundException {
+        for (Class<? extends Object> clz : acceptClasses) {
+            if (name.equals(clz.getName())) {
+                return super.getClassForName(name);
+            }
+        }
+        throw new IllegalArgumentException(String.format("Class is not accepted: %s", name));
+    }
+}

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/engine/YamlEngine.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/engine/YamlEngine.java
@@ -30,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -91,10 +92,11 @@ public final class YamlEngine {
      * Unmarshal YAML.
      *
      * @param yamlContent YAML content
+     * @param acceptClasses accept classes
      * @return map from YAML
      */
-    public static Map<?, ?> unmarshal(final String yamlContent) {
-        return Strings.isNullOrEmpty(yamlContent) ? new LinkedHashMap<>() : (Map) new Yaml().load(yamlContent);
+    public static Map<?, ?> unmarshal(final String yamlContent, final Collection<Class<?>> acceptClasses) {
+        return Strings.isNullOrEmpty(yamlContent) ? new LinkedHashMap<>() : (Map) new Yaml(new ClassFilterConstructor(acceptClasses)).load(yamlContent);
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/yaml/engine/YamlEngineTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/yaml/engine/YamlEngineTest.java
@@ -19,7 +19,13 @@ package org.apache.shardingsphere.core.yaml.engine;
 
 import org.apache.shardingsphere.core.yaml.config.common.YamlProxyUserConfiguration;
 import org.junit.Test;
+import org.yaml.snakeyaml.constructor.ConstructorException;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
 
@@ -38,9 +44,23 @@ public final class YamlEngineTest {
     @SuppressWarnings("unchecked")
     @Test
     public void assertUnmarshalMap() {
-        Map<String, Object> actual = (Map<String, Object>) YamlEngine.unmarshal("password: pwd\nauthorizedSchemas: db1");
+        Map<String, Object> actual = (Map<String, Object>) YamlEngine.unmarshal("password: pwd\nauthorizedSchemas: db1", Collections.<Class<?>>emptyList());
         assertThat(actual.get("password").toString(), is("pwd"));
         assertThat(actual.get("authorizedSchemas").toString(), is("db1"));
+    }
+    
+    @Test(expected = ConstructorException.class)
+    public void assertUnmarshalMapWithIllegalClasses() {
+        YamlEngine.unmarshal("url: !!java.net.URLClassLoader [[!!java.net.URL [\"http://localhost\"]]]", Collections.<Class<?>>emptyList());
+    }
+    
+    @Test
+    public void assertUnmarshalMapWithAcceptClasses() {
+        Collection<Class<?>> acceptClasses = new LinkedList<>();
+        acceptClasses.add(URLClassLoader.class);
+        acceptClasses.add(URL.class);
+        Map<String, URLClassLoader> actual = (Map) YamlEngine.unmarshal("url: !!java.net.URLClassLoader [[!!java.net.URL [\"http://localhost\"]]]", acceptClasses);
+        assertThat(actual.get("url").getClass().getName(), is(URLClassLoader.class.getName()));
     }
     
     @SuppressWarnings("unchecked")

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/SchemaChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/listener/SchemaChangedListener.java
@@ -48,6 +48,7 @@ import org.apache.shardingsphere.orchestration.yaml.config.YamlDataSourceConfigu
 import org.apache.shardingsphere.orchestration.yaml.swapper.DataSourceConfigurationYamlSwapper;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -101,7 +102,7 @@ public final class SchemaChangedListener extends PostShardingOrchestrationEventL
     
     @SuppressWarnings("unchecked")
     private DataSourceChangedEvent createDataSourceChangedEvent(final String shardingSchemaName, final DataChangedEvent event) {
-        Map<String, YamlDataSourceConfiguration> dataSourceConfigurations = (Map) YamlEngine.unmarshal(event.getValue());
+        Map<String, YamlDataSourceConfiguration> dataSourceConfigurations = (Map) YamlEngine.unmarshal(event.getValue(), Collections.<Class<?>>singletonList(YamlDataSourceConfiguration.class));
         Preconditions.checkState(null != dataSourceConfigurations && !dataSourceConfigurations.isEmpty(), "No available data sources to load for orchestration.");
         return new DataSourceChangedEvent(shardingSchemaName, Maps.transformValues(dataSourceConfigurations, new Function<YamlDataSourceConfiguration, DataSourceConfiguration>() {
             

--- a/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/service/ConfigurationService.java
+++ b/sharding-orchestration/sharding-orchestration-core/src/main/java/org/apache/shardingsphere/orchestration/internal/registry/config/service/ConfigurationService.java
@@ -42,6 +42,7 @@ import org.apache.shardingsphere.orchestration.yaml.config.YamlDataSourceConfigu
 import org.apache.shardingsphere.orchestration.yaml.swapper.DataSourceConfigurationYamlSwapper;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -202,7 +203,8 @@ public final class ConfigurationService {
      */
     @SuppressWarnings("unchecked")
     public Map<String, DataSourceConfiguration> loadDataSourceConfigurations(final String shardingSchemaName) {
-        Map<String, YamlDataSourceConfiguration> result = (Map) YamlEngine.unmarshal(regCenter.getDirectly(configNode.getDataSourcePath(shardingSchemaName)));
+        Map<String, YamlDataSourceConfiguration> result = (Map) YamlEngine.unmarshal(regCenter.getDirectly(configNode.getDataSourcePath(shardingSchemaName)),
+                Collections.<Class<?>>singletonList(YamlDataSourceConfiguration.class));
         Preconditions.checkState(null != result && !result.isEmpty(), "No available data sources to load for orchestration.");
         return Maps.transformValues(result, new Function<YamlDataSourceConfiguration, DataSourceConfiguration>() {
             

--- a/sharding-ui/sharding-ui-backend/src/main/java/org/apache/shardingsphere/ui/util/ConfigurationYamlConverter.java
+++ b/sharding-ui/sharding-ui-backend/src/main/java/org/apache/shardingsphere/ui/util/ConfigurationYamlConverter.java
@@ -38,6 +38,8 @@ import org.apache.shardingsphere.core.yaml.swapper.impl.MasterSlaveRuleConfigura
 import org.apache.shardingsphere.core.yaml.swapper.impl.ShardingRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.orchestration.yaml.config.YamlDataSourceConfiguration;
 import org.apache.shardingsphere.orchestration.yaml.swapper.DataSourceConfigurationYamlSwapper;
+
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -57,7 +59,7 @@ public final class ConfigurationYamlConverter {
      */
     @SuppressWarnings("unchecked")
     public static Map<String, DataSourceConfiguration> loadDataSourceConfigurations(final String data) {
-        Map<String, YamlDataSourceConfiguration> result = (Map) YamlEngine.unmarshal(data);
+        Map<String, YamlDataSourceConfiguration> result = (Map) YamlEngine.unmarshal(data, Collections.<Class<?>>singletonList(YamlDataSourceConfiguration.class));
         Preconditions.checkState(null != result && !result.isEmpty(), "No available data sources to load for orchestration.");
         return Maps.transformValues(result, new Function<YamlDataSourceConfiguration, DataSourceConfiguration>() {
 


### PR DESCRIPTION
Fixes #4199.

Changes proposed in this pull request:
-  add class filter constructor.
-  modify YamlEngine.Map<?, ?> unmarshal() method ,add parameter 'acceptClasses'.
-  modiry three calls of this method.
- add ut case.