### PR TITLE
rename "APM" to "APM Integration"

### DIFF
--- a/docs/document/content/features/orchestration/apm-integration.cn.md
+++ b/docs/document/content/features/orchestration/apm-integration.cn.md
@@ -1,7 +1,7 @@
 +++
 pre = "<b>3.3.4. </b>"
 toc = true
-title = "应用性能监控"
+title = "应用性能监控集成"
 weight = 4
 +++
 

--- a/docs/document/content/features/orchestration/apm-integration.en.md
+++ b/docs/document/content/features/orchestration/apm-integration.en.md
@@ -1,7 +1,7 @@
 +++
 pre = "<b>3.3.4. </b>"
 toc = true
-title = "APM"
+title = "APM Integration"
 weight = 4
 +++
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -110,11 +110,11 @@ You can get more detail from **[hint-example](./sharding-jdbc-example/other-feat
 
 You can get more detail from **[encrypt-example](./sharding-jdbc-example/other-feature-example/encrypt-example)**
 
-### Best Practice for APM
+### Best Practice for APM Integration
 
-We will add APM example recently.
+We will add APM integration example recently.
 
-### Best Practice for sharding-proxy.
+### Best Practice for sharding-proxy
 
 We prefer to add a docker base example recently.
 


### PR DESCRIPTION
Fixes #4470 .

Changes proposed in this pull request:
- rename "APM" to "APM Integration"
