### PR TITLE
Standard List usage

### DIFF
--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/resultset/DatabaseMetaDataResultSet.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/resultset/DatabaseMetaDataResultSet.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.shardingjdbc.jdbc.core.resultset;
 
-import com.google.common.collect.Lists;
 import lombok.EqualsAndHashCode;
 import org.apache.shardingsphere.core.rule.ShardingRule;
 import org.apache.shardingsphere.shardingjdbc.jdbc.unsupported.AbstractUnsupportedDatabaseMetaDataResultSet;
@@ -34,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
@@ -82,7 +82,7 @@ public final class DatabaseMetaDataResultSet extends AbstractUnsupportedDatabase
     }
     
     private Iterator<DatabaseMetaDataObject> initIterator(final ResultSet resultSet) throws SQLException {
-        ArrayList<DatabaseMetaDataObject> result = Lists.newArrayList();
+        LinkedList<DatabaseMetaDataObject> result = new LinkedList<>();
         Set<DatabaseMetaDataObject> removeDuplicationSet = new HashSet<>();
         int tableNameColumnIndex = columnLabelIndexMap.containsKey(TABLE_NAME) ? columnLabelIndexMap.get(TABLE_NAME) : -1;
         int indexNameColumnIndex = columnLabelIndexMap.containsKey(INDEX_NAME) ? columnLabelIndexMap.get(INDEX_NAME) : -1;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
@@ -71,6 +71,7 @@ import org.apache.shardingsphere.sql.parser.sql.value.CollectionValue;
 import org.apache.shardingsphere.sql.parser.sql.value.LiteralValue;
 
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -334,8 +335,8 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
                 ((ColumnAfterPositionSegment) columnPosition).getAfterColumnName());
     }
     
-    private List<TableSegment> extractColumnDefinition(final ColumnDefinitionContext columnDefinition) {
-        List<TableSegment> result = Lists.newArrayList();
+    private Collection<TableSegment> extractColumnDefinition(final ColumnDefinitionContext columnDefinition) {
+        Collection<TableSegment> result = new LinkedList<>();
         for (InlineDataType_Context inlineDataType : columnDefinition.inlineDataType_()) {
             if (null != inlineDataType.commonDataTypeOption_() && null != inlineDataType.commonDataTypeOption_().referenceDefinition_()) {
                 result.add((TableSegment) visit(inlineDataType.commonDataTypeOption_().referenceDefinition_()));
@@ -349,8 +350,8 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
         return result;
     }
     
-    private List<TableSegment> extractColumnDefinitions(final List<ColumnDefinitionContext> columnDefinitions) {
-        List<TableSegment> result = Lists.newArrayList();
+    private Collection<TableSegment> extractColumnDefinitions(final List<ColumnDefinitionContext> columnDefinitions) {
+        Collection<TableSegment> result = new LinkedList<>();
         for (ColumnDefinitionContext columnDefinition : columnDefinitions) {
             result.addAll(extractColumnDefinition(columnDefinition));
         }


### PR DESCRIPTION
According to standard, use `LinkedList` in priority, not use `Lists.newArrayList()` of Guava.

Changes proposed in this pull request:
- Modify `Lists.newArrayList()` to `new LinkedList<>`