### PR TITLE
Fix typo for TableTokenGenerator.isToGenerateTableTokenForRightValue

### DIFF
--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/TableTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/TableTokenGenerator.java
@@ -128,12 +128,12 @@ public final class TableTokenGenerator implements CollectionSQLTokenGenerator {
     
     private Collection<TableToken> getTableTokens(final SQLStatementContext sqlStatementContext, final PredicateSegment predicate) {
         Collection<TableToken> result = new LinkedList<>();
-        if (isToGenerateTableTokenForPredicate(sqlStatementContext.getTablesContext(), predicate)) {
+        if (isToGenerateTableTokenLeftValue(sqlStatementContext.getTablesContext(), predicate)) {
             Preconditions.checkState(predicate.getColumn().getOwner().isPresent());
             OwnerSegment segment = predicate.getColumn().getOwner().get();
             result.add(new TableToken(segment.getStartIndex(), segment.getStopIndex(), segment.getIdentifier()));
         }
-        if (isToGenerateTableTokenForColumn(sqlStatementContext.getTablesContext(), predicate)) {
+        if (isToGenerateTableTokenForRightValue(sqlStatementContext.getTablesContext(), predicate)) {
             Preconditions.checkState(((ColumnSegment) predicate.getRightValue()).getOwner().isPresent());
             OwnerSegment segment = ((ColumnSegment) predicate.getRightValue()).getOwner().get();
             result.add(new TableToken(segment.getStartIndex(), segment.getStopIndex(), segment.getIdentifier()));
@@ -146,12 +146,13 @@ public final class TableTokenGenerator implements CollectionSQLTokenGenerator {
         return result;
     }
     
-    private boolean isToGenerateTableTokenForPredicate(final TablesContext tablesContext, final PredicateSegment predicate) {
+    private boolean isToGenerateTableTokenLeftValue(final TablesContext tablesContext, final PredicateSegment predicate) {
         return predicate.getColumn().getOwner().isPresent() && isTable(predicate.getColumn().getOwner().get(), tablesContext);
     }
     
-    private boolean isToGenerateTableTokenForColumn(final TablesContext tablesContext, final PredicateSegment predicate) {
-        return predicate.getRightValue() instanceof ColumnSegment && predicate.getColumn().getOwner().isPresent() && isTable(predicate.getColumn().getOwner().get(), tablesContext);
+    private boolean isToGenerateTableTokenForRightValue(final TablesContext tablesContext, final PredicateSegment predicate) {
+        return predicate.getRightValue() instanceof ColumnSegment
+                && ((ColumnSegment) predicate.getRightValue()).getOwner().isPresent() && isTable(((ColumnSegment) predicate.getRightValue()).getOwner().get(), tablesContext);
     }
     
     private boolean isToGenerateTableTokenForProjection(final TablesContext tablesContext, final PredicateSegment predicate) {

--- a/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/TableTokenGenerator.java
+++ b/sharding-core/sharding-core-rewrite/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/TableTokenGenerator.java
@@ -172,14 +172,9 @@ public final class TableTokenGenerator implements CollectionSQLTokenGenerator, S
                 && isTable(((ColumnProjectionSegment) predicate.getRightValue()).getOwner().get(), tablesContext);
     }
     
-    private boolean isToGenerateTableToken(final TablesContext tablesContext, final OrderByItemSegment each) {
-        return each instanceof ColumnOrderByItemSegment && ((ColumnOrderByItemSegment) each).getColumn().getOwner().isPresent() 
-                && isTable(((ColumnOrderByItemSegment) each).getColumn().getOwner().get(), tablesContext);
-    }
-    
-    private boolean isToGenerateTableToken(final SQLStatementContext sqlStatementContext, final TableSegment tableSegment) {
-        Optional<Table> table = sqlStatementContext.getTablesContext().find(tableSegment.getIdentifier().getValue());
-        return table.isPresent() && !table.get().getAlias().isPresent() && shardingRule.findTableRule(table.get().getName()).isPresent();
+    private boolean isToGenerateTableToken(final TablesContext tablesContext, final OrderByItemSegment orderByItemSegment) {
+        return orderByItemSegment instanceof ColumnOrderByItemSegment && ((ColumnOrderByItemSegment) orderByItemSegment).getColumn().getOwner().isPresent() 
+                && isTable(((ColumnOrderByItemSegment) orderByItemSegment).getColumn().getOwner().get(), tablesContext);
     }
     
     private boolean isToGenerateTableToken(final SQLStatement sqlStatement, final TableSegment segment) {


### PR DESCRIPTION
The bug is use left value's owner to judge owner of right column value on table token generated class.