### PR TITLE
add downloadRoot for frontend-maven-plugin

### DIFF
--- a/sharding-ui/sharding-ui-frontend/pom.xml
+++ b/sharding-ui/sharding-ui-frontend/pom.xml
@@ -46,6 +46,7 @@
                         <configuration>
                             <nodeVersion>${node.version}</nodeVersion>
                             <npmVersion>${npm.version}</npmVersion>
+                            <downloadRoot>http://npm.taobao.org/mirrors/node/</downloadRoot>
                         </configuration>
                     </execution>
                     <execution>

--- a/sharding-ui/sharding-ui-frontend/pom.xml
+++ b/sharding-ui/sharding-ui-frontend/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <node.version>v6.10.0</node.version>
         <npm.version>3.10.10</npm.version>
+        <node-repo-mirror>https://nodejs.org/dist</node-repo-mirror>
     </properties>
 
     <build>
@@ -46,7 +47,7 @@
                         <configuration>
                             <nodeVersion>${node.version}</nodeVersion>
                             <npmVersion>${npm.version}</npmVersion>
-                            <downloadRoot>http://npm.taobao.org/mirrors/node/</downloadRoot>
+                            <downloadRoot>${node-repo-mirror}</downloadRoot>
                         </configuration>
                     </execution>
                     <execution>
@@ -82,4 +83,13 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>node-cn</id>
+            <properties>
+                <node-repo-mirror>http://npm.taobao.org/mirrors/node/</node-repo-mirror>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
`frontend-maven-plugin` will download node and npm from `https://nodejs.org/dist` by default, this is very slow for china's network. we can use a mirror site(`http://npm.taobao.org/mirrors/node/`) to speed up the build of ui-frontend module.

