### PR TITLE
Use identifier value to instead of name and quote character in SQLSegment

### DIFF
--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/condition/EncryptConditionEngine.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/condition/EncryptConditionEngine.java
@@ -97,7 +97,7 @@ public final class EncryptConditionEngine {
     
     private Optional<EncryptCondition> createEncryptCondition(final PredicateSegment predicateSegment, final TablesContext tablesContext) {
         Optional<String> tableName = tablesContext.findTableName(predicateSegment.getColumn(), relationMetas);
-        return tableName.isPresent() && encryptRule.findEncryptor(tableName.get(), predicateSegment.getColumn().getName()).isPresent()
+        return tableName.isPresent() && encryptRule.findEncryptor(tableName.get(), predicateSegment.getColumn().getIdentifier().getValue()).isPresent()
                 ? createEncryptCondition(predicateSegment, tableName.get()) : Optional.<EncryptCondition>absent();
     }
     
@@ -117,7 +117,7 @@ public final class EncryptConditionEngine {
     
     private static Optional<EncryptCondition> createCompareEncryptCondition(final String tableName, final PredicateSegment predicateSegment, final PredicateCompareRightValue compareRightValue) {
         return compareRightValue.getExpression() instanceof SimpleExpressionSegment
-                ? Optional.<EncryptCondition>of(new EncryptEqualCondition(predicateSegment.getColumn().getName(), tableName, compareRightValue.getExpression().getStartIndex(), 
+                ? Optional.<EncryptCondition>of(new EncryptEqualCondition(predicateSegment.getColumn().getIdentifier().getValue(), tableName, compareRightValue.getExpression().getStartIndex(), 
                 predicateSegment.getStopIndex(), compareRightValue.getExpression()))
                 : Optional.<EncryptCondition>absent();
     }
@@ -130,8 +130,8 @@ public final class EncryptConditionEngine {
             }
         }
         return expressionSegments.isEmpty() ? Optional.<EncryptCondition>absent()
-                : Optional.<EncryptCondition>of(new EncryptInCondition(
-                        predicateSegment.getColumn().getName(), tableName, inRightValue.getSqlExpressions().iterator().next().getStartIndex(), predicateSegment.getStopIndex(), expressionSegments));
+                : Optional.<EncryptCondition>of(new EncryptInCondition(predicateSegment.getColumn().getIdentifier().getValue(), 
+                tableName, inRightValue.getSqlExpressions().iterator().next().getStartIndex(), predicateSegment.getStopIndex(), expressionSegments));
     }
     
     private boolean isSupportedOperator(final String operator) {

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/impl/EncryptAssignmentParameterRewriter.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/impl/EncryptAssignmentParameterRewriter.java
@@ -54,7 +54,7 @@ public final class EncryptAssignmentParameterRewriter extends EncryptParameterRe
     public void rewrite(final ParameterBuilder parameterBuilder, final SQLStatementContext sqlStatementContext, final List<Object> parameters) {
         String tableName = sqlStatementContext.getTablesContext().getSingleTableName();
         for (AssignmentSegment each : getSetAssignmentSegment(sqlStatementContext.getSqlStatement()).getAssignments()) {
-            if (each.getValue() instanceof ParameterMarkerExpressionSegment && getEncryptRule().findEncryptor(tableName, each.getColumn().getName()).isPresent()) {
+            if (each.getValue() instanceof ParameterMarkerExpressionSegment && getEncryptRule().findEncryptor(tableName, each.getColumn().getIdentifier().getValue()).isPresent()) {
                 StandardParameterBuilder standardParameterBuilder = parameterBuilder instanceof StandardParameterBuilder
                         ? (StandardParameterBuilder) parameterBuilder : ((GroupedParameterBuilder) parameterBuilder).getParameterBuilders().get(0);
                 encryptParameters(standardParameterBuilder, tableName, each, parameters);
@@ -72,7 +72,7 @@ public final class EncryptAssignmentParameterRewriter extends EncryptParameterRe
     }
     
     private void encryptParameters(final StandardParameterBuilder parameterBuilder, final String tableName, final AssignmentSegment assignmentSegment, final List<Object> parameters) {
-        String columnName = assignmentSegment.getColumn().getName();
+        String columnName = assignmentSegment.getColumn().getIdentifier().getValue();
         int parameterMarkerIndex = ((ParameterMarkerExpressionSegment) assignmentSegment.getValue()).getParameterMarkerIndex();
         Object originalValue = parameters.get(parameterMarkerIndex);
         Object cipherValue = getEncryptRule().getEncryptValues(tableName, columnName, Collections.singletonList(originalValue)).iterator().next();

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/impl/EncryptInsertOnDuplicateKeyUpdateValueParameterRewriter.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/impl/EncryptInsertOnDuplicateKeyUpdateValueParameterRewriter.java
@@ -60,13 +60,13 @@ public final class EncryptInsertOnDuplicateKeyUpdateValueParameterRewriter exten
         GroupedParameterBuilder groupedParameterBuilder = (GroupedParameterBuilder) parameterBuilder;
         for (AssignmentSegment each : onDuplicateKeyColumnsSegments) {
             ExpressionSegment expressionSegment = each.getValue();
-            Object cipherColumnValue = null;
+            Object cipherColumnValue;
             Object plainColumnValue = null;
             if (expressionSegment instanceof ParameterMarkerExpressionSegment) {
                 plainColumnValue = parameters.get(((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex());
             }
             if (queryWithCipherColumn) {
-                Optional<Encryptor> encryptor = getEncryptRule().findEncryptor(tableName, each.getColumn().getName());
+                Optional<Encryptor> encryptor = getEncryptRule().findEncryptor(tableName, each.getColumn().getIdentifier().getValue());
                 if (encryptor.isPresent()) {
                     cipherColumnValue = encryptor.get().encrypt(plainColumnValue);
                     groupedParameterBuilder.getOnDuplicateKeyUpdateAddedParameters().add(cipherColumnValue);

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/AssistQueryAndPlainInsertColumnsTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/AssistQueryAndPlainInsertColumnsTokenGenerator.java
@@ -63,11 +63,11 @@ public final class AssistQueryAndPlainInsertColumnsTokenGenerator extends BaseEn
     
     private List<String> getColumns(final EncryptTable encryptTable, final ColumnSegment columnSegment) {
         List<String> result = new LinkedList<>();
-        Optional<String> assistedQueryColumn = encryptTable.findAssistedQueryColumn(columnSegment.getName());
+        Optional<String> assistedQueryColumn = encryptTable.findAssistedQueryColumn(columnSegment.getIdentifier().getValue());
         if (assistedQueryColumn.isPresent()) {
             result.add(assistedQueryColumn.get());
         }
-        Optional<String> plainColumn = encryptTable.findPlainColumn(columnSegment.getName());
+        Optional<String> plainColumn = encryptTable.findPlainColumn(columnSegment.getIdentifier().getValue());
         if (plainColumn.isPresent()) {
             result.add(plainColumn.get());
         }

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptAssignmentTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptAssignmentTokenGenerator.java
@@ -56,7 +56,7 @@ public final class EncryptAssignmentTokenGenerator extends BaseEncryptSQLTokenGe
         Collection<EncryptAssignmentToken> result = new LinkedList<>();
         String tableName = sqlStatementContext.getTablesContext().getSingleTableName();
         for (AssignmentSegment each : getSetAssignmentSegment(sqlStatementContext.getSqlStatement()).getAssignments()) {
-            if (getEncryptRule().findEncryptor(tableName, each.getColumn().getName()).isPresent()) {
+            if (getEncryptRule().findEncryptor(tableName, each.getColumn().getIdentifier().getValue()).isPresent()) {
                 Optional<EncryptAssignmentToken> sqlToken = generateSQLToken(tableName, each);
                 if (sqlToken.isPresent()) {
                     result.add(sqlToken.get());
@@ -87,7 +87,7 @@ public final class EncryptAssignmentTokenGenerator extends BaseEncryptSQLTokenGe
     
     private EncryptAssignmentToken generateParameterSQLToken(final String tableName, final AssignmentSegment assignmentSegment) {
         EncryptParameterAssignmentToken result = new EncryptParameterAssignmentToken(assignmentSegment.getColumn().getStartIndex(), assignmentSegment.getStopIndex());
-        String columnName = assignmentSegment.getColumn().getName();
+        String columnName = assignmentSegment.getColumn().getIdentifier().getValue();
         addCipherColumn(tableName, columnName, result);
         addAssistedQueryColumn(tableName, columnName, result);
         addPlainColumn(tableName, columnName, result);
@@ -122,22 +122,23 @@ public final class EncryptAssignmentTokenGenerator extends BaseEncryptSQLTokenGe
     
     private void addCipherAssignment(final String tableName, final AssignmentSegment assignmentSegment, final EncryptLiteralAssignmentToken token) {
         Object originalValue = ((LiteralExpressionSegment) assignmentSegment.getValue()).getLiterals();
-        Object cipherValue = getEncryptRule().getEncryptValues(tableName, assignmentSegment.getColumn().getName(), Collections.singletonList(originalValue)).iterator().next();
-        token.addAssignment(getEncryptRule().getCipherColumn(tableName, assignmentSegment.getColumn().getName()), cipherValue);
+        Object cipherValue = getEncryptRule().getEncryptValues(tableName, assignmentSegment.getColumn().getIdentifier().getValue(), Collections.singletonList(originalValue)).iterator().next();
+        token.addAssignment(getEncryptRule().getCipherColumn(tableName, assignmentSegment.getColumn().getIdentifier().getValue()), cipherValue);
     }
     
     private void addAssistedQueryAssignment(final String tableName, final AssignmentSegment assignmentSegment, final EncryptLiteralAssignmentToken token) {
         Object originalValue = ((LiteralExpressionSegment) assignmentSegment.getValue()).getLiterals();
-        Optional<String> assistedQueryColumn = getEncryptRule().findAssistedQueryColumn(tableName, assignmentSegment.getColumn().getName());
+        Optional<String> assistedQueryColumn = getEncryptRule().findAssistedQueryColumn(tableName, assignmentSegment.getColumn().getIdentifier().getValue());
         if (assistedQueryColumn.isPresent()) {
-            Object assistedQueryValue = getEncryptRule().getEncryptAssistedQueryValues(tableName, assignmentSegment.getColumn().getName(), Collections.singletonList(originalValue)).iterator().next();
+            Object assistedQueryValue = getEncryptRule().getEncryptAssistedQueryValues(
+                    tableName, assignmentSegment.getColumn().getIdentifier().getValue(), Collections.singletonList(originalValue)).iterator().next();
             token.addAssignment(assistedQueryColumn.get(), assistedQueryValue);
         }
     }
     
     private void addPlainAssignment(final String tableName, final AssignmentSegment assignmentSegment, final EncryptLiteralAssignmentToken token) {
         Object originalValue = ((LiteralExpressionSegment) assignmentSegment.getValue()).getLiterals();
-        Optional<String> plainColumn = getEncryptRule().findPlainColumn(tableName, assignmentSegment.getColumn().getName());
+        Optional<String> plainColumn = getEncryptRule().findPlainColumn(tableName, assignmentSegment.getColumn().getIdentifier().getValue());
         if (plainColumn.isPresent()) {
             token.addAssignment(plainColumn.get(), originalValue);
         }

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptInsertOnUpdateTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptInsertOnUpdateTokenGenerator.java
@@ -56,7 +56,7 @@ public final class EncryptInsertOnUpdateTokenGenerator extends BaseEncryptSQLTok
             return result;
         }
         for (AssignmentSegment each : onDuplicateKeyColumnsSegments) {
-            if (getEncryptRule().findEncryptor(tableName, each.getColumn().getName()).isPresent()) {
+            if (getEncryptRule().findEncryptor(tableName, each.getColumn().getIdentifier().getValue()).isPresent()) {
                 Optional<EncryptAssignmentToken> sqlToken = generateSQLToken(tableName, each);
                 if (sqlToken.isPresent()) {
                     result.add(sqlToken.get());
@@ -78,7 +78,7 @@ public final class EncryptInsertOnUpdateTokenGenerator extends BaseEncryptSQLTok
 
     private EncryptAssignmentToken generateParameterSQLToken(final String tableName, final AssignmentSegment assignmentSegment) {
         EncryptParameterAssignmentToken result = new EncryptParameterAssignmentToken(assignmentSegment.getColumn().getStartIndex(), assignmentSegment.getStopIndex());
-        String columnName = assignmentSegment.getColumn().getName();
+        String columnName = assignmentSegment.getColumn().getIdentifier().getValue();
         addCipherColumn(tableName, columnName, result);
         addPlainColumn(tableName, columnName, result);
         return result;
@@ -104,13 +104,13 @@ public final class EncryptInsertOnUpdateTokenGenerator extends BaseEncryptSQLTok
 
     private void addCipherAssignment(final String tableName, final AssignmentSegment assignmentSegment, final EncryptLiteralAssignmentToken token) {
         Object originalValue = ((LiteralExpressionSegment) assignmentSegment.getValue()).getLiterals();
-        Object cipherValue = getEncryptRule().getEncryptValues(tableName, assignmentSegment.getColumn().getName(), Collections.singletonList(originalValue)).iterator().next();
-        token.addAssignment(getEncryptRule().getCipherColumn(tableName, assignmentSegment.getColumn().getName()), cipherValue);
+        Object cipherValue = getEncryptRule().getEncryptValues(tableName, assignmentSegment.getColumn().getIdentifier().getValue(), Collections.singletonList(originalValue)).iterator().next();
+        token.addAssignment(getEncryptRule().getCipherColumn(tableName, assignmentSegment.getColumn().getIdentifier().getValue()), cipherValue);
     }
 
     private void addPlainAssignment(final String tableName, final AssignmentSegment assignmentSegment, final EncryptLiteralAssignmentToken token) {
         Object originalValue = ((LiteralExpressionSegment) assignmentSegment.getValue()).getLiterals();
-        Optional<String> plainColumn = getEncryptRule().findPlainColumn(tableName, assignmentSegment.getColumn().getName());
+        Optional<String> plainColumn = getEncryptRule().findPlainColumn(tableName, assignmentSegment.getColumn().getIdentifier().getValue());
         if (plainColumn.isPresent()) {
             token.addAssignment(plainColumn.get(), originalValue);
         }

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptPredicateColumnTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptPredicateColumnTokenGenerator.java
@@ -68,21 +68,21 @@ public final class EncryptPredicateColumnTokenGenerator extends BaseEncryptSQLTo
         Collection<SubstitutableColumnNameToken> result = new LinkedList<>();
         for (PredicateSegment each : andPredicate.getPredicates()) {
             Optional<EncryptTable> encryptTable = findEncryptTable(sqlStatementContext, each);
-            if (!encryptTable.isPresent() || !encryptTable.get().findEncryptor(each.getColumn().getName()).isPresent()) {
+            if (!encryptTable.isPresent() || !encryptTable.get().findEncryptor(each.getColumn().getIdentifier().getValue()).isPresent()) {
                 continue;
             }
             int startIndex = each.getColumn().getOwner().isPresent() ? each.getColumn().getOwner().get().getStopIndex() + 2 : each.getColumn().getStartIndex();
             int stopIndex = each.getColumn().getStopIndex();
             if (!queryWithCipherColumn) { 
-                Optional<String> plainColumn = encryptTable.get().findPlainColumn(each.getColumn().getName());
+                Optional<String> plainColumn = encryptTable.get().findPlainColumn(each.getColumn().getIdentifier().getValue());
                 if (plainColumn.isPresent()) {
                     result.add(new SubstitutableColumnNameToken(startIndex, stopIndex, plainColumn.get()));
                     continue;
                 }
             }
-            Optional<String> assistedQueryColumn = encryptTable.get().findAssistedQueryColumn(each.getColumn().getName());
+            Optional<String> assistedQueryColumn = encryptTable.get().findAssistedQueryColumn(each.getColumn().getIdentifier().getValue());
             SubstitutableColumnNameToken encryptColumnNameToken = assistedQueryColumn.isPresent() ? new SubstitutableColumnNameToken(startIndex, stopIndex, assistedQueryColumn.get())
-                    : new SubstitutableColumnNameToken(startIndex, stopIndex, encryptTable.get().getCipherColumn(each.getColumn().getName()));
+                    : new SubstitutableColumnNameToken(startIndex, stopIndex, encryptTable.get().getCipherColumn(each.getColumn().getIdentifier().getValue()));
             result.add(encryptColumnNameToken);
         }
         return result;

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
@@ -71,12 +71,12 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
     }
     
     private boolean isEncryptLogicColumn(final ProjectionSegment projectionSegment, final EncryptTable encryptTable) {
-        return projectionSegment instanceof ColumnProjectionSegment && encryptTable.getLogicColumns().contains(((ColumnProjectionSegment) projectionSegment).getName());
+        return projectionSegment instanceof ColumnProjectionSegment && encryptTable.getLogicColumns().contains(((ColumnProjectionSegment) projectionSegment).getIdentifier().getValue());
     }
     
     private SubstitutableColumnNameToken generateSQLToken(final ColumnProjectionSegment segment, final String tableName) {
-        Optional<String> plainColumn = getEncryptRule().findPlainColumn(tableName, segment.getName());
-        String columnName = plainColumn.isPresent() && !queryWithCipherColumn ? plainColumn.get() : getEncryptRule().getCipherColumn(tableName, segment.getName());
+        Optional<String> plainColumn = getEncryptRule().findPlainColumn(tableName, segment.getIdentifier().getValue());
+        String columnName = plainColumn.isPresent() && !queryWithCipherColumn ? plainColumn.get() : getEncryptRule().getCipherColumn(tableName, segment.getIdentifier().getValue());
         return segment.getOwner().isPresent() ? new SubstitutableColumnNameToken(segment.getOwner().get().getStopIndex() + 2, segment.getStopIndex(), columnName)
                 : new SubstitutableColumnNameToken(segment.getStartIndex(), segment.getStopIndex(), columnName);
     }

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/InsertCipherNameTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/InsertCipherNameTokenGenerator.java
@@ -51,8 +51,8 @@ public final class InsertCipherNameTokenGenerator extends BaseEncryptSQLTokenGen
         Map<String, String> logicAndCipherColumns = getEncryptRule().getLogicAndCipherColumns(sqlStatementContext.getTablesContext().getSingleTableName());
         Collection<SubstitutableColumnNameToken> result = new LinkedList<>();
         for (ColumnSegment each : sqlSegment.get().getColumns()) {
-            if (logicAndCipherColumns.keySet().contains(each.getName())) {
-                result.add(new SubstitutableColumnNameToken(each.getStartIndex(), each.getStopIndex(), logicAndCipherColumns.get(each.getName())));
+            if (logicAndCipherColumns.keySet().contains(each.getIdentifier().getValue())) {
+                result.add(new SubstitutableColumnNameToken(each.getStartIndex(), each.getStopIndex(), logicAndCipherColumns.get(each.getIdentifier().getValue())));
             }
         }
         return result;

--- a/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/condition/ShadowConditionEngine.java
+++ b/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/condition/ShadowConditionEngine.java
@@ -80,7 +80,8 @@ public final class ShadowConditionEngine {
         for (PredicateSegment predicate : andPredicate.getPredicates()) {
             Collection<Integer> stopIndexes = new HashSet<>();
             if (stopIndexes.add(predicate.getStopIndex())) {
-                Optional<ShadowCondition> condition = shadowRule.getColumn().equals(predicate.getColumn().getName()) ? createShadowCondition(predicate) : Optional.<ShadowCondition>absent();
+                Optional<ShadowCondition> condition = shadowRule.getColumn().equals(predicate.getColumn().getIdentifier().getValue())
+                        ? createShadowCondition(predicate) : Optional.<ShadowCondition>absent();
                 if (condition.isPresent()) {
                     return condition;
                 }
@@ -105,7 +106,7 @@ public final class ShadowConditionEngine {
     
     private static Optional<ShadowCondition> createCompareShadowCondition(final PredicateSegment predicateSegment, final PredicateCompareRightValue compareRightValue) {
         return compareRightValue.getExpression() instanceof SimpleExpressionSegment
-                ? Optional.of(new ShadowCondition(predicateSegment.getColumn().getName(), compareRightValue.getExpression().getStartIndex(),
+                ? Optional.of(new ShadowCondition(predicateSegment.getColumn().getIdentifier().getValue(), compareRightValue.getExpression().getStartIndex(),
                 predicateSegment.getStopIndex(), compareRightValue.getExpression()))
                 : Optional.<ShadowCondition>absent();
     }

--- a/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/judgement/impl/PreparedJudgementEngine.java
+++ b/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/judgement/impl/PreparedJudgementEngine.java
@@ -55,7 +55,7 @@ public final class PreparedJudgementEngine implements ShadowJudgementEngine {
         if (sqlStatementContext.getSqlStatement() instanceof InsertStatement) {
             LinkedList<ColumnSegment> columnSegments = (LinkedList<ColumnSegment>) ((InsertStatement) sqlStatementContext.getSqlStatement()).getColumns();
             for (int i = 0; i < columnSegments.size(); i++) {
-                if (columnSegments.get(i).getName().equals(shadowRule.getColumn())) {
+                if (columnSegments.get(i).getIdentifier().getValue().equals(shadowRule.getColumn())) {
                     final Object value = parameters.get(i);
                     return value instanceof Boolean && (Boolean) value;
                 }
@@ -79,7 +79,7 @@ public final class PreparedJudgementEngine implements ShadowJudgementEngine {
     
     private boolean judgePredicateSegments(final Collection<PredicateSegment> predicates) {
         for (PredicateSegment each : predicates) {
-            if (each.getColumn().getName().equals(shadowRule.getColumn())) {
+            if (each.getColumn().getIdentifier().getValue().equals(shadowRule.getColumn())) {
                 Preconditions.checkArgument(each.getRightValue() instanceof PredicateCompareRightValue, "must be PredicateCompareRightValue");
                 PredicateCompareRightValue rightValue = (PredicateCompareRightValue) each.getRightValue();
                 int parameterMarkerIndex = ((ParameterMarkerExpressionSegment) rightValue.getExpression()).getParameterMarkerIndex();

--- a/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/token/generator/impl/RemoveShadowColumnTokenGenerator.java
+++ b/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/token/generator/impl/RemoveShadowColumnTokenGenerator.java
@@ -50,7 +50,7 @@ public final class RemoveShadowColumnTokenGenerator extends BaseShadowSQLTokenGe
         Collection<RemoveToken> result = new LinkedList<>();
         LinkedList<ColumnSegment> columns = (LinkedList<ColumnSegment>) sqlSegment.get().getColumns();
         for (int i = 0; i < columns.size(); i++) {
-            if (getShadowRule().getColumn().equals(columns.get(i).getName())) {
+            if (getShadowRule().getColumn().equals(columns.get(i).getIdentifier().getValue())) {
                 if (i == 0) {
                     result.add(new RemoveToken(columns.get(i).getStartIndex(), columns.get(i + 1).getStartIndex() - 1));
                 } else {

--- a/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/token/generator/impl/ShadowPredicateColumnTokenGenerator.java
+++ b/shadow-core/shadow-core-rewrite/src/main/java/org/apache/shardingsphere/shadow/rewrite/token/generator/impl/ShadowPredicateColumnTokenGenerator.java
@@ -58,7 +58,7 @@ public final class ShadowPredicateColumnTokenGenerator extends BaseShadowSQLToke
         Collection<SQLToken> result = new LinkedList<>();
         LinkedList<PredicateSegment> predicates = (LinkedList<PredicateSegment>) andPredicate.getPredicates();
         for (int i = 0; i < predicates.size(); i++) {
-            if (!getShadowRule().getColumn().equals(predicates.get(i).getColumn().getName())) {
+            if (!getShadowRule().getColumn().equals(predicates.get(i).getColumn().getIdentifier().getValue())) {
                 continue;
             }
             if (predicates.size() == 1) {

--- a/shadow-core/shadow-core-rewrite/src/test/java/org/apache/shardingsphere/shadow/rewrite/judgement/impl/PreparedJudgementEngineTest.java
+++ b/shadow-core/shadow-core-rewrite/src/test/java/org/apache/shardingsphere/shadow/rewrite/judgement/impl/PreparedJudgementEngineTest.java
@@ -19,12 +19,12 @@ package org.apache.shardingsphere.shadow.rewrite.judgement.impl;
 
 import org.apache.shardingsphere.api.config.shadow.ShadowRuleConfiguration;
 import org.apache.shardingsphere.core.rule.ShadowRule;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.metadata.RelationMetas;
 import org.apache.shardingsphere.sql.parser.relation.statement.impl.InsertSQLStatementContext;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.InsertColumnsSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.InsertStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class PreparedJudgementEngineTest {
         InsertStatement insertStatement = new InsertStatement();
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
         insertColumnsSegment.getColumns().addAll(
-                Arrays.asList(new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new ColumnSegment(0, 0, "name", QuoteCharacter.NONE), new ColumnSegment(0, 0, "shadow", QuoteCharacter.NONE)));
+                Arrays.asList(new ColumnSegment(0, 0, new IdentifierValue("id")), new ColumnSegment(0, 0, new IdentifierValue("name")), new ColumnSegment(0, 0, new IdentifierValue("shadow"))));
         insertStatement.setColumns(insertColumnsSegment);
         InsertSQLStatementContext insertSQLStatementContext = new InsertSQLStatementContext(relationMetas, Arrays.<Object>asList(1, "Tom", 2, "Jerry", 3, true), insertStatement);
         PreparedJudgementEngine preparedJudgementEngine = new PreparedJudgementEngine(shadowRule, insertSQLStatementContext, Arrays.<Object>asList(1, "Tom", true));

--- a/shadow-core/shadow-core-rewrite/src/test/java/org/apache/shardingsphere/shadow/rewrite/judgement/impl/SimpleJudgementEngineTest.java
+++ b/shadow-core/shadow-core-rewrite/src/test/java/org/apache/shardingsphere/shadow/rewrite/judgement/impl/SimpleJudgementEngineTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.shadow.rewrite.judgement.impl;
 
 import org.apache.shardingsphere.api.config.shadow.ShadowRuleConfiguration;
 import org.apache.shardingsphere.core.rule.ShadowRule;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.metadata.RelationMetas;
 import org.apache.shardingsphere.sql.parser.relation.statement.impl.InsertSQLStatementContext;
 import org.apache.shardingsphere.sql.parser.relation.statement.impl.SelectSQLStatementContext;
@@ -36,6 +35,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.WhereSegme
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateCompareRightValue;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,12 +47,12 @@ import java.util.Collections;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SimpleJudgementEngineTest {
-
+public final class SimpleJudgementEngineTest {
+    
     private RelationMetas relationMetas;
-
+    
     private ShadowRule shadowRule;
-
+    
     @Before
     public void setUp() {
         relationMetas = mock(RelationMetas.class);
@@ -61,14 +61,13 @@ public class SimpleJudgementEngineTest {
         shadowRuleConfiguration.setColumn("shadow");
         shadowRule = new ShadowRule(shadowRuleConfiguration);
     }
-
+    
     @Test
     public void judgeForInsert() {
         InsertStatement insertStatement = new InsertStatement();
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
-        insertColumnsSegment.getColumns().addAll(Arrays.asList(new ColumnSegment(0, 0, "id", QuoteCharacter.NONE),
-                new ColumnSegment(0, 0, "name", QuoteCharacter.NONE),
-                new ColumnSegment(0, 0, "shadow", QuoteCharacter.NONE)));
+        insertColumnsSegment.getColumns().addAll(
+                Arrays.asList(new ColumnSegment(0, 0, new IdentifierValue("id")), new ColumnSegment(0, 0, new IdentifierValue("name")), new ColumnSegment(0, 0, new IdentifierValue("shadow"))));
         insertStatement.setColumns(insertColumnsSegment);
         insertStatement.getValues()
                 .addAll(Collections.singletonList(new InsertValuesSegment(0, 0, new ArrayList<ExpressionSegment>() {
@@ -81,7 +80,6 @@ public class SimpleJudgementEngineTest {
         InsertSQLStatementContext insertSQLStatementContext = new InsertSQLStatementContext(relationMetas, Collections.emptyList(), insertStatement);
         SimpleJudgementEngine simpleJudgementEngine = new SimpleJudgementEngine(shadowRule, insertSQLStatementContext);
         Assert.assertTrue("should be shadow", simpleJudgementEngine.isShadowSQL());
-
         insertStatement.getValues().clear();
         insertStatement.getValues()
                 .addAll(Collections.singletonList(new InsertValuesSegment(0, 0, new ArrayList<ExpressionSegment>() {
@@ -95,33 +93,28 @@ public class SimpleJudgementEngineTest {
         simpleJudgementEngine = new SimpleJudgementEngine(shadowRule, insertSQLStatementContext);
         Assert.assertFalse("should not be shadow", simpleJudgementEngine.isShadowSQL());
     }
-
+    
     @Test
     public void judgeForWhereSegment() {
         SelectStatement selectStatement = new SelectStatement();
         WhereSegment whereSegment = new WhereSegment(0, 0);
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().addAll(Collections.singletonList(new PredicateSegment(0, 0,
-                new ColumnSegment(0, 0, "shadow", QuoteCharacter.NONE),
-                new PredicateCompareRightValue("=", new LiteralExpressionSegment(0, 0, "true")))));
+        andPredicate.getPredicates().addAll(Collections.singletonList(
+                new PredicateSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("shadow")), new PredicateCompareRightValue("=", new LiteralExpressionSegment(0, 0, "true")))));
         whereSegment.getAndPredicates().addAll(Collections.singletonList(andPredicate));
         selectStatement.setWhere(whereSegment);
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
         projectionsSegment.setDistinctRow(true);
-        projectionsSegment.getProjections()
-                .addAll(Collections.singletonList(new ExpressionProjectionSegment(0, 0, "true")));
+        projectionsSegment.getProjections().addAll(Collections.singletonList(new ExpressionProjectionSegment(0, 0, "true")));
         selectStatement.setProjections(projectionsSegment);
         SelectSQLStatementContext selectSQLStatementContext = new SelectSQLStatementContext(relationMetas, "", Collections.emptyList(), selectStatement);
         SimpleJudgementEngine simpleJudgementEngine = new SimpleJudgementEngine(shadowRule, selectSQLStatementContext);
         Assert.assertTrue("should be shadow", simpleJudgementEngine.isShadowSQL());
-
         andPredicate.getPredicates().clear();
-        andPredicate.getPredicates().addAll(Collections.singletonList(new PredicateSegment(0, 0,
-                new ColumnSegment(0, 0, "shadow", QuoteCharacter.NONE),
-                new PredicateCompareRightValue("=", new LiteralExpressionSegment(0, 0, "false")))));
+        andPredicate.getPredicates().addAll(Collections.singletonList(
+                new PredicateSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("shadow")), new PredicateCompareRightValue("=", new LiteralExpressionSegment(0, 0, "false")))));
         projectionsSegment.getProjections().clear();
-        projectionsSegment.getProjections()
-                .addAll(Collections.singletonList(new ExpressionProjectionSegment(0, 0, "false")));
+        projectionsSegment.getProjections().addAll(Collections.singletonList(new ExpressionProjectionSegment(0, 0, "false")));
         Assert.assertFalse("should not be shadow", simpleJudgementEngine.isShadowSQL());
     }
 }

--- a/sharding-core/sharding-core-merge/src/test/java/org/apache/shardingsphere/sharding/merge/ShardingResultMergerEngineTest.java
+++ b/sharding-core/sharding-core-merge/src/test/java/org/apache/shardingsphere/sharding/merge/ShardingResultMergerEngineTest.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dal.dialect.postgresql.ShowStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.underlying.common.constant.properties.ShardingSphereProperties;
 import org.apache.shardingsphere.underlying.common.database.type.DatabaseTypes;
 import org.apache.shardingsphere.underlying.merge.engine.merger.impl.TransparentResultMerger;
@@ -68,7 +69,7 @@ public final class ShardingResultMergerEngineTest {
     @Test
     public void assertNewInstanceWithOtherStatement() {
         InsertStatement insertStatement = new InsertStatement();
-        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, "tbl", QuoteCharacter.NONE));
+        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl")));
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
         insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, "col", QuoteCharacter.NONE));
         insertStatement.setColumns(insertColumnsSegment);

--- a/sharding-core/sharding-core-merge/src/test/java/org/apache/shardingsphere/sharding/merge/ShardingResultMergerEngineTest.java
+++ b/sharding-core/sharding-core-merge/src/test/java/org/apache/shardingsphere/sharding/merge/ShardingResultMergerEngineTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sharding.merge;
 
 import org.apache.shardingsphere.sharding.merge.dal.ShardingDALResultMerger;
 import org.apache.shardingsphere.sharding.merge.dql.ShardingDQLResultMerger;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByItem;
@@ -71,7 +70,7 @@ public final class ShardingResultMergerEngineTest {
         InsertStatement insertStatement = new InsertStatement();
         insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl")));
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
-        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, "col", QuoteCharacter.NONE));
+        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("col")));
         insertStatement.setColumns(insertColumnsSegment);
         SQLStatementContext sqlStatementContext = new InsertSQLStatementContext(null, Collections.emptyList(), insertStatement);
         ShardingSphereProperties properties = new ShardingSphereProperties(new Properties());

--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/IndexTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/IndexTokenGenerator.java
@@ -43,7 +43,7 @@ public final class IndexTokenGenerator implements CollectionSQLTokenGenerator {
     public Collection<IndexToken> generateSQLTokens(final SQLStatementContext sqlStatementContext) {
         Collection<IndexToken> result = new LinkedList<>();
         for (SQLSegment each : sqlStatementContext.getSqlStatement().findSQLSegments(IndexSegment.class)) {
-            result.add(new IndexToken(each.getStartIndex(), each.getStopIndex(), ((IndexSegment) each).getName(), ((IndexSegment) each).getQuoteCharacter()));
+            result.add(new IndexToken(each.getStartIndex(), each.getStopIndex(), ((IndexSegment) each).getIdentifier().getValue(), ((IndexSegment) each).getIdentifier().getQuoteCharacter()));
         }
         return result;
     }

--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/OrderByTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/OrderByTokenGenerator.java
@@ -46,7 +46,7 @@ public final class OrderByTokenGenerator implements OptionalSQLTokenGenerator, I
         for (OrderByItem each : ((SelectSQLStatementContext) sqlStatementContext).getOrderByContext().getItems()) {
             if (each.getSegment() instanceof ColumnOrderByItemSegment) {
                 ColumnOrderByItemSegment columnOrderByItemSegment = (ColumnOrderByItemSegment) each.getSegment();
-                QuoteCharacter quoteCharacter = columnOrderByItemSegment.getColumn().getQuoteCharacter();
+                QuoteCharacter quoteCharacter = columnOrderByItemSegment.getColumn().getIdentifier().getQuoteCharacter();
                 columnLabel = quoteCharacter.getStartDelimiter() + columnOrderByItemSegment.getText() + quoteCharacter.getEndDelimiter();
             } else if (each.getSegment() instanceof ExpressionOrderByItemSegment) {
                 columnLabel = ((ExpressionOrderByItemSegment) each.getSegment()).getText();

--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/TableTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/TableTokenGenerator.java
@@ -92,21 +92,21 @@ public final class TableTokenGenerator implements CollectionSQLTokenGenerator, S
     private Optional<TableToken> generateSQLToken(final SQLStatementContext sqlStatementContext, final OwnerAvailable<TableSegment> segment) {
         Optional<TableSegment> owner = segment.getOwner();
         return owner.isPresent() && isToGenerateTableToken(sqlStatementContext, owner.get())
-                ? Optional.of(new TableToken(owner.get().getStartIndex(), owner.get().getStopIndex(), owner.get().getTableName(), owner.get().getTableQuoteCharacter()))
+                ? Optional.of(new TableToken(owner.get().getStartIndex(), owner.get().getStopIndex(), owner.get().getTable().getValue(), owner.get().getTable().getQuoteCharacter()))
                 : Optional.<TableToken>absent();
     }
     
     private Optional<TableToken> generateSQLToken(final SQLStatement sqlStatement, final TableAvailable segment) {
         return isToGenerateTableToken(sqlStatement, segment)
-                ? Optional.of(new TableToken(segment.getStartIndex(), segment.getStopIndex(), segment.getTableName(), segment.getTableQuoteCharacter())) : Optional.<TableToken>absent();
+                ? Optional.of(new TableToken(segment.getStartIndex(), segment.getStopIndex(), segment.getTable().getValue(), segment.getTable().getQuoteCharacter())) : Optional.<TableToken>absent();
     }
     
     private boolean isToGenerateTableToken(final SQLStatementContext sqlStatementContext, final TableSegment tableSegment) {
-        Optional<Table> table = sqlStatementContext.getTablesContext().find(tableSegment.getTableName());
+        Optional<Table> table = sqlStatementContext.getTablesContext().find(tableSegment.getTable().getValue());
         return table.isPresent() && !table.get().getAlias().isPresent() && shardingRule.findTableRule(table.get().getName()).isPresent();
     }
     
     private boolean isToGenerateTableToken(final SQLStatement sqlStatement, final TableAvailable segment) {
-        return shardingRule.findTableRule(segment.getTableName()).isPresent() || !(sqlStatement instanceof SelectStatement);
+        return shardingRule.findTableRule(segment.getTable().getValue()).isPresent() || !(sqlStatement instanceof SelectStatement);
     }
 }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngine.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngine.java
@@ -103,10 +103,10 @@ public final class WhereClauseShardingConditionEngine {
         Map<Column, Collection<RouteValue>> result = new HashMap<>();
         for (PredicateSegment each : andPredicate.getPredicates()) {
             Optional<String> tableName = tablesContext.findTableName(each.getColumn(), relationMetas);
-            if (!tableName.isPresent() || !shardingRule.isShardingColumn(each.getColumn().getName(), tableName.get())) {
+            if (!tableName.isPresent() || !shardingRule.isShardingColumn(each.getColumn().getIdentifier().getValue(), tableName.get())) {
                 continue;
             }
-            Column column = new Column(each.getColumn().getName(), tableName.get());
+            Column column = new Column(each.getColumn().getIdentifier().getValue(), tableName.get());
             Optional<RouteValue> routeValue = ConditionValueGeneratorFactory.generate(each.getRightValue(), column, parameters);
             if (!routeValue.isPresent()) {
                 continue;

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/keygen/GeneratedKey.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/keygen/GeneratedKey.java
@@ -60,7 +60,7 @@ public final class GeneratedKey {
      * @return generate key
      */
     public static Optional<GeneratedKey> getGenerateKey(final ShardingRule shardingRule, final TableMetas tableMetas, final List<Object> parameters, final InsertStatement insertStatement) {
-        Optional<String> generateKeyColumnName = shardingRule.findGenerateKeyColumnName(insertStatement.getTable().getTableName());
+        Optional<String> generateKeyColumnName = shardingRule.findGenerateKeyColumnName(insertStatement.getTable().getTable().getValue());
         if (!generateKeyColumnName.isPresent()) {
             return Optional.absent();
         }
@@ -70,7 +70,7 @@ public final class GeneratedKey {
     
     private static boolean containsGenerateKey(final TableMetas tableMetas, final InsertStatement insertStatement, final String generateKeyColumnName) {
         return insertStatement.getColumnNames().isEmpty()
-                ? tableMetas.getAllColumnNames(insertStatement.getTable().getTableName()).size() == insertStatement.getValueCountForPerGroup()
+                ? tableMetas.getAllColumnNames(insertStatement.getTable().getTable().getValue()).size() == insertStatement.getValueCountForPerGroup()
                 : insertStatement.getColumnNames().contains(generateKeyColumnName);
     }
     
@@ -96,13 +96,13 @@ public final class GeneratedKey {
     
     private static int findGenerateKeyIndex(final TableMetas tableMetas, final InsertStatement insertStatement, final String generateKeyColumnName) {
         return insertStatement.getColumnNames().isEmpty()
-                ? tableMetas.getAllColumnNames(insertStatement.getTable().getTableName()).indexOf(generateKeyColumnName) : insertStatement.getColumnNames().indexOf(generateKeyColumnName);
+                ? tableMetas.getAllColumnNames(insertStatement.getTable().getTable().getValue()).indexOf(generateKeyColumnName) : insertStatement.getColumnNames().indexOf(generateKeyColumnName);
     }
     
     private static GeneratedKey createGeneratedKey(final ShardingRule shardingRule, final InsertStatement insertStatement, final String generateKeyColumnName) {
         GeneratedKey result = new GeneratedKey(generateKeyColumnName, true);
         for (int i = 0; i < insertStatement.getValueListCount(); i++) {
-            result.getGeneratedValues().add(shardingRule.generateKey(insertStatement.getTable().getTableName()));
+            result.getGeneratedValues().add(shardingRule.generateKey(insertStatement.getTable().getTable().getValue()));
         }
         return result;
     }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
@@ -66,8 +66,8 @@ public final class ShardingTableBroadcastRoutingEngine implements ShardingRouteE
     private Collection<String> getTableNamesFromMetaData(final DropIndexStatement dropIndexStatement) {
         Collection<String> result = new LinkedList<>();
         for (IndexSegment each : dropIndexStatement.getIndexes()) {
-            Optional<String> tableName = findLogicTableNameFromMetaData(each.getName());
-            Preconditions.checkState(tableName.isPresent(), "Cannot find index name `%s`.", each.getName());
+            Optional<String> tableName = findLogicTableNameFromMetaData(each.getIdentifier().getValue());
+            Preconditions.checkState(tableName.isPresent(), "Cannot find index name `%s`.", each.getIdentifier().getValue());
             result.add(tableName.get());
         }
         return result;

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidator.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidator.java
@@ -44,7 +44,7 @@ public final class ShardingInsertStatementValidator implements ShardingStatement
     
     private boolean isUpdateShardingKey(final ShardingRule shardingRule, final OnDuplicateKeyColumnsSegment onDuplicateKeyColumnsSegment, final String tableName) {
         for (AssignmentSegment each : onDuplicateKeyColumnsSegment.getColumns()) {
-            if (shardingRule.isShardingColumn(each.getColumn().getName(), tableName)) {
+            if (shardingRule.isShardingColumn(each.getColumn().getIdentifier().getValue(), tableName)) {
                 return true;
             }
         }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidator.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidator.java
@@ -37,7 +37,7 @@ public final class ShardingInsertStatementValidator implements ShardingStatement
     @Override
     public void validate(final ShardingRule shardingRule, final InsertStatement sqlStatement, final List<Object> parameters) {
         Optional<OnDuplicateKeyColumnsSegment> onDuplicateKeyColumnsSegment = sqlStatement.findSQLSegment(OnDuplicateKeyColumnsSegment.class);
-        if (onDuplicateKeyColumnsSegment.isPresent() && isUpdateShardingKey(shardingRule, onDuplicateKeyColumnsSegment.get(), sqlStatement.getTable().getTableName())) {
+        if (onDuplicateKeyColumnsSegment.isPresent() && isUpdateShardingKey(shardingRule, onDuplicateKeyColumnsSegment.get(), sqlStatement.getTable().getTable().getValue())) {
             throw new ShardingSphereException("INSERT INTO .... ON DUPLICATE KEY UPDATE can not support update for sharding column.");
         }
     }

--- a/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidator.java
+++ b/sharding-core/sharding-core-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidator.java
@@ -48,7 +48,7 @@ public final class ShardingUpdateStatementValidator implements ShardingStatement
     public void validate(final ShardingRule shardingRule, final UpdateStatement sqlStatement, final List<Object> parameters) {
         String tableName = new TablesContext(sqlStatement).getSingleTableName();
         for (AssignmentSegment each : sqlStatement.getSetAssignment().getAssignments()) {
-            String shardingColumn = each.getColumn().getName();
+            String shardingColumn = each.getColumn().getIdentifier().getValue();
             if (shardingRule.isShardingColumn(shardingColumn, tableName)) {
                 Optional<Object> shardingColumnSetAssignmentValue = getShardingColumnSetAssignmentValue(each, parameters);
                 Optional<Object> shardingValue = Optional.absent();
@@ -88,7 +88,7 @@ public final class ShardingUpdateStatementValidator implements ShardingStatement
     
     private Optional<Object> getShardingValue(final AndPredicate andPredicate, final List<Object> parameters, final String shardingColumn) {
         for (PredicateSegment each : andPredicate.getPredicates()) {
-            if (!shardingColumn.equalsIgnoreCase(each.getColumn().getName())) {
+            if (!shardingColumn.equalsIgnoreCase(each.getColumn().getIdentifier().getValue())) {
                 continue;
             }
             PredicateRightValue rightValue = each.getRightValue();

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/keygen/GeneratedKeyTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/keygen/GeneratedKeyTest.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.LiteralE
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.InsertStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.underlying.common.metadata.table.TableMetas;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public final class GeneratedKeyTest {
     
     @Before
     public void setUp() {
-        insertStatement.setTable(new TableSegment(0, 0, "tbl", QuoteCharacter.NONE));
+        insertStatement.setTable(new TableSegment(0, 0, new IdentifierValue("tbl")));
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
         insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, "id", QuoteCharacter.NONE));
         insertStatement.setColumns(insertColumnsSegment);

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/keygen/GeneratedKeyTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/keygen/GeneratedKeyTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sharding.route.engine.keygen;
 
 import com.google.common.base.Optional;
 import org.apache.shardingsphere.core.rule.ShardingRule;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.InsertValuesSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.InsertColumnsSegment;
@@ -60,7 +59,7 @@ public final class GeneratedKeyTest {
     public void setUp() {
         insertStatement.setTable(new TableSegment(0, 0, new IdentifierValue("tbl")));
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
-        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, "id", QuoteCharacter.NONE));
+        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("id")));
         insertStatement.setColumns(insertColumnsSegment);
     }
     

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngineTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngineTest.java
@@ -90,7 +90,7 @@ public final class ShardingTableBroadcastRoutingEngineTest {
     public void assertRouteForNonExistDropIndex() {
         DropIndexStatement indexStatement = mock(DropIndexStatement.class);
         IndexSegment indexSegment = mock(IndexSegment.class);
-        when(indexSegment.getName()).thenReturn("no_index");
+        when(indexSegment.getIdentifier().getValue()).thenReturn("no_index");
         when(indexStatement.getIndexes()).thenReturn(Lists.newArrayList(indexSegment));
         when(sqlStatementContext.getSqlStatement()).thenReturn(indexStatement);
         tableBroadcastRoutingEngine.route(shardingRule);
@@ -100,7 +100,7 @@ public final class ShardingTableBroadcastRoutingEngineTest {
     public void assertRouteForDropIndex() {
         DropIndexStatement indexStatement = mock(DropIndexStatement.class);
         IndexSegment indexSegment = mock(IndexSegment.class);
-        when(indexSegment.getName()).thenReturn("index_name");
+        when(indexSegment.getIdentifier().getValue()).thenReturn("index_name");
         when(indexStatement.getIndexes()).thenReturn(Lists.newArrayList(indexSegment));
         when(sqlStatementContext.getSqlStatement()).thenReturn(indexStatement);
         RouteResult actual = tableBroadcastRoutingEngine.route(shardingRule);

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngineTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngineTest.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.sql.parser.relation.statement.SQLStatementConte
 import org.apache.shardingsphere.sql.parser.sql.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.ddl.DDLStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.ddl.DropIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.underlying.common.metadata.table.TableMetaData;
 import org.apache.shardingsphere.underlying.common.metadata.table.TableMetas;
 import org.apache.shardingsphere.underlying.route.context.RouteResult;
@@ -89,8 +90,7 @@ public final class ShardingTableBroadcastRoutingEngineTest {
     @Test(expected = IllegalStateException.class)
     public void assertRouteForNonExistDropIndex() {
         DropIndexStatement indexStatement = mock(DropIndexStatement.class);
-        IndexSegment indexSegment = mock(IndexSegment.class);
-        when(indexSegment.getIdentifier().getValue()).thenReturn("no_index");
+        IndexSegment indexSegment = new IndexSegment(0, 0, new IdentifierValue("no_index"));
         when(indexStatement.getIndexes()).thenReturn(Lists.newArrayList(indexSegment));
         when(sqlStatementContext.getSqlStatement()).thenReturn(indexStatement);
         tableBroadcastRoutingEngine.route(shardingRule);
@@ -99,8 +99,7 @@ public final class ShardingTableBroadcastRoutingEngineTest {
     @Test
     public void assertRouteForDropIndex() {
         DropIndexStatement indexStatement = mock(DropIndexStatement.class);
-        IndexSegment indexSegment = mock(IndexSegment.class);
-        when(indexSegment.getIdentifier().getValue()).thenReturn("index_name");
+        IndexSegment indexSegment = new IndexSegment(0, 0, new IdentifierValue("index_name"));
         when(indexStatement.getIndexes()).thenReturn(Lists.newArrayList(indexSegment));
         when(sqlStatementContext.getSqlStatement()).thenReturn(indexStatement);
         RouteResult actual = tableBroadcastRoutingEngine.route(shardingRule);

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidatorTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidatorTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sharding.route.engine.validator.impl;
 
 import org.apache.shardingsphere.core.rule.ShardingRule;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.AssignmentSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.OnDuplicateKeyColumnsSegment;
@@ -57,7 +56,7 @@ public final class ShardingInsertStatementValidatorTest {
     private InsertStatement createInsertStatement() {
         InsertStatement result = new InsertStatement();
         result.setTable(new TableSegment(0, 0, new IdentifierValue("user")));
-        ColumnSegment columnSegment = new ColumnSegment(0, 0, "id", QuoteCharacter.NONE);
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("id"));
         AssignmentSegment assignmentSegment = new AssignmentSegment(0, 0, columnSegment, new ParameterMarkerExpressionSegment(0, 0, 1));
         result.getAllSQLSegments().add(new OnDuplicateKeyColumnsSegment(0, 0, Collections.singletonList(assignmentSegment)));
         return result;

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidatorTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingInsertStatementValidatorTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.OnDuplicateKe
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.InsertStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.underlying.common.exception.ShardingSphereException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +56,7 @@ public final class ShardingInsertStatementValidatorTest {
     
     private InsertStatement createInsertStatement() {
         InsertStatement result = new InsertStatement();
-        result.setTable(new TableSegment(0, 0, "user", QuoteCharacter.NONE));
+        result.setTable(new TableSegment(0, 0, new IdentifierValue("user")));
         ColumnSegment columnSegment = new ColumnSegment(0, 0, "id", QuoteCharacter.NONE);
         AssignmentSegment assignmentSegment = new AssignmentSegment(0, 0, columnSegment, new ParameterMarkerExpressionSegment(0, 0, 1));
         result.getAllSQLSegments().add(new OnDuplicateKeyColumnsSegment(0, 0, Collections.singletonList(assignmentSegment)));

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidatorTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidatorTest.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.WhereSegme
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateCompareRightValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.UpdateStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.underlying.common.exception.ShardingSphereException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,7 +85,7 @@ public final class ShardingUpdateStatementValidatorTest {
     
     private UpdateStatement createUpdateStatement() {
         UpdateStatement result = new UpdateStatement();
-        result.getAllSQLSegments().add(new TableSegment(0, 0, "user", QuoteCharacter.NONE));
+        result.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("user")));
         result.setSetAssignment(
                 new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, "")))));
         return result;
@@ -92,7 +93,7 @@ public final class ShardingUpdateStatementValidatorTest {
     
     private UpdateStatement createUpdateStatementAndParameters(final Object shardingColumnParameter) {
         UpdateStatement result = new UpdateStatement();
-        result.getAllSQLSegments().add(new TableSegment(0, 0, "user", QuoteCharacter.NONE));
+        result.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("user")));
         Collection<AssignmentSegment> assignments = Collections.singletonList(
                 new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, shardingColumnParameter)));
         SetAssignmentSegment setAssignmentSegment = new SetAssignmentSegment(0, 0, assignments);

--- a/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidatorTest.java
+++ b/sharding-core/sharding-core-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidatorTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sharding.route.engine.validator.impl;
 
 import org.apache.shardingsphere.core.rule.ShardingRule;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.AssignmentSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
@@ -87,7 +86,7 @@ public final class ShardingUpdateStatementValidatorTest {
         UpdateStatement result = new UpdateStatement();
         result.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("user")));
         result.setSetAssignment(
-                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, "")))));
+                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("id")), new LiteralExpressionSegment(0, 0, "")))));
         return result;
     }
     
@@ -95,14 +94,14 @@ public final class ShardingUpdateStatementValidatorTest {
         UpdateStatement result = new UpdateStatement();
         result.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("user")));
         Collection<AssignmentSegment> assignments = Collections.singletonList(
-                new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, shardingColumnParameter)));
+                new AssignmentSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("id")), new LiteralExpressionSegment(0, 0, shardingColumnParameter)));
         SetAssignmentSegment setAssignmentSegment = new SetAssignmentSegment(0, 0, assignments);
         result.setSetAssignment(setAssignmentSegment);
         WhereSegment where = new WhereSegment(0, 0);
         where.setParametersCount(1);
         where.setParameterMarkerStartIndex(0);
         AndPredicate andPre = new AndPredicate();
-        andPre.getPredicates().add(new PredicateSegment(0, 1, new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new PredicateCompareRightValue("=", new ParameterMarkerExpressionSegment(0, 0, 0))));
+        andPre.getPredicates().add(new PredicateSegment(0, 1, new ColumnSegment(0, 0, new IdentifierValue("id")), new PredicateCompareRightValue("=", new ParameterMarkerExpressionSegment(0, 0, 0))));
         where.getAndPredicates().add(andPre);
         result.setWhere(where);
         return result;

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/executor/AbstractStatementExecutor.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/executor/AbstractStatementExecutor.java
@@ -221,7 +221,7 @@ public abstract class AbstractStatementExecutor {
         if (null == createIndexStatement.getIndex()) {
             return;
         }
-        runtimeContext.getMetaData().getTables().get(sqlStatementContext.getTablesContext().getSingleTableName()).getIndexes().add(createIndexStatement.getIndex().getName());
+        runtimeContext.getMetaData().getTables().get(sqlStatementContext.getTablesContext().getSingleTableName()).getIndexes().add(createIndexStatement.getIndex().getIdentifier().getValue());
     }
     
     private void refreshTableMetaDataForDropIndex(final ShardingRuntimeContext runtimeContext, final SQLStatementContext sqlStatementContext) {
@@ -242,7 +242,7 @@ public abstract class AbstractStatementExecutor {
     private Collection<String> getIndexNames(final DropIndexStatement dropIndexStatement) {
         Collection<String> result = new LinkedList<>();
         for (IndexSegment each : dropIndexStatement.getIndexes()) {
-            result.add(each.getName());
+            result.add(each.getIdentifier().getValue());
         }
         return result;
     }

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
@@ -158,7 +158,7 @@ public final class ShardingSchema extends LogicSchema {
     private void refreshTableMetaDataForCreateIndex(final SQLStatementContext sqlStatementContext) {
         CreateIndexStatement createIndexStatement = (CreateIndexStatement) sqlStatementContext.getSqlStatement();
         if (null != createIndexStatement.getIndex()) {
-            getMetaData().getTables().get(sqlStatementContext.getTablesContext().getSingleTableName()).getIndexes().add(createIndexStatement.getIndex().getName());
+            getMetaData().getTables().get(sqlStatementContext.getTablesContext().getSingleTableName()).getIndexes().add(createIndexStatement.getIndex().getIdentifier().getValue());
         }
     }
     
@@ -191,7 +191,7 @@ public final class ShardingSchema extends LogicSchema {
     private Collection<String> getIndexNames(final DropIndexStatement dropIndexStatement) {
         Collection<String> result = new LinkedList<>();
         for (IndexSegment each : dropIndexStatement.getIndexes()) {
-            result.add(each.getName());
+            result.add(each.getIdentifier().getValue());
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/column/ColumnExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/column/ColumnExtractor.java
@@ -44,8 +44,7 @@ public final class ColumnExtractor implements OptionalSQLSegmentExtractor {
     
     private ColumnSegment getColumnSegment(final ParserRuleContext columnNode) {
         ParserRuleContext nameNode = ExtractorUtils.getFirstChildNode(columnNode, RuleName.NAME);
-        IdentifierValue columnIdentifier = new IdentifierValue(nameNode.getText());
-        ColumnSegment result = new ColumnSegment(columnNode.getStart().getStartIndex(), columnNode.getStop().getStopIndex(), columnIdentifier.getValue(), columnIdentifier.getQuoteCharacter());
+        ColumnSegment result = new ColumnSegment(columnNode.getStart().getStartIndex(), columnNode.getStop().getStopIndex(), new IdentifierValue(nameNode.getText()));
         Optional<ParserRuleContext> ownerNode = ExtractorUtils.findFirstChildNodeNoneRecursive(columnNode, RuleName.OWNER);
         if (ownerNode.isPresent()) {
             IdentifierValue ownerIdentifier = new IdentifierValue(ownerNode.get().getText());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/column/ColumnExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/column/ColumnExtractor.java
@@ -49,7 +49,7 @@ public final class ColumnExtractor implements OptionalSQLSegmentExtractor {
         Optional<ParserRuleContext> ownerNode = ExtractorUtils.findFirstChildNodeNoneRecursive(columnNode, RuleName.OWNER);
         if (ownerNode.isPresent()) {
             IdentifierValue ownerIdentifier = new IdentifierValue(ownerNode.get().getText());
-            result.setOwner(new TableSegment(ownerNode.get().getStart().getStartIndex(), ownerNode.get().getStop().getStopIndex(), ownerIdentifier.getValue(), ownerIdentifier.getQuoteCharacter()));
+            result.setOwner(new TableSegment(ownerNode.get().getStart().getStartIndex(), ownerNode.get().getStop().getStopIndex(), ownerIdentifier));
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/index/IndexExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/index/IndexExtractor.java
@@ -38,8 +38,7 @@ public final class IndexExtractor implements OptionalSQLSegmentExtractor {
     public Optional<IndexSegment> extract(final ParserRuleContext ancestorNode, final Map<ParserRuleContext, Integer> parameterMarkerIndexes) {
         Optional<ParserRuleContext> indexNameNode = ExtractorUtils.findFirstChildNode(ancestorNode, RuleName.INDEX_NAME);
         if (indexNameNode.isPresent()) {
-            IdentifierValue identifier = new IdentifierValue(indexNameNode.get().getText());
-            return Optional.of(new IndexSegment(indexNameNode.get().getStart().getStartIndex(), indexNameNode.get().getStop().getStopIndex(), identifier.getValue(), identifier.getQuoteCharacter()));
+            return Optional.of(new IndexSegment(indexNameNode.get().getStart().getStartIndex(), indexNameNode.get().getStop().getStopIndex(), new IdentifierValue(indexNameNode.get().getText())));
         }
         return Optional.absent();
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/schema/SchemaExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/schema/SchemaExtractor.java
@@ -38,8 +38,7 @@ public final class SchemaExtractor implements OptionalSQLSegmentExtractor {
     public Optional<SchemaSegment> extract(final ParserRuleContext ancestorNode, final Map<ParserRuleContext, Integer> parameterMarkerIndexes) {
         Optional<ParserRuleContext> schemaNode = ExtractorUtils.findFirstChildNode(ancestorNode, RuleName.SCHEMA_NAME);
         if (schemaNode.isPresent()) {
-            IdentifierValue identifier = new IdentifierValue(schemaNode.get().getText());
-            return Optional.of(new SchemaSegment(schemaNode.get().getStart().getStartIndex(), schemaNode.get().getStop().getStopIndex(), identifier.getValue(), identifier.getQuoteCharacter()));
+            return Optional.of(new SchemaSegment(schemaNode.get().getStart().getStartIndex(), schemaNode.get().getStop().getStopIndex(), new IdentifierValue(schemaNode.get().getText())));
         }
         return Optional.absent();
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/table/TableExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/table/TableExtractor.java
@@ -49,12 +49,10 @@ public final class TableExtractor implements OptionalSQLSegmentExtractor {
     
     private TableSegment getTableSegment(final ParserRuleContext tableNode) {
         ParserRuleContext nameNode = ExtractorUtils.getFirstChildNode(tableNode, RuleName.NAME);
-        IdentifierValue tableIdentifier = new IdentifierValue(nameNode.getText());
-        TableSegment result = new TableSegment(nameNode.getStart().getStartIndex(), nameNode.getStop().getStopIndex(), tableIdentifier);
+        TableSegment result = new TableSegment(nameNode.getStart().getStartIndex(), nameNode.getStop().getStopIndex(), new IdentifierValue(nameNode.getText()));
         Optional<ParserRuleContext> ownerNode = ExtractorUtils.findFirstChildNodeNoneRecursive(tableNode, RuleName.OWNER);
         if (ownerNode.isPresent()) {
-            IdentifierValue ownerIdentifier = new IdentifierValue(ownerNode.get().getText());
-            result.setOwner(new SchemaSegment(ownerNode.get().getStart().getStartIndex(), ownerNode.get().getStop().getStopIndex(), ownerIdentifier.getValue(), ownerIdentifier.getQuoteCharacter()));
+            result.setOwner(new SchemaSegment(ownerNode.get().getStart().getStartIndex(), ownerNode.get().getStop().getStopIndex(), new IdentifierValue(ownerNode.get().getText())));
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/table/TableExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/common/table/TableExtractor.java
@@ -50,7 +50,7 @@ public final class TableExtractor implements OptionalSQLSegmentExtractor {
     private TableSegment getTableSegment(final ParserRuleContext tableNode) {
         ParserRuleContext nameNode = ExtractorUtils.getFirstChildNode(tableNode, RuleName.NAME);
         IdentifierValue tableIdentifier = new IdentifierValue(nameNode.getText());
-        TableSegment result = new TableSegment(nameNode.getStart().getStartIndex(), nameNode.getStop().getStopIndex(), tableIdentifier.getValue(), tableIdentifier.getQuoteCharacter());
+        TableSegment result = new TableSegment(nameNode.getStart().getStartIndex(), nameNode.getStop().getStopIndex(), tableIdentifier);
         Optional<ParserRuleContext> ownerNode = ExtractorUtils.findFirstChildNodeNoneRecursive(tableNode, RuleName.OWNER);
         if (ownerNode.isPresent()) {
             IdentifierValue ownerIdentifier = new IdentifierValue(ownerNode.get().getText());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/select/item/impl/ShorthandProjectionExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/impl/dml/select/item/impl/ShorthandProjectionExtractor.java
@@ -48,7 +48,7 @@ public final class ShorthandProjectionExtractor implements OptionalSQLSegmentExt
                     qualifiedShorthandNode.get().getStart().getStartIndex(), qualifiedShorthandNode.get().getStop().getStopIndex(), qualifiedShorthandNode.get().getText());
             ParserRuleContext ownerNode = (ParserRuleContext) qualifiedShorthandNode.get().getChild(0);
             IdentifierValue ownerIdentifier = new IdentifierValue(ownerNode.getText());
-            result.setOwner(new TableSegment(ownerNode.getStart().getStartIndex(), ownerNode.getStop().getStopIndex(), ownerIdentifier.getValue(), ownerIdentifier.getQuoteCharacter()));
+            result.setOwner(new TableSegment(ownerNode.getStart().getStartIndex(), ownerNode.getStop().getStopIndex(), ownerIdentifier));
             return Optional.of(result);
         }
         return Optional.absent();

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/filler/impl/dal/SchemaFiller.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/filler/impl/dal/SchemaFiller.java
@@ -32,7 +32,7 @@ public final class SchemaFiller implements SQLSegmentFiller<SchemaSegment> {
     @Override
     public void fill(final SchemaSegment sqlSegment, final SQLStatement sqlStatement) {
         if (sqlStatement instanceof UseStatement) {
-            ((UseStatement) sqlStatement).setSchema(sqlSegment.getName());
+            ((UseStatement) sqlStatement).setSchema(sqlSegment.getIdentifier().getValue());
         }
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/index/IndexSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/index/IndexSegment.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.sql.parser.sql.segment.ddl.index;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 
 /**
  * Index segment.
@@ -35,7 +35,5 @@ public final class IndexSegment implements SQLSegment {
     
     private final int stopIndex;
     
-    private final String name;
-    
-    private final QuoteCharacter quoteCharacter;
+    private final IdentifierValue identifier;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegment.java
@@ -57,7 +57,7 @@ public class ColumnSegment implements SQLSegment, PredicateRightValue, OwnerAvai
      * @return qualified name
      */
     public final String getQualifiedName() {
-        return null == owner ? name : owner.getTableName() + "." + name;
+        return null == owner ? name : owner.getTable().getValue() + "." + name;
     }
 
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegment.java
@@ -22,11 +22,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateRightValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.OwnerAvailable;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 
 /**
  * Column segment.
@@ -45,9 +45,7 @@ public class ColumnSegment implements SQLSegment, PredicateRightValue, OwnerAvai
     
     private final int stopIndex;
     
-    private final String name;
-    
-    private final QuoteCharacter quoteCharacter;
+    private final IdentifierValue identifier;
     
     private TableSegment owner;
     
@@ -57,7 +55,7 @@ public class ColumnSegment implements SQLSegment, PredicateRightValue, OwnerAvai
      * @return qualified name
      */
     public final String getQualifiedName() {
-        return null == owner ? name : owner.getTable().getValue() + "." + name;
+        return null == owner ? identifier.getValue() : owner.getTable().getValue() + "." + identifier.getValue();
     }
 
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/item/ColumnProjectionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/item/ColumnProjectionSegment.java
@@ -21,7 +21,6 @@ import com.google.common.base.Optional;
 import lombok.Getter;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.AliasAvailable;
-import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.util.SQLUtil;
 
 /**
@@ -37,7 +36,7 @@ public final class ColumnProjectionSegment extends ColumnSegment implements Proj
     private String alias;
     
     public ColumnProjectionSegment(final String text, final ColumnSegment columnSegment) {
-        super(columnSegment.getStartIndex(), columnSegment.getStopIndex(), new IdentifierValue(columnSegment.getName()).getValue(), new IdentifierValue(columnSegment.getName()).getQuoteCharacter());
+        super(columnSegment.getStartIndex(), columnSegment.getStopIndex(), columnSegment.getIdentifier());
         this.text = SQLUtil.getExpressionWithoutOutsideParentheses(text);
         if (columnSegment.getOwner().isPresent()) {
             setOwner(columnSegment.getOwner().get());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/SchemaSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/SchemaSegment.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.sql.parser.sql.segment.generic;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 
 /**
  * Schema segment.
@@ -35,7 +35,5 @@ public final class SchemaSegment implements SQLSegment {
     
     private final int stopIndex;
     
-    private final String name;
-    
-    private final QuoteCharacter quoteCharacter;
+    private final IdentifierValue identifier;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableAvailable.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableAvailable.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.sql.parser.sql.segment.generic;
 
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 
 /**
  * Table available.
@@ -28,16 +28,9 @@ import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
 public interface TableAvailable extends SQLSegment {
     
     /**
-     * Get table name.
+     * Get table.
      *
-     * @return table name
+     * @return table
      */
-    String getTableName();
-    
-    /**
-     * Get table quote character.
-     *
-     * @return table quote character
-     */
-    QuoteCharacter getTableQuoteCharacter();
+    IdentifierValue getTable();
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableSegment.java
@@ -22,8 +22,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
-import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.util.SQLUtil;
 
 /**
@@ -34,17 +33,15 @@ import org.apache.shardingsphere.sql.parser.util.SQLUtil;
  * @author zhangliang
  */
 @RequiredArgsConstructor
+@Getter
 @ToString
-public final class TableSegment implements SQLSegment, TableAvailable, OwnerAvailable<SchemaSegment>, AliasAvailable {
+public final class TableSegment implements TableAvailable, OwnerAvailable<SchemaSegment>, AliasAvailable {
     
     private final int startIndex;
     
-    @Getter
     private final int stopIndex;
     
-    private final String name;
-    
-    private final QuoteCharacter quoteCharacter;
+    private final IdentifierValue table;
     
     @Setter
     private SchemaSegment owner;
@@ -54,16 +51,6 @@ public final class TableSegment implements SQLSegment, TableAvailable, OwnerAvai
     @Override
     public int getStartIndex() {
         return null == owner ? startIndex : owner.getStartIndex(); 
-    }
-    
-    @Override
-    public String getTableName() {
-        return name;
-    }
-    
-    @Override
-    public QuoteCharacter getTableQuoteCharacter() {
-        return quoteCharacter;
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/statement/dml/InsertStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/sql/statement/dml/InsertStatement.java
@@ -102,7 +102,7 @@ public final class InsertStatement extends DMLStatement implements TableSegmentA
     private List<String> getColumnNamesForInsertColumns() {
         List<String> result = new LinkedList<>();
         for (ColumnSegment each : getColumns()) {
-            result.add(each.getName().toLowerCase());
+            result.add(each.getIdentifier().getValue().toLowerCase());
         }
         return result;
     }
@@ -110,7 +110,7 @@ public final class InsertStatement extends DMLStatement implements TableSegmentA
     private List<String> getColumnNamesForSetAssignment() {
         List<String> result = new LinkedList<>();
         for (AssignmentSegment each : setAssignment.getAssignments()) {
-            result.add(each.getColumn().getName().toLowerCase());
+            result.add(each.getColumn().getIdentifier().getValue().toLowerCase());
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegmentTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegmentTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.sql.segment.dml.column;
 
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
@@ -29,13 +28,13 @@ public final class ColumnSegmentTest {
     
     @Test
     public void assertGetQualifiedNameWithoutOwner() {
-        ColumnSegment actual = new ColumnSegment(0, 0, "col", QuoteCharacter.NONE);
+        ColumnSegment actual = new ColumnSegment(0, 0, new IdentifierValue("col"));
         assertThat(actual.getQualifiedName(), is("col"));
     }
     
     @Test
     public void assertGetQualifiedNameWithOwner() {
-        ColumnSegment actual = new ColumnSegment(0, 0, "col", QuoteCharacter.NONE);
+        ColumnSegment actual = new ColumnSegment(0, 0, new IdentifierValue("col"));
         actual.setOwner(new TableSegment(0, 0, new IdentifierValue("tbl")));
         assertThat(actual.getQualifiedName(), is("tbl.col"));
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegmentTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/dml/column/ColumnSegmentTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sql.parser.sql.segment.dml.column;
 
 import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -35,7 +36,7 @@ public final class ColumnSegmentTest {
     @Test
     public void assertGetQualifiedNameWithOwner() {
         ColumnSegment actual = new ColumnSegment(0, 0, "col", QuoteCharacter.NONE);
-        actual.setOwner(new TableSegment(0, 0, "tbl", QuoteCharacter.NONE));
+        actual.setOwner(new TableSegment(0, 0, new IdentifierValue("tbl")));
         assertThat(actual.getQualifiedName(), is("tbl.col"));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableSegmentTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableSegmentTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.sql.segment.generic;
 
 import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -27,13 +28,13 @@ public final class TableSegmentTest {
     
     @Test
     public void getStartIndexWithoutOwner() {
-        TableSegment tableSegment = new TableSegment(10, 13, "tbl", QuoteCharacter.NONE);
+        TableSegment tableSegment = new TableSegment(10, 13, new IdentifierValue("tbl"));
         assertThat(tableSegment.getStartIndex(), is(10));
     }
     
     @Test
     public void getStartIndexWithOwner() {
-        TableSegment tableSegment = new TableSegment(10, 13, "tbl", QuoteCharacter.NONE);
+        TableSegment tableSegment = new TableSegment(10, 13, new IdentifierValue("tbl"));
         tableSegment.setOwner(new SchemaSegment(7, 8, "o", QuoteCharacter.NONE));
         assertThat(tableSegment.getStartIndex(), is(7));
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableSegmentTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/segment/generic/TableSegmentTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.sql.segment.generic;
 
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ public final class TableSegmentTest {
     @Test
     public void getStartIndexWithOwner() {
         TableSegment tableSegment = new TableSegment(10, 13, new IdentifierValue("tbl"));
-        tableSegment.setOwner(new SchemaSegment(7, 8, "o", QuoteCharacter.NONE));
+        tableSegment.setOwner(new SchemaSegment(7, 8, new IdentifierValue("o")));
         assertThat(tableSegment.getStartIndex(), is(7));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/statement/dml/InsertStatementTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/statement/dml/InsertStatementTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.sql.statement.dml;
 
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.AssignmentSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.InsertValuesSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.SetAssignmentSegment;
@@ -25,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.InsertColumnsSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -45,7 +45,7 @@ public final class InsertStatementTest {
     public void assertNotUseDefaultColumnsWithColumns() {
         InsertStatement insertStatement = new InsertStatement();
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
-        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, "col", QuoteCharacter.NONE));
+        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("col")));
         insertStatement.setColumns(insertColumnsSegment);
         assertFalse(insertStatement.useDefaultColumns());
     }
@@ -62,7 +62,7 @@ public final class InsertStatementTest {
     public void assertGetColumnNamesForInsertColumns() {
         InsertStatement insertStatement = new InsertStatement();
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
-        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, "col", QuoteCharacter.NONE));
+        insertColumnsSegment.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("col")));
         insertStatement.setColumns(insertColumnsSegment);
         assertThat(insertStatement.getColumnNames().size(), is(1));
         assertThat(insertStatement.getColumnNames().iterator().next(), is("col"));
@@ -72,7 +72,7 @@ public final class InsertStatementTest {
     public void assertGetColumnNamesForSetAssignment() {
         InsertStatement insertStatement = new InsertStatement();
         insertStatement.setSetAssignment(
-                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "col", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, 1)))));
+                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("col")), new LiteralExpressionSegment(0, 0, 1)))));
         assertThat(insertStatement.getColumnNames().size(), is(1));
         assertThat(insertStatement.getColumnNames().iterator().next(), is("col"));
     }
@@ -89,7 +89,7 @@ public final class InsertStatementTest {
     public void assertGetValueListCountWithSetAssignment() {
         InsertStatement insertStatement = new InsertStatement();
         insertStatement.setSetAssignment(
-                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "col", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, 1)))));
+                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("col")), new LiteralExpressionSegment(0, 0, 1)))));
         assertThat(insertStatement.getValueListCount(), is(1));
     }
     
@@ -104,7 +104,7 @@ public final class InsertStatementTest {
     public void assertGetValueCountForPerGroupWithSetAssignment() {
         InsertStatement insertStatement = new InsertStatement();
         insertStatement.setSetAssignment(
-                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "col", QuoteCharacter.NONE), new LiteralExpressionSegment(0, 0, 1)))));
+                new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("col")), new LiteralExpressionSegment(0, 0, 1)))));
         assertThat(insertStatement.getValueCountForPerGroup(), is(1));
     }
     
@@ -127,7 +127,7 @@ public final class InsertStatementTest {
     public void assertGetAllValueExpressionsWithSetAssignment() {
         InsertStatement insertStatement = new InsertStatement();
         ExpressionSegment valueSegment = new LiteralExpressionSegment(0, 0, 1);
-        insertStatement.setSetAssignment(new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, "col", QuoteCharacter.NONE), valueSegment))));
+        insertStatement.setSetAssignment(new SetAssignmentSegment(0, 0, Collections.singletonList(new AssignmentSegment(0, 0, new ColumnSegment(0, 0, new IdentifierValue("col")), valueSegment))));
         assertThat(insertStatement.getAllValueExpressions().size(), is(1));
         assertThat(insertStatement.getAllValueExpressions().iterator().next().size(), is(1));
         assertThat(insertStatement.getAllValueExpressions().iterator().next().iterator().next(), is(valueSegment));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/statement/generic/AbstractSQLStatementTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/test/java/org/apache/shardingsphere/sql/parser/sql/statement/generic/AbstractSQLStatementTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.sql.parser.sql.statement.generic;
 
 import com.google.common.base.Optional;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -39,7 +39,7 @@ public final class AbstractSQLStatementTest {
         SQLStatement sqlStatement = createSQLStatement();
         Optional<TableSegment> actual = sqlStatement.findSQLSegment(TableSegment.class);
         assertTrue(actual.isPresent());
-        assertThat(actual.get().getTableName(), is("tbl1"));
+        assertThat(actual.get().getTable().getValue(), is("tbl1"));
     }
     
     @Test
@@ -53,15 +53,15 @@ public final class AbstractSQLStatementTest {
     public void assertFindSQLSegments() {
         SQLStatement sqlStatement = createSQLStatement();
         Iterator<TableSegment> actual = sqlStatement.findSQLSegments(TableSegment.class).iterator();
-        assertThat(actual.next().getTableName(), is("tbl1"));
-        assertThat(actual.next().getTableName(), is("tbl2"));
+        assertThat(actual.next().getTable().getValue(), is("tbl1"));
+        assertThat(actual.next().getTable().getValue(), is("tbl2"));
         assertFalse(actual.hasNext());
     }
     
     private SQLStatement createSQLStatement() {
         SQLStatement result = new SelectStatement();
-        result.getAllSQLSegments().add(new TableSegment(0, 0, "tbl1", QuoteCharacter.NONE));
-        result.getAllSQLSegments().add(new TableSegment(0, 0, "tbl2", QuoteCharacter.NONE));
+        result.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl1")));
+        result.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl2")));
         return result;
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
@@ -204,8 +204,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
         TableSegment result = new TableSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), tableIdentifier);
         OwnerContext owner = ctx.owner();
         if (null != owner) {
-            IdentifierValue ownerIdentifier = (IdentifierValue) visit(owner.identifier());
-            result.setOwner(new SchemaSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), ownerIdentifier.getValue(), ownerIdentifier.getQuoteCharacter()));
+            result.setOwner(new SchemaSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), (IdentifierValue) visit(owner.identifier())));
         }
         return result;
     }
@@ -216,8 +215,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
         ColumnSegment result = new ColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnName.getValue(), columnName.getQuoteCharacter());
         OwnerContext owner = ctx.owner();
         if (null != owner) {
-            IdentifierValue ownerIdentifier = (IdentifierValue) visit(owner.identifier());
-            result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), ownerIdentifier));
+            result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), (IdentifierValue) visit(owner.identifier())));
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
@@ -200,8 +200,8 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     
     @Override
     public final ASTNode visitTableName(final TableNameContext ctx) {
-        IdentifierValue tableName = (IdentifierValue) visit(ctx.name());
-        TableSegment result = new TableSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), tableName.getValue(), tableName.getQuoteCharacter());
+        IdentifierValue tableIdentifier = (IdentifierValue) visit(ctx.name());
+        TableSegment result = new TableSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), tableIdentifier);
         OwnerContext owner = ctx.owner();
         if (null != owner) {
             IdentifierValue ownerIdentifier = (IdentifierValue) visit(owner.identifier());
@@ -217,7 +217,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
         OwnerContext owner = ctx.owner();
         if (null != owner) {
             IdentifierValue ownerIdentifier = (IdentifierValue) visit(owner.identifier());
-            result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), ownerIdentifier.getValue(), ownerIdentifier.getQuoteCharacter()));
+            result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), ownerIdentifier));
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
@@ -211,8 +211,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     
     @Override
     public final ASTNode visitColumnName(final ColumnNameContext ctx) {
-        IdentifierValue columnName = (IdentifierValue) visit(ctx.name());
-        ColumnSegment result = new ColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnName.getValue(), columnName.getQuoteCharacter());
+        ColumnSegment result = new ColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), (IdentifierValue) visit(ctx.name()));
         OwnerContext owner = ctx.owner();
         if (null != owner) {
             result.setOwner(new TableSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), (IdentifierValue) visit(owner.identifier())));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/MySQLVisitor.java
@@ -222,8 +222,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     
     @Override
     public final ASTNode visitIndexName(final IndexNameContext ctx) {
-        IdentifierValue indexName = (IdentifierValue) visit(ctx.identifier());
-        return new IndexSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), indexName.getValue(), indexName.getQuoteCharacter());
+        return new IndexSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), (IdentifierValue) visit(ctx.identifier()));
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/dal/MySQLShowLikeExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/core/extractor/dal/MySQLShowLikeExtractor.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.core.extractor.api.OptionalSQLSegmen
 import org.apache.shardingsphere.sql.parser.core.extractor.util.ExtractorUtils;
 import org.apache.shardingsphere.sql.parser.core.extractor.util.RuleName;
 import org.apache.shardingsphere.sql.parser.sql.segment.dal.ShowLikeSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 
 import java.util.Map;
 
@@ -43,6 +44,6 @@ public final class MySQLShowLikeExtractor implements OptionalSQLSegmentExtractor
         Optional<ParserRuleContext> stringLiteralsNode = ExtractorUtils.findFirstChildNode(showLikeNode.get(), RuleName.STRING_LITERALS);
         Preconditions.checkState(stringLiteralsNode.isPresent());
         String pattern = stringLiteralsNode.get().getText().substring(1, stringLiteralsNode.get().getText().length() - 1);
-        return Optional.of(new ShowLikeSegment(stringLiteralsNode.get().getStart().getStartIndex() + 1, stringLiteralsNode.get().getStop().getStopIndex() - 1, pattern));
+        return Optional.of(new ShowLikeSegment(stringLiteralsNode.get().getStart().getStartIndex() + 1, stringLiteralsNode.get().getStop().getStopIndex() - 1, new IdentifierValue(pattern)));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dal/ShowLikeSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/dal/ShowLikeSegment.java
@@ -19,9 +19,8 @@ package org.apache.shardingsphere.sql.parser.sql.segment.dal;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
-import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableAvailable;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 
 /**
  * Show like segment.
@@ -30,21 +29,11 @@ import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableAvailable;
  */
 @RequiredArgsConstructor
 @Getter
-public final class ShowLikeSegment implements SQLSegment, TableAvailable {
+public final class ShowLikeSegment implements TableAvailable {
     
     private final int startIndex;
     
     private final int stopIndex;
     
-    private final String pattern;
-    
-    @Override
-    public String getTableName() {
-        return pattern;
-    }
-    
-    @Override
-    public QuoteCharacter getTableQuoteCharacter() {
-        return QuoteCharacter.NONE;
-    }
+    private final IdentifierValue table;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDALVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDALVisitor.java
@@ -182,12 +182,12 @@ public final class MySQLDALVisitor extends MySQLVisitor {
 
     @Override
     public ASTNode visitSetVariable(final SetVariableContext ctx) {
-        List<VariableExprContext> variableExprs = ctx.variableExpr();
+        List<VariableExprContext> variableExpressions = ctx.variableExpr();
         SetStatement result = new SetStatement();
-        for (VariableExprContext vectx: variableExprs) {
-            String variable = vectx.variable_().getText();
-            String expr = vectx.expr().getText();
-            VariableExpressionSegment variableExpressionSegment = new VariableExpressionSegment(vectx.start.getStartIndex(), vectx.stop.getStopIndex(), variable, expr);
+        for (VariableExprContext each: variableExpressions) {
+            String variable = each.variable_().getText();
+            String expr = each.expr().getText();
+            VariableExpressionSegment variableExpressionSegment = new VariableExpressionSegment(each.start.getStartIndex(), each.stop.getStopIndex(), variable, expr);
             result.getAllSQLSegments().add(variableExpressionSegment);
         }
         return result;
@@ -201,6 +201,6 @@ public final class MySQLDALVisitor extends MySQLVisitor {
     @Override
     public ASTNode visitShowLike(final ShowLikeContext ctx) {
         StringLiteralValue literalValue = (StringLiteralValue) visit(ctx.stringLiterals());
-        return new ShowLikeSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), literalValue.getValue());
+        return new ShowLikeSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), new IdentifierValue(literalValue.getValue()));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDALVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDALVisitor.java
@@ -145,8 +145,7 @@ public final class MySQLDALVisitor extends MySQLVisitor {
         FromTableContext fromTableContext = ctx.fromTable();
         if (null != fromSchemaContext) {
             SchemaNameContext schemaNameContext = fromSchemaContext.schemaName();
-            IdentifierValue identifier = (IdentifierValue) visit(schemaNameContext);
-            SchemaSegment schemaSegment = new SchemaSegment(schemaNameContext.start.getStartIndex(), schemaNameContext.stop.getStopIndex(), identifier.getValue(), identifier.getQuoteCharacter());
+            SchemaSegment schemaSegment = new SchemaSegment(schemaNameContext.start.getStartIndex(), schemaNameContext.stop.getStopIndex(), (IdentifierValue) visit(schemaNameContext));
             result.getAllSQLSegments().add(schemaSegment);
         }
         if (null != fromTableContext) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDDLVisitor.java
@@ -173,14 +173,14 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
         });
         boolean isPrimaryKey = inlineDataTypes.size() > 0 || generatedDataTypes.size() > 0;
         return new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                column.getName(), dataType.getValue(), isPrimaryKey);
+                column.getIdentifier().getValue(), dataType.getValue(), isPrimaryKey);
     }
     
     @Override
     public ASTNode visitFirstOrAfterColumn(final FirstOrAfterColumnContext ctx) {
         return null == ctx.columnName() ? new ColumnFirstPositionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null)
                 : new ColumnAfterPositionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null,
-                ((ColumnSegment) visit(ctx.columnName())).getName());
+                ((ColumnSegment) visit(ctx.columnName())).getIdentifier().getValue());
     }
     
     @Override
@@ -290,7 +290,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     @Override
     public ASTNode visitDropColumnSpecification(final DropColumnSpecificationContext ctx) {
         return new DropColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                ((ColumnSegment) visit(ctx.columnName())).getName());
+                ((ColumnSegment) visit(ctx.columnName())).getIdentifier().getValue());
     }
     
     @Override
@@ -306,7 +306,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor {
     @Override
     public ASTNode visitRenameColumnSpecification(final RenameColumnSpecificationContext ctx) {
         return new RenameColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                ((ColumnSegment) visit(ctx.columnName(0))).getName(), ((ColumnSegment) visit(ctx.columnName(1))).getName());
+                ((ColumnSegment) visit(ctx.columnName(0))).getIdentifier().getValue(), ((ColumnSegment) visit(ctx.columnName(1))).getIdentifier().getValue());
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDMLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/visitor/MySQLDMLVisitor.java
@@ -349,8 +349,7 @@ public final class MySQLDMLVisitor extends MySQLVisitor {
             QualifiedShorthandContext shorthand = ctx.qualifiedShorthand();
             ShorthandProjectionSegment result = new ShorthandProjectionSegment(shorthand.getStart().getStartIndex(), shorthand.getStop().getStopIndex(), shorthand.getText());
             IdentifierValue identifier = new IdentifierValue(shorthand.identifier().getText());
-            result.setOwner(new TableSegment(
-                    shorthand.identifier().getStart().getStartIndex(), shorthand.identifier().getStop().getStopIndex(), identifier.getValue(), identifier.getQuoteCharacter()));
+            result.setOwner(new TableSegment(shorthand.identifier().getStart().getStartIndex(), shorthand.identifier().getStop().getStopIndex(), identifier));
             return result;
         }
         String alias = null == ctx.alias() ? null : ctx.alias().getText();

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngine.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngine.java
@@ -90,7 +90,7 @@ public final class RowNumberPaginationContextEngine {
     }
     
     private boolean isRowNumberColumn(final PredicateSegment predicate, final String rowNumberAlias) {
-        return ROW_NUMBER_IDENTIFIERS.contains(predicate.getColumn().getName()) || predicate.getColumn().getName().equalsIgnoreCase(rowNumberAlias);
+        return ROW_NUMBER_IDENTIFIERS.contains(predicate.getColumn().getIdentifier().getValue()) || predicate.getColumn().getIdentifier().getValue().equalsIgnoreCase(rowNumberAlias);
     }
     
     private boolean isCompareCondition(final PredicateSegment predicate) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/TopPaginationContextEngine.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/TopPaginationContextEngine.java
@@ -68,7 +68,7 @@ public final class TopPaginationContextEngine {
     }
     
     private boolean isRowNumberColumn(final PredicateSegment predicate, final String rowNumberAlias) {
-        return predicate.getColumn().getName().equalsIgnoreCase(rowNumberAlias);
+        return predicate.getColumn().getIdentifier().getValue().equalsIgnoreCase(rowNumberAlias);
     }
     
     private boolean isCompareCondition(final PredicateSegment predicate) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngine.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngine.java
@@ -74,11 +74,11 @@ public final class ProjectionEngine {
     
     private ShorthandProjection createProjection(final ShorthandProjectionSegment projectionSegment) {
         Optional<TableSegment> owner = projectionSegment.getOwner();
-        return new ShorthandProjection(owner.isPresent() ? owner.get().getTableName() : null);
+        return new ShorthandProjection(owner.isPresent() ? owner.get().getTable().getValue() : null);
     }
     
     private ColumnProjection createProjection(final ColumnProjectionSegment projectionSegment) {
-        String owner = projectionSegment.getOwner().isPresent() ? projectionSegment.getOwner().get().getTableName() : null;
+        String owner = projectionSegment.getOwner().isPresent() ? projectionSegment.getOwner().get().getTable().getValue() : null;
         return new ColumnProjection(owner, projectionSegment.getName(), projectionSegment.getAlias().orNull());
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngine.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngine.java
@@ -79,7 +79,7 @@ public final class ProjectionEngine {
     
     private ColumnProjection createProjection(final ColumnProjectionSegment projectionSegment) {
         String owner = projectionSegment.getOwner().isPresent() ? projectionSegment.getOwner().get().getTable().getValue() : null;
-        return new ColumnProjection(owner, projectionSegment.getName(), projectionSegment.getAlias().orNull());
+        return new ColumnProjection(owner, projectionSegment.getIdentifier().getValue(), projectionSegment.getAlias().orNull());
     }
     
     private ExpressionProjection createProjection(final ExpressionProjectionSegment projectionSegment) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngine.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngine.java
@@ -223,7 +223,7 @@ public final class ProjectionsContextEngine {
     private boolean isSameProjection(final TablesContext tablesContext, final ShorthandProjection shorthandProjection, final ColumnOrderByItemSegment orderItem) {
         Preconditions.checkState(shorthandProjection.getOwner().isPresent());
         Optional<Table> table = tablesContext.find(shorthandProjection.getOwner().get());
-        return table.isPresent() && relationMetas.containsColumn(table.get().getName(), orderItem.getColumn().getName());
+        return table.isPresent() && relationMetas.containsColumn(table.get().getName(), orderItem.getColumn().getIdentifier().getValue());
     }
     
     private boolean isSameAlias(final Projection projection, final TextOrderByItemSegment orderItem) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngine.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngine.java
@@ -109,8 +109,8 @@ public final class ProjectionsContextEngine {
     
     private Collection<String> getQualifiedShorthandColumnLabels(final Collection<TableSegment> tables, final String owner) {
         for (TableSegment each : tables) {
-            if (owner.equalsIgnoreCase(each.getAlias().or(each.getTableName()))) {
-                return relationMetas.getAllColumnNames(each.getTableName());
+            if (owner.equalsIgnoreCase(each.getAlias().or(each.getTable().getValue()))) {
+                return relationMetas.getAllColumnNames(each.getTable().getValue());
             }
         }
         return Collections.emptyList();
@@ -119,7 +119,7 @@ public final class ProjectionsContextEngine {
     private Collection<String> getUnqualifiedShorthandColumnLabels(final Collection<TableSegment> tables) {
         Collection<String> result = new LinkedList<>();
         for (TableSegment each : tables) {
-            result.addAll(relationMetas.getAllColumnNames(each.getTableName()));
+            result.addAll(relationMetas.getAllColumnNames(each.getTable().getValue()));
         }
         return result;
     }
@@ -176,7 +176,7 @@ public final class ProjectionsContextEngine {
     
     private boolean containsItemWithOwnerInShorthandProjections(final TablesContext tablesContext, final Collection<Projection> projections, final OrderByItemSegment orderItem) {
         return orderItem instanceof ColumnOrderByItemSegment && ((ColumnOrderByItemSegment) orderItem).getColumn().getOwner().isPresent()
-                && findShorthandProjection(tablesContext, projections, ((ColumnOrderByItemSegment) orderItem).getColumn().getOwner().get().getTableName()).isPresent();
+                && findShorthandProjection(tablesContext, projections, ((ColumnOrderByItemSegment) orderItem).getColumn().getOwner().get().getTable().getValue()).isPresent();
     }
     
     private Optional<ShorthandProjection> findShorthandProjection(final TablesContext tablesContext, final Collection<Projection> projections, final String tableNameOrAlias) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContext.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContext.java
@@ -55,10 +55,10 @@ public final class TablesContext {
         }
         for (TableAvailable each : sqlStatement.findSQLSegments(TableAvailable.class)) {
             Optional<String> alias = getAlias(each);
-            if (aliases.contains(each.getTableName()) && !alias.isPresent()) {
+            if (aliases.contains(each.getTable().getValue()) && !alias.isPresent()) {
                 continue;
             }
-            tables.add(new Table(each.getTableName(), alias.orNull()));
+            tables.add(new Table(each.getTable().getValue(), alias.orNull()));
             if (each instanceof TableSegment) {
                 setSchema((TableSegment) each);
             }
@@ -164,7 +164,7 @@ public final class TablesContext {
             return Optional.of(getSingleTableName());
         }
         if (columnSegment.getOwner().isPresent()) {
-            Optional<Table> table = find(columnSegment.getOwner().get().getTableName());
+            Optional<Table> table = find(columnSegment.getOwner().get().getTable().getValue());
             return table.isPresent() ? Optional.of(table.get().getName()) : Optional.<String>absent();
         }
         return findTableNameFromMetaData(columnSegment.getName(), relationMetas);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContext.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContext.java
@@ -71,10 +71,10 @@ public final class TablesContext {
     
     private void setSchema(final TableSegment tableSegment) {
         if (tableSegment.getOwner().isPresent()) {
-            if (null != schema && !tableSegment.getOwner().get().getName().equalsIgnoreCase(schema)) {
+            if (null != schema && !tableSegment.getOwner().get().getIdentifier().getValue().equalsIgnoreCase(schema)) {
                 throw new UnsupportedOperationException("Cannot support multiple schemas in one SQL");
             }
-            schema = tableSegment.getOwner().get().getName();
+            schema = tableSegment.getOwner().get().getIdentifier().getValue();
         }
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContext.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContext.java
@@ -167,7 +167,7 @@ public final class TablesContext {
             Optional<Table> table = find(columnSegment.getOwner().get().getTable().getValue());
             return table.isPresent() ? Optional.of(table.get().getName()) : Optional.<String>absent();
         }
-        return findTableNameFromMetaData(columnSegment.getName(), relationMetas);
+        return findTableNameFromMetaData(columnSegment.getIdentifier().getValue(), relationMetas);
     }
     
     private Optional<String> findTableNameFromMetaData(final String columnName, final RelationMetas relationMetas) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectSQLStatementContext.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/main/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectSQLStatementContext.java
@@ -156,7 +156,7 @@ public final class SelectSQLStatementContext extends CommonSQLStatementContext {
     
     private String getOrderItemText(final TextOrderByItemSegment orderByItemSegment) {
         return orderByItemSegment instanceof ColumnOrderByItemSegment
-                ? ((ColumnOrderByItemSegment) orderByItemSegment).getColumn().getName() : ((ExpressionOrderByItemSegment) orderByItemSegment).getExpression();
+                ? ((ColumnOrderByItemSegment) orderByItemSegment).getColumn().getIdentifier().getValue() : ((ExpressionOrderByItemSegment) orderByItemSegment).getExpression();
     }
     
     /**

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.engine;
 
 import com.google.common.base.Optional;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
@@ -30,6 +29,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.rownum.Pa
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.AndPredicate;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.PredicateSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateCompareRightValue;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -89,7 +89,7 @@ public final class RowNumberPaginationContextEngineTest {
         when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         AndPredicate andPredicate = mock(AndPredicate.class);
         PredicateSegment predicateSegment = mock(PredicateSegment.class);
-        when(predicateSegment.getColumn()).thenReturn(new ColumnSegment(0, 10, "rownum", QuoteCharacter.NONE));
+        when(predicateSegment.getColumn()).thenReturn(new ColumnSegment(0, 10, new IdentifierValue("rownum")));
         when(andPredicate.getPredicates()).thenReturn(Collections.singleton(predicateSegment));
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
@@ -102,7 +102,7 @@ public final class RowNumberPaginationContextEngineTest {
         when(predicateCompareRightValue.getOperator()).thenReturn(">");
         when(predicateCompareRightValue.getExpression()).thenReturn(new ParameterMarkerExpressionSegment(0, 10, 0));
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, "rownum", QuoteCharacter.NONE), predicateCompareRightValue));
+        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue("rownum")), predicateCompareRightValue));
         ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
         when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         PaginationContext paginationContext = new RowNumberPaginationContextEngine()
@@ -118,7 +118,7 @@ public final class RowNumberPaginationContextEngineTest {
         when(predicateCompareRightValue.getOperator()).thenReturn(operator);
         when(predicateCompareRightValue.getExpression()).thenReturn(new LiteralExpressionSegment(0, 10, 100));
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, "rownum", QuoteCharacter.NONE), predicateCompareRightValue));
+        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue("rownum")), predicateCompareRightValue));
         ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
         when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());
@@ -138,7 +138,7 @@ public final class RowNumberPaginationContextEngineTest {
         when(predicateCompareRightValue.getOperator()).thenReturn(operator);
         when(predicateCompareRightValue.getExpression()).thenReturn(new LiteralExpressionSegment(0, 10, 100));
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, "rownum", QuoteCharacter.NONE), predicateCompareRightValue));
+        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue("rownum")), predicateCompareRightValue));
         ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
         when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         PaginationContext rowNumberPaginationContextEngine = new RowNumberPaginationContextEngine()

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/TopPaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/TopPaginationContextEngineTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.engine;
 
 import com.google.common.base.Optional;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
@@ -32,6 +31,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.AndPredica
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.PredicateSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateCompareRightValue;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.predicate.value.PredicateInRightValue;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -79,7 +79,7 @@ public final class TopPaginationContextEngineTest {
     @Test
     public void assertCreatePaginationContextWhenPredicateInRightValue() {
         String name = "rowNumberAlias";
-        ColumnSegment columnSegment = new ColumnSegment(0, 10, name, QuoteCharacter.NONE);
+        ColumnSegment columnSegment = new ColumnSegment(0, 10, new IdentifierValue(name));
         PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, mock(PredicateInRightValue.class));
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(predicateSegment);
@@ -94,7 +94,7 @@ public final class TopPaginationContextEngineTest {
     @Test
     public void assertCreatePaginationContextWhenParameterMarkerRowNumberValueSegment() {
         String name = "rowNumberAlias";
-        ColumnSegment columnSegment = new ColumnSegment(0, 10, name, QuoteCharacter.NONE);
+        ColumnSegment columnSegment = new ColumnSegment(0, 10, new IdentifierValue(name));
         PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
         when(predicateCompareRightValue.getOperator()).thenReturn(">");
         when(predicateCompareRightValue.getExpression()).thenReturn(new ParameterMarkerExpressionSegment(0, 10, 0));
@@ -118,7 +118,7 @@ public final class TopPaginationContextEngineTest {
     
     private void assertCreatePaginationContextWhenRowNumberPredicatePresentAndWithGivenOperator(final String operator) {
         String name = "rowNumberAlias";
-        ColumnSegment columnSegment = new ColumnSegment(0, 10, name, QuoteCharacter.NONE);
+        ColumnSegment columnSegment = new ColumnSegment(0, 10, new IdentifierValue(name));
         PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
         when(predicateCompareRightValue.getOperator()).thenReturn(operator);
         when(predicateCompareRightValue.getExpression()).thenReturn(new LiteralExpressionSegment(0, 10, 100));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ColumnProjectio
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -52,7 +53,7 @@ public final class ProjectionEngineTest {
     @Test
     public void assertCreateProjectionWhenProjectionSegmentInstanceOfShorthandProjectionSegment() {
         ShorthandProjectionSegment shorthandProjectionSegment = mock(ShorthandProjectionSegment.class);
-        when(shorthandProjectionSegment.getOwner()).thenReturn(Optional.of(mock(TableSegment.class)));
+        when(shorthandProjectionSegment.getOwner()).thenReturn(Optional.of(new TableSegment(0, 0, new IdentifierValue("tbl"))));
         Optional<Projection> actual = new ProjectionEngine().createProjection(null, shorthandProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(ShorthandProjection.class));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sql.parser.relation.segment.select.projection.
 
 import com.google.common.base.Optional;
 import org.apache.shardingsphere.sql.parser.core.constant.AggregationType;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.Projection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.impl.AggregationDistinctProjection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.impl.AggregationProjection;
@@ -61,7 +60,7 @@ public final class ProjectionEngineTest {
     
     @Test
     public void assertCreateProjectionWhenProjectionSegmentInstanceOfColumnProjectionSegment() {
-        ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment("text", new ColumnSegment(0, 10, "name", QuoteCharacter.NONE));
+        ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment("text", new ColumnSegment(0, 10, new IdentifierValue("name")));
         columnProjectionSegment.setAlias("alias");
         Optional<Projection> actual = new ProjectionEngine().createProjection(null, columnProjectionSegment);
         assertTrue(actual.isPresent());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.generic.SchemaSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableAvailable;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -61,7 +62,7 @@ public final class ProjectionsContextEngineTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
-        TableSegment owner = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
         owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
@@ -75,7 +76,7 @@ public final class ProjectionsContextEngineTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
-        TableSegment owner = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
         owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
@@ -93,7 +94,7 @@ public final class ProjectionsContextEngineTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
-        TableSegment owner = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
         owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
@@ -111,7 +112,7 @@ public final class ProjectionsContextEngineTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
-        TableSegment owner = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
         owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
@@ -133,7 +134,7 @@ public final class ProjectionsContextEngineTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
-        TableSegment owner = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
         owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
@@ -154,12 +155,12 @@ public final class ProjectionsContextEngineTest {
         SelectStatement selectStatement = mock(SelectStatement.class);
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
-        TableSegment tableSegment = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment tableSegment = new TableSegment(0, 10, new IdentifierValue("name"));
         SchemaSegment schemaSegment = mock(SchemaSegment.class);
         when(schemaSegment.getName()).thenReturn("name");
         tableSegment.setOwner(schemaSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
-        TableSegment owner = new TableSegment(0, 10, "name", QuoteCharacter.NONE);
+        TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
         owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
         shorthandProjectionSegment.setOwner(owner);
         when(selectStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable) tableSegment));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -162,9 +162,8 @@ public final class ProjectionsContextEngineTest {
         owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(selectStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable) tableSegment));
-        ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getName()).thenReturn("name");
-        when(columnSegment.getOwner()).thenReturn(Optional.of(tableSegment));
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("col"));
+        columnSegment.setOwner(tableSegment);
         ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment("ColumnProjectionSegment", columnSegment);
         columnProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Lists.<ProjectionSegment>newArrayList(columnProjectionSegment, shorthandProjectionSegment));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sql.parser.relation.segment.select.projection.
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByItem;
@@ -63,7 +62,7 @@ public final class ProjectionsContextEngineTest {
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
-        owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
+        owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
         ProjectionsContext actual = new ProjectionsContextEngine(null).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
@@ -77,7 +76,7 @@ public final class ProjectionsContextEngineTest {
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
-        owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
+        owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
         OrderByContext orderByContext = mock(OrderByContext.class);
@@ -95,7 +94,7 @@ public final class ProjectionsContextEngineTest {
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
-        owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
+        owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
         OrderByContext orderByContext = mock(OrderByContext.class);
@@ -113,7 +112,7 @@ public final class ProjectionsContextEngineTest {
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
-        owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
+        owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
         OrderByContext orderByContext = mock(OrderByContext.class);
@@ -135,14 +134,14 @@ public final class ProjectionsContextEngineTest {
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
-        owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
+        owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(projectionsSegment.getProjections()).thenReturn(Collections.<ProjectionSegment>singleton(shorthandProjectionSegment));
         OrderByContext orderByContext = mock(OrderByContext.class);
         OrderByItem orderByItem = mock(OrderByItem.class);
         ColumnOrderByItemSegment columnOrderByItemSegment = mock(ColumnOrderByItemSegment.class);
         ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getOwner()).thenReturn(Optional.of(mock(TableSegment.class)));
+        when(columnSegment.getOwner()).thenReturn(Optional.of(new TableSegment(0, 0, new IdentifierValue("tbl"))));
         when(columnOrderByItemSegment.getColumn()).thenReturn(columnSegment);
         when(orderByItem.getSegment()).thenReturn(columnOrderByItemSegment);
         when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
@@ -156,12 +155,11 @@ public final class ProjectionsContextEngineTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
         TableSegment tableSegment = new TableSegment(0, 10, new IdentifierValue("name"));
-        SchemaSegment schemaSegment = mock(SchemaSegment.class);
-        when(schemaSegment.getName()).thenReturn("name");
+        SchemaSegment schemaSegment = new SchemaSegment(0, 0, new IdentifierValue("schema"));
         tableSegment.setOwner(schemaSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment owner = new TableSegment(0, 10, new IdentifierValue("name"));
-        owner.setOwner(new SchemaSegment(0, 10, "name", QuoteCharacter.NONE));
+        owner.setOwner(new SchemaSegment(0, 10, new IdentifierValue("name")));
         shorthandProjectionSegment.setOwner(owner);
         when(selectStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable) tableSegment));
         ColumnSegment columnSegment = mock(ColumnSegment.class);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContextTest.java
@@ -196,9 +196,8 @@ public final class TablesContextTest {
     @Test
     public void assertInstanceCreatedWhenNoExceptionThrown() {
         SQLStatement sqlStatement = mock(SQLStatement.class);
-        TableSegment tableSegment = new TableSegment(0, 10, new IdentifierValue("TableSegmentName"));
-        SchemaSegment schemaSegment = mock(SchemaSegment.class);
-        when(schemaSegment.getName()).thenReturn("SchemaSegmentName");
+        TableSegment tableSegment = new TableSegment(0, 10, new IdentifierValue("tbl"));
+        SchemaSegment schemaSegment = new SchemaSegment(0, 0, new IdentifierValue("schema"));
         tableSegment.setOwner(schemaSegment);
         when(sqlStatement.findSQLSegments(TableAvailable.class)).thenReturn(Collections.singletonList((TableAvailable) tableSegment));
         new TablesContext(sqlStatement);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContextTest.java
@@ -167,8 +167,7 @@ public final class TablesContextTest {
         selectStatement.getAllSQLSegments().add(createTableSegment("table_1", "tbl_1"));
         selectStatement.getAllSQLSegments().add(createTableSegment("table_2", "tbl_2"));
         TablesContext tablesContext = new TablesContext(selectStatement);
-        ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getOwner()).thenReturn(Optional.<TableSegment>absent());
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("col"));
         RelationMetas relationMetas = mock(RelationMetas.class);
         assertFalse(tablesContext.findTableName(columnSegment, relationMetas).isPresent());
     }
@@ -178,9 +177,7 @@ public final class TablesContextTest {
         SelectStatement selectStatement = new SelectStatement();
         selectStatement.getAllSQLSegments().add(createTableSegment("table_1", "tbl_1"));
         selectStatement.getAllSQLSegments().add(createTableSegment("table_2", "tbl_2"));
-        ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getOwner()).thenReturn(Optional.<TableSegment>absent());
-        when(columnSegment.getName()).thenReturn("columnName");
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("col"));
         RelationMetas relationMetas = mock(RelationMetas.class);
         when(relationMetas.containsColumn(anyString(), anyString())).thenReturn(true);
         assertTrue(new TablesContext(selectStatement).findTableName(columnSegment, relationMetas).isPresent());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/table/TablesContextTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sql.parser.relation.segment.table;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.metadata.RelationMetas;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.SchemaSegment;
@@ -27,6 +26,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableAvailable;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
@@ -157,7 +157,7 @@ public final class TablesContextTest {
         selectStatement.getAllSQLSegments().add(createTableSegment("table_2", "tbl_2"));
         TablesContext tablesContext = new TablesContext(selectStatement);
         ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getOwner()).thenReturn(Optional.of(new TableSegment(0, 10, "table_1", QuoteCharacter.NONE)));
+        when(columnSegment.getOwner()).thenReturn(Optional.of(new TableSegment(0, 10, new IdentifierValue("table_1"))));
         assertTrue(tablesContext.findTableName(columnSegment, null).isPresent());
     }
     
@@ -196,7 +196,7 @@ public final class TablesContextTest {
     @Test
     public void assertInstanceCreatedWhenNoExceptionThrown() {
         SQLStatement sqlStatement = mock(SQLStatement.class);
-        TableSegment tableSegment = new TableSegment(0, 10, "TableSegmentName", QuoteCharacter.NONE);
+        TableSegment tableSegment = new TableSegment(0, 10, new IdentifierValue("TableSegmentName"));
         SchemaSegment schemaSegment = mock(SchemaSegment.class);
         when(schemaSegment.getName()).thenReturn("SchemaSegmentName");
         tableSegment.setOwner(schemaSegment);
@@ -205,7 +205,7 @@ public final class TablesContextTest {
     }
     
     private TableSegment createTableSegment(final String tableName, final String alias) {
-        TableSegment result = new TableSegment(0, 0, tableName, QuoteCharacter.NONE);
+        TableSegment result = new TableSegment(0, 0, new IdentifierValue(tableName));
         result.setAlias(alias);
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/InsertSQLStatementContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/InsertSQLStatementContextTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.LiteralE
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.InsertStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -41,7 +42,7 @@ public final class InsertSQLStatementContextTest {
     @Test
     public void assertInsertSQLStatementContextWithColumnNames() {
         InsertStatement insertStatement = new InsertStatement();
-        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, "tbl", QuoteCharacter.NONE));
+        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl")));
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
         insertColumnsSegment.getColumns().addAll(Arrays.asList(
                 new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new ColumnSegment(0, 0, "name", QuoteCharacter.NONE), new ColumnSegment(0, 0, "status", QuoteCharacter.NONE)));
@@ -56,7 +57,7 @@ public final class InsertSQLStatementContextTest {
         RelationMetas relationMetas = mock(RelationMetas.class);
         when(relationMetas.getAllColumnNames("tbl")).thenReturn(Arrays.asList("id", "name", "status"));
         InsertStatement insertStatement = new InsertStatement();
-        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, "tbl", QuoteCharacter.NONE));
+        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl")));
         setUpInsertValues(insertStatement);
         InsertSQLStatementContext actual = new InsertSQLStatementContext(relationMetas, Arrays.<Object>asList(1, "Tom", 2, "Jerry"), insertStatement);
         assertInsertSQLStatementContext(actual);
@@ -67,7 +68,7 @@ public final class InsertSQLStatementContextTest {
         RelationMetas relationMetas = mock(RelationMetas.class);
         when(relationMetas.getAllColumnNames("tbl")).thenReturn(Arrays.asList("id", "name", "status"));
         InsertStatement insertStatement = new InsertStatement();
-        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, "tbl", QuoteCharacter.NONE));
+        insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl")));
         setUpInsertValues(insertStatement);
         InsertSQLStatementContext actual = new InsertSQLStatementContext(relationMetas, Arrays.<Object>asList(1, "Tom", 2, "Jerry"), insertStatement);
         assertThat(actual.getGroupedParameters().size(), is(2));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/InsertSQLStatementContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/InsertSQLStatementContextTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.relation.statement.impl;
 
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.metadata.RelationMetas;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.assignment.InsertValuesSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
@@ -45,7 +44,7 @@ public final class InsertSQLStatementContextTest {
         insertStatement.getAllSQLSegments().add(new TableSegment(0, 0, new IdentifierValue("tbl")));
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0);
         insertColumnsSegment.getColumns().addAll(Arrays.asList(
-                new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), new ColumnSegment(0, 0, "name", QuoteCharacter.NONE), new ColumnSegment(0, 0, "status", QuoteCharacter.NONE)));
+                new ColumnSegment(0, 0, new IdentifierValue("id")), new ColumnSegment(0, 0, new IdentifierValue("name")), new ColumnSegment(0, 0, new IdentifierValue("status"))));
         insertStatement.setColumns(insertColumnsSegment);
         setUpInsertValues(insertStatement);
         InsertSQLStatementContext actual = new InsertSQLStatementContext(mock(RelationMetas.class), Arrays.<Object>asList(1, "Tom", 2, "Jerry"), insertStatement);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectSQLStatementContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectSQLStatementContextTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sql.parser.relation.statement.impl;
 
 import com.google.common.collect.Lists;
 import org.apache.shardingsphere.sql.parser.core.constant.OrderDirection;
-import org.apache.shardingsphere.sql.parser.core.constant.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByItem;
@@ -151,13 +150,13 @@ public final class SelectSQLStatementContextTest {
             case INDEX_ORDER_BY:
                 return new IndexOrderByItemSegment(0, 0, 4, OrderDirection.ASC, OrderDirection.ASC);
             case COLUMN_ORDER_BY_WITH_OWNER:
-                ColumnSegment columnSegment = new ColumnSegment(0, 0, "name", QuoteCharacter.NONE);
+                ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("name"));
                 columnSegment.setOwner(new TableSegment(0, 0, new IdentifierValue("table")));
                 return new ColumnOrderByItemSegment(columnSegment, OrderDirection.ASC, OrderDirection.ASC);
             case COLUMN_ORDER_BY_WITH_ALIAS:
-                return new ColumnOrderByItemSegment(new ColumnSegment(0, 0, "n", QuoteCharacter.NONE), OrderDirection.ASC, OrderDirection.ASC);
+                return new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("n")), OrderDirection.ASC, OrderDirection.ASC);
             default:
-                return new ColumnOrderByItemSegment(new ColumnSegment(0, 0, "id", QuoteCharacter.NONE), OrderDirection.ASC, OrderDirection.ASC);
+                return new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("id")), OrderDirection.ASC, OrderDirection.ASC);
         }
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectSQLStatementContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectSQLStatementContextTest.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.IndexOrde
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -151,7 +152,7 @@ public final class SelectSQLStatementContextTest {
                 return new IndexOrderByItemSegment(0, 0, 4, OrderDirection.ASC, OrderDirection.ASC);
             case COLUMN_ORDER_BY_WITH_OWNER:
                 ColumnSegment columnSegment = new ColumnSegment(0, 0, "name", QuoteCharacter.NONE);
-                columnSegment.setOwner(new TableSegment(0, 0, "table", QuoteCharacter.NONE));
+                columnSegment.setOwner(new TableSegment(0, 0, new IdentifierValue("table")));
                 return new ColumnOrderByItemSegment(columnSegment, OrderDirection.ASC, OrderDirection.ASC);
             case COLUMN_ORDER_BY_WITH_ALIAS:
                 return new ColumnOrderByItemSegment(new ColumnSegment(0, 0, "n", QuoteCharacter.NONE), OrderDirection.ASC, OrderDirection.ASC);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/column/ColumnAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/column/ColumnAssert.java
@@ -46,15 +46,15 @@ public final class ColumnAssert {
      * @param expected expected column
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnSegment actual, final ExpectedColumn expected) {
-        assertThat(assertContext.getText("Column name assertion error: "), actual.getName(), is(expected.getName()));
+        assertThat(assertContext.getText("Column name assertion error: "), actual.getIdentifier().getValue(), is(expected.getName()));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getOwner().isPresent());
             TableAssert.assertOwner(assertContext, actual.getOwner().get(), expected.getOwner());
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getOwner().isPresent());
         }
-        assertThat(assertContext.getText("Column start delimiter assertion error: "), actual.getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Column end delimiter assertion error: "), actual.getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        assertThat(assertContext.getText("Column start delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText("Column end delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/index/IndexAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/index/IndexAssert.java
@@ -44,9 +44,9 @@ public final class IndexAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final IndexSegment actual, final ExpectedIndex expected) {
         assertNotNull(assertContext.getText("Index should exist."), expected);
-        assertThat(assertContext.getText("Index name assertion error: "), actual.getName(), is(expected.getName()));
-        assertThat(assertContext.getText("Index name start delimiter assertion error: "), actual.getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Index name end delimiter assertion error: "), actual.getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        assertThat(assertContext.getText("Index name assertion error: "), actual.getIdentifier().getValue(), is(expected.getName()));
+        assertThat(assertContext.getText("Index name start delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText("Index name end delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         // TODO assert start index and stop index
         //        SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/orderby/OrderByItemAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/orderby/OrderByItemAssert.java
@@ -91,7 +91,7 @@ public final class OrderByItemAssert {
     
     private static void assertColumnOrderByItem(final SQLCaseAssertContext assertContext,
                                                 final ColumnOrderByItemSegment actual, final ExpectedColumnOrderByItem expected, final String type) {
-        assertThat(assertContext.getText(String.format("%s item column name assertion error: ", type)), actual.getColumn().getName(), is(expected.getName()));
+        assertThat(assertContext.getText(String.format("%s item column name assertion error: ", type)), actual.getColumn().getIdentifier().getValue(), is(expected.getName()));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getColumn().getOwner().isPresent());
             TableAssert.assertOwner(assertContext, actual.getColumn().getOwner().get(), expected.getOwner());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/projection/ProjectionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/projection/ProjectionAssert.java
@@ -110,9 +110,9 @@ public final class ProjectionAssert {
     }
     
     private static void assertColumnProjection(final SQLCaseAssertContext assertContext, final ColumnProjectionSegment actual, final ExpectedColumnProjection expected) {
-        assertThat(assertContext.getText("Column projection name assertion error: "), actual.getName(), is(expected.getName()));
-        assertThat(assertContext.getText("Column projection start delimiter assertion error: "), actual.getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Column projection end delimiter assertion error: "), actual.getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        assertThat(assertContext.getText("Column projection name assertion error: "), actual.getIdentifier().getValue(), is(expected.getName()));
+        assertThat(assertContext.getText("Column projection start delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText("Column projection end delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         assertThat(assertContext.getText("Column projection alias assertion error: "), actual.getAlias().orNull(), is(expected.getAlias()));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getOwner().isPresent());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/schema/SchemaAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/schema/SchemaAssert.java
@@ -43,9 +43,9 @@ public final class SchemaAssert {
      * @param expected expected schema
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SchemaSegment actual, final ExpectedSchema expected) {
-        assertThat(assertContext.getText("Owner name assertion error: "), actual.getName(), is(expected.getName()));
-        assertThat(assertContext.getText("Owner start delimiter assertion error: "), actual.getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Owner end delimiter assertion error: "), actual.getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        assertThat(assertContext.getText("Owner name assertion error: "), actual.getIdentifier().getValue(), is(expected.getName()));
+        assertThat(assertContext.getText("Owner start delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText("Owner end delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/table/TableAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/table/TableAssert.java
@@ -66,7 +66,7 @@ public final class TableAssert {
      * @param expected expected table
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final TableSegment actual, final ExpectedTable expected) {
-        assertThat(assertContext.getText("Table name assertion error: "), actual.getTableName(), is(expected.getName()));
+        assertThat(assertContext.getText("Table name assertion error: "), actual.getTable().getValue(), is(expected.getName()));
         assertThat(assertContext.getText("Table alias assertion error: "), actual.getAlias().orNull(), is(expected.getAlias()));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getOwner().isPresent());
@@ -74,8 +74,8 @@ public final class TableAssert {
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getOwner().isPresent());
         }
-        assertThat(assertContext.getText("Table start delimiter assertion error: "), actual.getTableQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Table end delimiter assertion error: "), actual.getTableQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        assertThat(assertContext.getText("Table start delimiter assertion error: "), actual.getTable().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText("Table end delimiter assertion error: "), actual.getTable().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
     
@@ -87,9 +87,9 @@ public final class TableAssert {
      * @param expected expected table owner
      */
     public static void assertOwner(final SQLCaseAssertContext assertContext, final TableSegment actual, final ExpectedTableOwner expected) {
-        assertThat(assertContext.getText("Owner name assertion error: "), actual.getTableName(), is(expected.getName()));
-        assertThat(assertContext.getText("Owner name start delimiter assertion error: "), actual.getTableQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Owner name end delimiter assertion error: "), actual.getTableQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        assertThat(assertContext.getText("Owner name assertion error: "), actual.getTable().getValue(), is(expected.getName()));
+        assertThat(assertContext.getText("Owner name start delimiter assertion error: "), actual.getTable().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText("Owner name end delimiter assertion error: "), actual.getTable().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }


### PR DESCRIPTION
For #3914.

Changes proposed in this pull request:
- Use identifier value to instead of name and quote character in TableSegment
- Use identifier value to instead of name and quote character in SchemaSegment
- Use identifier value to instead of name and quote character in ColumnSegment
- Use identifier value to instead of name and quote character in IndexSegment
