### PR TITLE
Optimize MySQL Antlr4 rule names

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -492,10 +492,10 @@ orderByItem
     ;
 
 dataType
-    : dataTypeName_ dataTypeLength? characterSet_? collateClause_? UNSIGNED? ZEROFILL? | dataTypeName_ LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet_? collateClause_?
+    : dataTypeName dataTypeLength? characterSet_? collateClause_? UNSIGNED? ZEROFILL? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet_? collateClause_?
     ;
 
-dataTypeName_
+dataTypeName
     : identifier identifier?
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -20,7 +20,7 @@ grammar DDLStatement;
 import Symbol, Keyword, MySQLKeyword, Literals, BaseRule, DMLStatement;
 
 createTable
-    : CREATE createTableSpecification_? TABLE tableNotExistClause_ tableName (createDefinitionClause_ | createLikeClause_)
+    : CREATE createTableSpecification_? TABLE tableNotExistClause_ tableName (createDefinitionClause | createLikeClause)
     ;
 
 createIndex
@@ -32,7 +32,7 @@ createIndex
     ;
 
 alterTable
-    : ALTER TABLE tableName alterDefinitionClause_?
+    : ALTER TABLE tableName alterDefinitionClause?
     ;
 
 dropTable
@@ -231,8 +231,8 @@ tableNotExistClause_
     : (IF NOT EXISTS)?
     ;
 
-createDefinitionClause_
-    : LP_ createDefinitions_ RP_
+createDefinitionClause
+    : LP_ createDefinitions RP_
     ;
 
 createDatabaseSpecification_
@@ -241,35 +241,35 @@ createDatabaseSpecification_
     | DEFAULT ENCRYPTION EQ_ Y_N_
     ;
 
-createDefinitions_
-    : createDefinition_ (COMMA_ createDefinition_)*
+createDefinitions
+    : createDefinition (COMMA_ createDefinition)*
     ;
 
-createDefinition_
-    : columnDefinition | indexDefinition_ | constraintDefinition_ | checkConstraintDefinition_
+createDefinition
+    : columnDefinition | indexDefinition_ | constraintDefinition | checkConstraintDefinition_
     ;
 
 columnDefinition
-    : columnName dataType (inlineDataType_* | generatedDataType_*)
+    : columnName dataType (inlineDataType* | generatedDataType*)
     ;
 
-inlineDataType_
-    : commonDataTypeOption_
+inlineDataType
+    : commonDataTypeOption
     | AUTO_INCREMENT
     | DEFAULT (literals | expr)
     | COLUMN_FORMAT (FIXED | DYNAMIC | DEFAULT)
     | STORAGE (DISK | MEMORY | DEFAULT)
     ;
 
-commonDataTypeOption_
-    : primaryKey | UNIQUE KEY? | NOT? NULL | collateClause_ | checkConstraintDefinition_ | referenceDefinition_ | COMMENT STRING_
+commonDataTypeOption
+    : primaryKey | UNIQUE KEY? | NOT? NULL | collateClause_ | checkConstraintDefinition_ | referenceDefinition | COMMENT STRING_
     ;
 
 checkConstraintDefinition_
     : (CONSTRAINT ignoredIdentifier_?)? CHECK expr (NOT? ENFORCED)?
     ;
 
-referenceDefinition_
+referenceDefinition
     : REFERENCES tableName keyParts_ (MATCH FULL | MATCH PARTIAL | MATCH SIMPLE)? (ON (UPDATE | DELETE) referenceOption_)*
     ;
 
@@ -277,8 +277,8 @@ referenceOption_
     : RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT
     ;
 
-generatedDataType_
-    : commonDataTypeOption_
+generatedDataType
+    : commonDataTypeOption
     | (GENERATED ALWAYS)? AS expr
     | (VIRTUAL | STORED)
     ;
@@ -307,8 +307,8 @@ indexOption_
     | (VISIBLE | INVISIBLE)
     ;
 
-constraintDefinition_
-    : (CONSTRAINT ignoredIdentifier_?)? (primaryKeyOption_ | uniqueOption_ | foreignKeyOption_)
+constraintDefinition
+    : (CONSTRAINT ignoredIdentifier_?)? (primaryKeyOption_ | uniqueOption_ | foreignKeyOption)
     ;
 
 primaryKeyOption_
@@ -323,11 +323,11 @@ uniqueOption_
     : UNIQUE (INDEX | KEY)? indexName? indexType_? keyParts_ indexOption_*
     ;
 
-foreignKeyOption_
-    : FOREIGN KEY indexName? columnNames referenceDefinition_
+foreignKeyOption
+    : FOREIGN KEY indexName? columnNames referenceDefinition
     ;
 
-createLikeClause_
+createLikeClause
     : LP_? LIKE tableName RP_?
     ;
 
@@ -335,11 +335,11 @@ createIndexSpecification_
     : (UNIQUE | FULLTEXT | SPATIAL)?
     ;
 
-alterDefinitionClause_
-    : alterSpecification_ (COMMA_ alterSpecification_)*
+alterDefinitionClause
+    : alterSpecification (COMMA_ alterSpecification)*
     ;
 
-alterSpecification_
+alterSpecification
     : tableOptions_
     | addColumnSpecification
     | addIndexSpecification
@@ -428,7 +428,7 @@ addIndexSpecification
     ;
 
 addConstraintSpecification
-    : ADD constraintDefinition_
+    : ADD constraintDefinition
     ;
 
 changeColumnSpecification

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
@@ -31,7 +31,7 @@ import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CharFun
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ColumnNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ColumnNamesContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ConvertFunctionContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DataTypeName_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DataTypeNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ExprContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ExtractFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.FunctionCallContext;
@@ -213,7 +213,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     }
     
     @Override
-    public final ASTNode visitDataTypeName_(final DataTypeName_Context ctx) {
+    public final ASTNode visitDataTypeName(final DataTypeNameContext ctx) {
         return visit(ctx.identifier(0));
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
@@ -26,27 +26,27 @@ import org.antlr.v4.runtime.Token;
 import org.apache.shardingsphere.sql.parser.MySQLVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AddColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AddConstraintSpecificationContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterDefinitionClause_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterSpecification_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterDefinitionClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ChangeColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ColumnDefinitionContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ConstraintDefinition_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinitionClause_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinition_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ConstraintDefinitionContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinitionClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateIndexContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateLikeClause_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateLikeClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CreateTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropIndexContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropPrimaryKeySpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DropTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.FirstOrAfterColumnContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ForeignKeyOption_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.GeneratedDataType_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.InlineDataType_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ForeignKeyOptionContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.GeneratedDataTypeContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.InlineDataTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ModifyColumnSpecificationContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ReferenceDefinition_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ReferenceDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.RenameColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.TruncateTableContext;
 import org.apache.shardingsphere.sql.parser.sql.ASTNode;
@@ -87,13 +87,13 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
         TableSegment table = (TableSegment) visit(ctx.tableName());
         result.setTable(table);
         result.getAllSQLSegments().add(table);
-        CreateDefinitionClause_Context createDefinitionClause = ctx.createDefinitionClause_();
+        CreateDefinitionClauseContext createDefinitionClause = ctx.createDefinitionClause();
         if (null != createDefinitionClause) {
             CreateTableStatement createDefinition = (CreateTableStatement) visit(createDefinitionClause);
             result.getColumnDefinitions().addAll(createDefinition.getColumnDefinitions());
             result.getAllSQLSegments().addAll(createDefinition.getAllSQLSegments());
         }
-        CreateLikeClause_Context createLikeClause = ctx.createLikeClause_();
+        CreateLikeClauseContext createLikeClause = ctx.createLikeClause();
         if (null != createLikeClause) {
             result.getAllSQLSegments().add((TableSegment) visit(createLikeClause));
         }
@@ -106,7 +106,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
         TableSegment table = (TableSegment) visit(ctx.tableName());
         result.setTable(table);
         result.getAllSQLSegments().add(table);
-        AlterDefinitionClause_Context alterDefinitionClause = ctx.alterDefinitionClause_();
+        AlterDefinitionClauseContext alterDefinitionClause = ctx.alterDefinitionClause();
         if (null != alterDefinitionClause) {
             AlterTableStatement alterDefinition = (AlterTableStatement) visit(alterDefinitionClause);
             result.getAddedColumnDefinitions().addAll(alterDefinition.getAddedColumnDefinitions());
@@ -156,18 +156,18 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     @Override
     public ASTNode visitColumnDefinition(final ColumnDefinitionContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
-        LiteralValue dataType = (LiteralValue) visit(ctx.dataType().dataTypeName_());
-        Collection<InlineDataType_Context> inlineDataTypes = Collections2.filter(ctx.inlineDataType_(), new Predicate<InlineDataType_Context>() {
+        LiteralValue dataType = (LiteralValue) visit(ctx.dataType().dataTypeName());
+        Collection<InlineDataTypeContext> inlineDataTypes = Collections2.filter(ctx.inlineDataType(), new Predicate<InlineDataTypeContext>() {
             @Override
-            public boolean apply(final InlineDataType_Context inlineDataType) {
-                return null != inlineDataType.commonDataTypeOption_() && null != inlineDataType.commonDataTypeOption_().primaryKey();
+            public boolean apply(final InlineDataTypeContext inlineDataType) {
+                return null != inlineDataType.commonDataTypeOption() && null != inlineDataType.commonDataTypeOption().primaryKey();
             }
         });
-        Collection<GeneratedDataType_Context> generatedDataTypes = Collections2.filter(ctx.generatedDataType_(), new Predicate<GeneratedDataType_Context>() {
+        Collection<GeneratedDataTypeContext> generatedDataTypes = Collections2.filter(ctx.generatedDataType(), new Predicate<GeneratedDataTypeContext>() {
             @Override
-            public boolean apply(final GeneratedDataType_Context generatedDataType) {
-                return null != generatedDataType.commonDataTypeOption_()
-                        && null != generatedDataType.commonDataTypeOption_().primaryKey();
+            public boolean apply(final GeneratedDataTypeContext generatedDataType) {
+                return null != generatedDataType.commonDataTypeOption()
+                        && null != generatedDataType.commonDataTypeOption().primaryKey();
             }
         });
         boolean isPrimaryKey = inlineDataTypes.size() > 0 || generatedDataTypes.size() > 0;
@@ -183,16 +183,16 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     }
     
     @Override
-    public ASTNode visitCreateDefinitionClause_(final CreateDefinitionClause_Context ctx) {
+    public ASTNode visitCreateDefinitionClause(final CreateDefinitionClauseContext ctx) {
         CreateTableStatement result = new CreateTableStatement();
-        for (CreateDefinition_Context createDefinition : ctx.createDefinitions_().createDefinition_()) {
+        for (CreateDefinitionContext createDefinition : ctx.createDefinitions().createDefinition()) {
             ColumnDefinitionContext columnDefinition = createDefinition.columnDefinition();
             if (null != columnDefinition) {
                 result.getColumnDefinitions().add((ColumnDefinitionSegment) visit(columnDefinition));
                 result.getAllSQLSegments().addAll(extractColumnDefinition(columnDefinition));
             }
-            ConstraintDefinition_Context constraintDefinition = createDefinition.constraintDefinition_();
-            ForeignKeyOption_Context foreignKeyOption = null == constraintDefinition ? null : constraintDefinition.foreignKeyOption_();
+            ConstraintDefinitionContext constraintDefinition = createDefinition.constraintDefinition();
+            ForeignKeyOptionContext foreignKeyOption = null == constraintDefinition ? null : constraintDefinition.foreignKeyOption();
             if (null != foreignKeyOption) {
                 result.getAllSQLSegments().add((TableSegment) visit(foreignKeyOption));
             }
@@ -204,14 +204,14 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     }
     
     @Override
-    public ASTNode visitCreateLikeClause_(final CreateLikeClause_Context ctx) {
+    public ASTNode visitCreateLikeClause(final CreateLikeClauseContext ctx) {
         return visit(ctx.tableName());
     }
     
     @Override
-    public ASTNode visitAlterDefinitionClause_(final AlterDefinitionClause_Context ctx) {
+    public ASTNode visitAlterDefinitionClause(final AlterDefinitionClauseContext ctx) {
         final AlterTableStatement result = new AlterTableStatement();
-        for (AlterSpecification_Context alterSpecification : ctx.alterSpecification_()) {
+        for (AlterSpecificationContext alterSpecification : ctx.alterSpecification()) {
             AddColumnSpecificationContext addColumnSpecification = alterSpecification.addColumnSpecification();
             if (null != addColumnSpecification) {
                 CollectionValue<AddColumnDefinitionSegment> addColumnDefinitions = (CollectionValue<AddColumnDefinitionSegment>) visit(addColumnSpecification);
@@ -225,8 +225,8 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
                 result.getAllSQLSegments().addAll(extractColumnDefinitions(addColumnSpecification.columnDefinition()));
             }
             AddConstraintSpecificationContext addConstraintSpecification = alterSpecification.addConstraintSpecification();
-            ForeignKeyOption_Context foreignKeyOption = null == addConstraintSpecification
-                    ? null : addConstraintSpecification.constraintDefinition_().foreignKeyOption_();
+            ForeignKeyOptionContext foreignKeyOption = null == addConstraintSpecification
+                    ? null : addConstraintSpecification.constraintDefinition().foreignKeyOption();
             if (null != foreignKeyOption) {
                 result.getAllSQLSegments().add((TableSegment) visit(foreignKeyOption));
             }
@@ -309,13 +309,13 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     }
     
     @Override
-    public ASTNode visitReferenceDefinition_(final ReferenceDefinition_Context ctx) {
+    public ASTNode visitReferenceDefinition(final ReferenceDefinitionContext ctx) {
         return visit(ctx.tableName());
     }
     
     @Override
-    public ASTNode visitForeignKeyOption_(final ForeignKeyOption_Context ctx) {
-        return visit(ctx.referenceDefinition_());
+    public ASTNode visitForeignKeyOption(final ForeignKeyOptionContext ctx) {
+        return visit(ctx.referenceDefinition());
     }
     
     private ModifyColumnDefinitionSegment extractModifyColumnDefinition(final Token start, final Token stop, final ColumnDefinitionContext columnDefinition,
@@ -337,14 +337,14 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     
     private Collection<TableSegment> extractColumnDefinition(final ColumnDefinitionContext columnDefinition) {
         Collection<TableSegment> result = new LinkedList<>();
-        for (InlineDataType_Context inlineDataType : columnDefinition.inlineDataType_()) {
-            if (null != inlineDataType.commonDataTypeOption_() && null != inlineDataType.commonDataTypeOption_().referenceDefinition_()) {
-                result.add((TableSegment) visit(inlineDataType.commonDataTypeOption_().referenceDefinition_()));
+        for (InlineDataTypeContext inlineDataType : columnDefinition.inlineDataType()) {
+            if (null != inlineDataType.commonDataTypeOption() && null != inlineDataType.commonDataTypeOption().referenceDefinition()) {
+                result.add((TableSegment) visit(inlineDataType.commonDataTypeOption().referenceDefinition()));
             }
         }
-        for (GeneratedDataType_Context generatedDataType : columnDefinition.generatedDataType_()) {
-            if (null != generatedDataType.commonDataTypeOption_() && null != generatedDataType.commonDataTypeOption_().referenceDefinition_()) {
-                result.add((TableSegment) visit(generatedDataType.commonDataTypeOption_().referenceDefinition_()));
+        for (GeneratedDataTypeContext generatedDataType : columnDefinition.generatedDataType()) {
+            if (null != generatedDataType.commonDataTypeOption() && null != generatedDataType.commonDataTypeOption().referenceDefinition()) {
+                result.add((TableSegment) visit(generatedDataType.commonDataTypeOption().referenceDefinition()));
             }
         }
         return result;


### PR DESCRIPTION
Fixes #3914.

Optimize MySQL Antlr4 rule names of `MySQLDDLVisitor`. Rule names of `MySQLDDLVisitor` should remove `_` by standard of Antlr4 rule name.

Changes proposed in this pull request:
- Rule names of `DDLStatement.g4` for `MySQLDDLVisitor` remove `_` to optimize MySQL Antlr4 rule names.
