### PR TITLE
Add IdentifierValue

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/value/impl/IdentifierValue.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/value/impl/IdentifierValue.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.value.impl;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.value.ValueASTNode;
+
+/**
+ * Identifier value.
+ *
+ * @author panjuan
+ */
+@RequiredArgsConstructor
+@Getter
+public final class IdentifierValue implements ValueASTNode<String> {
+    
+    private final String value;
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
@@ -87,6 +87,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.generic.SchemaSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.BooleanValue;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.CollectionValue;
+import org.apache.shardingsphere.sql.parser.sql.value.impl.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.LiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.NumberValue;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.ParameterMarkerValue;
@@ -149,12 +150,12 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     @Override
     public final ASTNode visitIdentifier(final IdentifierContext ctx) {
         UnreservedWord_Context unreservedWord = ctx.unreservedWord_();
-        return null != unreservedWord ? visit(unreservedWord) : new LiteralValue(ctx.getText());
+        return null != unreservedWord ? visit(unreservedWord) : new IdentifierValue(ctx.getText());
     }
     
     @Override
     public final ASTNode visitUnreservedWord_(final UnreservedWord_Context ctx) {
-        return new LiteralValue(ctx.getText());
+        return new IdentifierValue(ctx.getText());
     }
     
     @Override
@@ -164,31 +165,29 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     
     @Override
     public final ASTNode visitTableName(final TableNameContext ctx) {
-        LiteralValue tableName = (LiteralValue) visit(ctx.name());
+        IdentifierValue tableName = (IdentifierValue) visit(ctx.name());
         TableSegment result = new TableSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), tableName.getValue());
         OwnerContext owner = ctx.owner();
         if (null != owner) {
-            LiteralValue literalValue = (LiteralValue) visit(owner.identifier());
-            result.setOwner(new SchemaSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), literalValue.getValue()));
+            result.setOwner(new SchemaSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), ((IdentifierValue) visit(owner.identifier())).getValue()));
         }
         return result;
     }
     
     @Override
     public final ASTNode visitColumnName(final ColumnNameContext ctx) {
-        LiteralValue columnName = (LiteralValue) visit(ctx.name());
+        IdentifierValue columnName = (IdentifierValue) visit(ctx.name());
         ColumnSegment result = new ColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnName.getValue());
         OwnerContext owner = ctx.owner();
         if (null != owner) {
-            LiteralValue literalValue = (LiteralValue) visit(owner.identifier());
-            result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), literalValue.getValue()));
+            result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), ((IdentifierValue) visit(owner.identifier())).getValue()));
         }
         return result;
     }
     
     @Override
     public final ASTNode visitIndexName(final IndexNameContext ctx) {
-        LiteralValue indexName = (LiteralValue) visit(ctx.identifier());
+        IdentifierValue indexName = (IdentifierValue) visit(ctx.identifier());
         return new IndexSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), indexName.getValue());
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDALVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDALVisitor.java
@@ -44,6 +44,7 @@ import org.apache.shardingsphere.sql.parser.sql.statement.dal.dialect.mysql.Show
 import org.apache.shardingsphere.sql.parser.sql.statement.dal.dialect.mysql.ShowTableStatusStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dal.dialect.mysql.ShowTablesStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dal.dialect.mysql.UseStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.impl.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.LiteralValue;
 
 /**
@@ -55,9 +56,8 @@ public final class MySQLDALVisitor extends MySQLVisitor {
     
     @Override
     public ASTNode visitUse(final UseContext ctx) {
-        LiteralValue schema = (LiteralValue) visit(ctx.schemaName());
         UseStatement result = new UseStatement();
-        result.setSchema(schema.getValue());
+        result.setSchema(((IdentifierValue) visit(ctx.schemaName())).getValue());
         return result;
     }
     
@@ -136,8 +136,7 @@ public final class MySQLDALVisitor extends MySQLVisitor {
         FromTableContext fromTableContext = ctx.fromTable();
         if (null != fromSchemaContext) {
             SchemaNameContext schemaNameContext = fromSchemaContext.schemaName();
-            LiteralValue schema = (LiteralValue) visit(schemaNameContext);
-            SchemaSegment schemaSegment = new SchemaSegment(schemaNameContext.start.getStartIndex(), schemaNameContext.stop.getStopIndex(), schema.getValue());
+            SchemaSegment schemaSegment = new SchemaSegment(schemaNameContext.start.getStartIndex(), schemaNameContext.stop.getStopIndex(), ((IdentifierValue) visit(schemaNameContext)).getValue());
             result.getAllSQLSegments().add(schemaSegment);
         }
         if (null != fromTableContext) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
@@ -68,7 +68,7 @@ import org.apache.shardingsphere.sql.parser.sql.statement.ddl.DropIndexStatement
 import org.apache.shardingsphere.sql.parser.sql.statement.ddl.DropTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.ddl.TruncateStatement;
 import org.apache.shardingsphere.sql.parser.sql.value.impl.CollectionValue;
-import org.apache.shardingsphere.sql.parser.sql.value.impl.LiteralValue;
+import org.apache.shardingsphere.sql.parser.sql.value.impl.IdentifierValue;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -156,7 +156,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     @Override
     public ASTNode visitColumnDefinition(final ColumnDefinitionContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
-        LiteralValue dataType = (LiteralValue) visit(ctx.dataType().dataTypeName_());
+        IdentifierValue dataType = (IdentifierValue) visit(ctx.dataType().dataTypeName_());
         Collection<InlineDataType_Context> inlineDataTypes = Collections2.filter(ctx.inlineDataType_(), new Predicate<InlineDataType_Context>() {
             @Override
             public boolean apply(final InlineDataType_Context inlineDataType) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
@@ -26,27 +26,27 @@ import org.antlr.v4.runtime.Token;
 import org.apache.shardingsphere.sql.parser.MySQLVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AddColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AddConstraintSpecificationContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterDefinitionClause_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterSpecification_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterDefinitionClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ChangeColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ColumnDefinitionContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ConstraintDefinition_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinitionClause_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinition_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ConstraintDefinitionContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinitionClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateIndexContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateLikeClause_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateLikeClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropIndexContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropPrimaryKeySpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.FirstOrAfterColumnContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ForeignKeyOption_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.GeneratedDataType_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.InlineDataType_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ForeignKeyOptionContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.GeneratedDataTypeContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.InlineDataTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ModifyColumnSpecificationContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ReferenceDefinition_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ReferenceDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.RenameColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.TruncateTableContext;
 import org.apache.shardingsphere.sql.parser.sql.ASTNode;
@@ -87,13 +87,13 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
         TableSegment table = (TableSegment) visit(ctx.tableName());
         result.setTable(table);
         result.getAllSQLSegments().add(table);
-        CreateDefinitionClause_Context createDefinitionClause = ctx.createDefinitionClause_();
+        CreateDefinitionClauseContext createDefinitionClause = ctx.createDefinitionClause();
         if (null != createDefinitionClause) {
             CreateTableStatement createDefinition = (CreateTableStatement) visit(createDefinitionClause);
             result.getColumnDefinitions().addAll(createDefinition.getColumnDefinitions());
             result.getAllSQLSegments().addAll(createDefinition.getAllSQLSegments());
         }
-        CreateLikeClause_Context createLikeClause = ctx.createLikeClause_();
+        CreateLikeClauseContext createLikeClause = ctx.createLikeClause();
         if (null != createLikeClause) {
             result.getAllSQLSegments().add((TableSegment) visit(createLikeClause));
         }
@@ -106,7 +106,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
         TableSegment table = (TableSegment) visit(ctx.tableName());
         result.setTable(table);
         result.getAllSQLSegments().add(table);
-        AlterDefinitionClause_Context alterDefinitionClause = ctx.alterDefinitionClause_();
+        AlterDefinitionClauseContext alterDefinitionClause = ctx.alterDefinitionClause();
         if (null != alterDefinitionClause) {
             AlterTableStatement alterDefinition = (AlterTableStatement) visit(alterDefinitionClause);
             result.getAddedColumnDefinitions().addAll(alterDefinition.getAddedColumnDefinitions());
@@ -156,18 +156,19 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     @Override
     public ASTNode visitColumnDefinition(final ColumnDefinitionContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
-        IdentifierValue dataType = (IdentifierValue) visit(ctx.dataType().dataTypeName_());
-        Collection<InlineDataType_Context> inlineDataTypes = Collections2.filter(ctx.inlineDataType_(), new Predicate<InlineDataType_Context>() {
+        IdentifierValue dataType = (IdentifierValue) visit(ctx.dataType().dataTypeName());
+        Collection<InlineDataTypeContext> inlineDataTypes = Collections2.filter(ctx.inlineDataType(), new Predicate<InlineDataTypeContext>() {
+            
             @Override
-            public boolean apply(final InlineDataType_Context inlineDataType) {
-                return null != inlineDataType.commonDataTypeOption_() && null != inlineDataType.commonDataTypeOption_().primaryKey();
+            public boolean apply(final InlineDataTypeContext inlineDataType) {
+                return null != inlineDataType.commonDataTypeOption() && null != inlineDataType.commonDataTypeOption().primaryKey();
             }
         });
-        Collection<GeneratedDataType_Context> generatedDataTypes = Collections2.filter(ctx.generatedDataType_(), new Predicate<GeneratedDataType_Context>() {
+        Collection<GeneratedDataTypeContext> generatedDataTypes = Collections2.filter(ctx.generatedDataType(), new Predicate<GeneratedDataTypeContext>() {
             @Override
-            public boolean apply(final GeneratedDataType_Context generatedDataType) {
-                return null != generatedDataType.commonDataTypeOption_()
-                        && null != generatedDataType.commonDataTypeOption_().primaryKey();
+            public boolean apply(final GeneratedDataTypeContext generatedDataType) {
+                return null != generatedDataType.commonDataTypeOption()
+                        && null != generatedDataType.commonDataTypeOption().primaryKey();
             }
         });
         boolean isPrimaryKey = inlineDataTypes.size() > 0 || generatedDataTypes.size() > 0;
@@ -183,16 +184,16 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     }
     
     @Override
-    public ASTNode visitCreateDefinitionClause_(final CreateDefinitionClause_Context ctx) {
+    public ASTNode visitCreateDefinitionClause(final CreateDefinitionClauseContext ctx) {
         CreateTableStatement result = new CreateTableStatement();
-        for (CreateDefinition_Context createDefinition : ctx.createDefinitions_().createDefinition_()) {
+        for (CreateDefinitionContext createDefinition : ctx.createDefinitions().createDefinition()) {
             ColumnDefinitionContext columnDefinition = createDefinition.columnDefinition();
             if (null != columnDefinition) {
                 result.getColumnDefinitions().add((ColumnDefinitionSegment) visit(columnDefinition));
                 result.getAllSQLSegments().addAll(extractColumnDefinition(columnDefinition));
             }
-            ConstraintDefinition_Context constraintDefinition = createDefinition.constraintDefinition_();
-            ForeignKeyOption_Context foreignKeyOption = null == constraintDefinition ? null : constraintDefinition.foreignKeyOption_();
+            ConstraintDefinitionContext constraintDefinition = createDefinition.constraintDefinition();
+            ForeignKeyOptionContext foreignKeyOption = null == constraintDefinition ? null : constraintDefinition.foreignKeyOption();
             if (null != foreignKeyOption) {
                 result.getAllSQLSegments().add((TableSegment) visit(foreignKeyOption));
             }
@@ -204,14 +205,14 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     }
     
     @Override
-    public ASTNode visitCreateLikeClause_(final CreateLikeClause_Context ctx) {
+    public ASTNode visitCreateLikeClause(final CreateLikeClauseContext ctx) {
         return visit(ctx.tableName());
     }
     
     @Override
-    public ASTNode visitAlterDefinitionClause_(final AlterDefinitionClause_Context ctx) {
+    public ASTNode visitAlterDefinitionClause(final AlterDefinitionClauseContext ctx) {
         final AlterTableStatement result = new AlterTableStatement();
-        for (AlterSpecification_Context alterSpecification : ctx.alterSpecification_()) {
+        for (AlterSpecificationContext alterSpecification : ctx.alterSpecification()) {
             AddColumnSpecificationContext addColumnSpecification = alterSpecification.addColumnSpecification();
             if (null != addColumnSpecification) {
                 CollectionValue<AddColumnDefinitionSegment> addColumnDefinitions = (CollectionValue<AddColumnDefinitionSegment>) visit(addColumnSpecification);
@@ -225,8 +226,8 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
                 result.getAllSQLSegments().addAll(extractColumnDefinitions(addColumnSpecification.columnDefinition()));
             }
             AddConstraintSpecificationContext addConstraintSpecification = alterSpecification.addConstraintSpecification();
-            ForeignKeyOption_Context foreignKeyOption = null == addConstraintSpecification
-                    ? null : addConstraintSpecification.constraintDefinition_().foreignKeyOption_();
+            ForeignKeyOptionContext foreignKeyOption = null == addConstraintSpecification
+                    ? null : addConstraintSpecification.constraintDefinition().foreignKeyOption();
             if (null != foreignKeyOption) {
                 result.getAllSQLSegments().add((TableSegment) visit(foreignKeyOption));
             }
@@ -309,13 +310,13 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     }
     
     @Override
-    public ASTNode visitReferenceDefinition_(final ReferenceDefinition_Context ctx) {
+    public ASTNode visitReferenceDefinition(final ReferenceDefinitionContext ctx) {
         return visit(ctx.tableName());
     }
     
     @Override
-    public ASTNode visitForeignKeyOption_(final ForeignKeyOption_Context ctx) {
-        return visit(ctx.referenceDefinition_());
+    public ASTNode visitForeignKeyOption(final ForeignKeyOptionContext ctx) {
+        return visit(ctx.referenceDefinition());
     }
     
     private ModifyColumnDefinitionSegment extractModifyColumnDefinition(final Token start, final Token stop, final ColumnDefinitionContext columnDefinition,
@@ -337,14 +338,14 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     
     private Collection<TableSegment> extractColumnDefinition(final ColumnDefinitionContext columnDefinition) {
         Collection<TableSegment> result = new LinkedList<>();
-        for (InlineDataType_Context inlineDataType : columnDefinition.inlineDataType_()) {
-            if (null != inlineDataType.commonDataTypeOption_() && null != inlineDataType.commonDataTypeOption_().referenceDefinition_()) {
-                result.add((TableSegment) visit(inlineDataType.commonDataTypeOption_().referenceDefinition_()));
+        for (InlineDataTypeContext inlineDataType : columnDefinition.inlineDataType()) {
+            if (null != inlineDataType.commonDataTypeOption() && null != inlineDataType.commonDataTypeOption().referenceDefinition()) {
+                result.add((TableSegment) visit(inlineDataType.commonDataTypeOption().referenceDefinition()));
             }
         }
-        for (GeneratedDataType_Context generatedDataType : columnDefinition.generatedDataType_()) {
-            if (null != generatedDataType.commonDataTypeOption_() && null != generatedDataType.commonDataTypeOption_().referenceDefinition_()) {
-                result.add((TableSegment) visit(generatedDataType.commonDataTypeOption_().referenceDefinition_()));
+        for (GeneratedDataTypeContext generatedDataType : columnDefinition.generatedDataType()) {
+            if (null != generatedDataType.commonDataTypeOption() && null != generatedDataType.commonDataTypeOption().referenceDefinition()) {
+                result.add((TableSegment) visit(generatedDataType.commonDataTypeOption().referenceDefinition()));
             }
         }
         return result;


### PR DESCRIPTION
For #3914.

Add new class `IdentifierValue` to make different with `IdentifierValue` and `LiteralValue`.
`IdentifierValue` is used for table name, column name, etc;
`LiteralValue` is for literal value in expr, for example: id=`1`;