### PR TITLE
Replace mocks with instances in Unit Tests

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/groupby/engine/GroupByContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/groupby/engine/GroupByContextEngineTest.java
@@ -30,7 +30,6 @@ import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -61,7 +60,7 @@ public final class GroupByContextEngineTest {
         expectedOrderByItem2.setIndex(2);
         OrderByItem expectedOrderByItem3 = new OrderByItem(indexOrderByItemSegment2);
         expectedOrderByItem3.setIndex(3);
-        assertThat(actualGroupByContext.getItems(), is((Collection<OrderByItem>) Arrays.asList(expectedOrderByItem1, expectedOrderByItem2, expectedOrderByItem3)));
+        assertThat(actualGroupByContext.getItems(), is(Arrays.asList(expectedOrderByItem1, expectedOrderByItem2, expectedOrderByItem3)));
         assertThat(actualGroupByContext.getLastIndex(), is(10));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/groupby/engine/GroupByContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/groupby/engine/GroupByContextEngineTest.java
@@ -17,31 +17,30 @@
 
 package org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.engine;
 
+import org.apache.shardingsphere.sql.parser.core.constant.OrderDirection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByItem;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.GroupBySegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.IndexOrderByItemSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class GroupByContextEngineTest {
     
     @Test
     public void assertCreateGroupByContextWithoutGroupBy() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getGroupBy()).thenReturn(Optional.empty());
+        SelectStatement selectStatement = new SelectStatement();
         GroupByContext actualGroupByContext = new GroupByContextEngine().createGroupByContext(selectStatement);
         assertTrue(actualGroupByContext.getItems().isEmpty());
         assertThat(actualGroupByContext.getLastIndex(), is(0));
@@ -49,26 +48,20 @@ public final class GroupByContextEngineTest {
     
     @Test
     public void assertCreateGroupByContextWithGroupBy() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        ColumnOrderByItemSegment columnOrderByItemSegment = mock(ColumnOrderByItemSegment.class);
-        IndexOrderByItemSegment indexOrderByItemSegment1 = mock(IndexOrderByItemSegment.class);
-        when(indexOrderByItemSegment1.getColumnIndex()).thenReturn(2);
-        IndexOrderByItemSegment indexOrderByItemSegment2 = mock(IndexOrderByItemSegment.class);
-        when(indexOrderByItemSegment2.getColumnIndex()).thenReturn(3);
-        GroupBySegment groupBySegment = mock(GroupBySegment.class);
-        when(groupBySegment.getGroupByItems()).thenReturn(Arrays.asList(columnOrderByItemSegment, indexOrderByItemSegment1, indexOrderByItemSegment2));
-        when(groupBySegment.getStopIndex()).thenReturn(10);
-        when(selectStatement.getGroupBy()).thenReturn(Optional.of(groupBySegment));
+        SelectStatement selectStatement = new SelectStatement();
+        OrderByItemSegment columnOrderByItemSegment = new ColumnOrderByItemSegment(new ColumnSegment(0, 1, new IdentifierValue("column1")), OrderDirection.ASC);
+        OrderByItemSegment indexOrderByItemSegment1 = new IndexOrderByItemSegment(1, 2, 2, OrderDirection.ASC, OrderDirection.DESC);
+        OrderByItemSegment indexOrderByItemSegment2 = new IndexOrderByItemSegment(2, 3, 3, OrderDirection.ASC, OrderDirection.DESC);
+        GroupBySegment groupBySegment = new GroupBySegment(0, 10, Arrays.asList(columnOrderByItemSegment, indexOrderByItemSegment1, indexOrderByItemSegment2));
+        selectStatement.setGroupBy(groupBySegment);
+        
         GroupByContext actualGroupByContext = new GroupByContextEngine().createGroupByContext(selectStatement);
-        OrderByItem orderByItem1 = new OrderByItem(indexOrderByItemSegment1);
-        orderByItem1.setIndex(2);
-        OrderByItem orderByItem2 = new OrderByItem(indexOrderByItemSegment2);
-        orderByItem2.setIndex(3);
-        assertThat(actualGroupByContext.getItems(), is(Arrays.asList(new OrderByItem(columnOrderByItemSegment), orderByItem1, orderByItem2)));
+        OrderByItem expectedOrderByItem1 = new OrderByItem(columnOrderByItemSegment);
+        OrderByItem expectedOrderByItem2 = new OrderByItem(indexOrderByItemSegment1);
+        expectedOrderByItem2.setIndex(2);
+        OrderByItem expectedOrderByItem3 = new OrderByItem(indexOrderByItemSegment2);
+        expectedOrderByItem3.setIndex(3);
+        assertThat(actualGroupByContext.getItems(), is((Collection<OrderByItem>) Arrays.asList(expectedOrderByItem1, expectedOrderByItem2, expectedOrderByItem3)));
         assertThat(actualGroupByContext.getLastIndex(), is(10));
-        List<OrderByItem> results = new ArrayList<>(actualGroupByContext.getItems());
-        assertThat(results.get(0).getIndex(), is(0));
-        assertThat(results.get(1).getIndex(), is(2));
-        assertThat(results.get(2).getIndex(), is(3));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/orderby/engine/OrderByContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/orderby/engine/OrderByContextEngineTest.java
@@ -17,39 +17,37 @@
 
 package org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.engine;
 
+import org.apache.shardingsphere.sql.parser.core.constant.OrderDirection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByItem;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.OrderBySegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.IndexOrderByItemSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class OrderByContextEngineTest {
     
     @Test
     public void assertCreateOrderByWithoutOrderBy() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        GroupByContext groupByContext = mock(GroupByContext.class);
-        OrderByItem orderByItem1 = mock(OrderByItem.class);
-        OrderByItem orderByItem2 = mock(OrderByItem.class);
+        SelectStatement selectStatement = new SelectStatement();
+        OrderByItem orderByItem1 = new OrderByItem(new IndexOrderByItemSegment(0, 1, 1, OrderDirection.ASC, OrderDirection.DESC));
+        OrderByItem orderByItem2 = new OrderByItem(new IndexOrderByItemSegment(1, 2, 2, OrderDirection.ASC, OrderDirection.DESC));
         Collection<OrderByItem> orderByItems = Arrays.asList(orderByItem1, orderByItem2);
-        when(groupByContext.getItems()).thenReturn(orderByItems);
-        when(selectStatement.getOrderBy()).thenReturn(Optional.empty());
+        GroupByContext groupByContext = new GroupByContext(orderByItems, 0);
         OrderByContext actualOrderByContext = new OrderByContextEngine().createOrderBy(selectStatement, groupByContext);
         assertThat(actualOrderByContext.getItems(), is(orderByItems));
         assertTrue(actualOrderByContext.isGenerated());
@@ -57,25 +55,22 @@ public final class OrderByContextEngineTest {
     
     @Test
     public void assertCreateOrderByWithOrderBy() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        ColumnOrderByItemSegment columnOrderByItemSegment = mock(ColumnOrderByItemSegment.class);
-        IndexOrderByItemSegment indexOrderByItemSegment1 = mock(IndexOrderByItemSegment.class);
-        when(indexOrderByItemSegment1.getColumnIndex()).thenReturn(2);
-        IndexOrderByItemSegment indexOrderByItemSegment2 = mock(IndexOrderByItemSegment.class);
-        when(indexOrderByItemSegment2.getColumnIndex()).thenReturn(3);
-        OrderBySegment orderBySegment = mock(OrderBySegment.class);
-        when(orderBySegment.getOrderByItems()).thenReturn(Arrays.asList(columnOrderByItemSegment, indexOrderByItemSegment1, indexOrderByItemSegment2));
-        when(selectStatement.getOrderBy()).thenReturn(Optional.of(orderBySegment));
-        OrderByContext actualOrderByContext = new OrderByContextEngine().createOrderBy(selectStatement, mock(GroupByContext.class));
-        OrderByItem orderByItem1 = new OrderByItem(indexOrderByItemSegment1);
-        orderByItem1.setIndex(2);
-        OrderByItem orderByItem2 = new OrderByItem(indexOrderByItemSegment2);
-        orderByItem2.setIndex(3);
-        assertThat(actualOrderByContext.getItems(), is(Arrays.asList(new OrderByItem(columnOrderByItemSegment), orderByItem1, orderByItem2)));
+        SelectStatement selectStatement = new SelectStatement();
+        OrderByItemSegment columnOrderByItemSegment = new ColumnOrderByItemSegment(new ColumnSegment(0, 1, new IdentifierValue("column1")), OrderDirection.ASC);
+        OrderByItemSegment indexOrderByItemSegment1 = new IndexOrderByItemSegment(1, 2, 2, OrderDirection.ASC, OrderDirection.DESC);
+        OrderByItemSegment indexOrderByItemSegment2 = new IndexOrderByItemSegment(2, 3, 3, OrderDirection.ASC, OrderDirection.DESC);
+        OrderBySegment orderBySegment = new OrderBySegment(0, 1, Arrays.asList(columnOrderByItemSegment, indexOrderByItemSegment1, indexOrderByItemSegment2));
+        selectStatement.setOrderBy(orderBySegment);
+        GroupByContext emptyGroupByContext = new GroupByContext(Collections.<OrderByItem>emptyList(), 0);
+
+        OrderByContext actualOrderByContext = new OrderByContextEngine().createOrderBy(selectStatement, emptyGroupByContext);
+
+        OrderByItem expectedOrderByItem1 = new OrderByItem(columnOrderByItemSegment);
+        OrderByItem expectedOrderByItem2 = new OrderByItem(indexOrderByItemSegment1);
+        expectedOrderByItem2.setIndex(2);
+        OrderByItem expectedOrderByItem3 = new OrderByItem(indexOrderByItemSegment2);
+        expectedOrderByItem3.setIndex(3);
+        assertThat(actualOrderByContext.getItems(), is((Collection<OrderByItem>) Arrays.asList(expectedOrderByItem1, expectedOrderByItem2, expectedOrderByItem3)));
         assertFalse(actualOrderByContext.isGenerated());
-        List<OrderByItem> results = new ArrayList<>(actualOrderByContext.getItems());
-        assertThat(results.get(0).getIndex(), is(0));
-        assertThat(results.get(1).getIndex(), is(2));
-        assertThat(results.get(2).getIndex(), is(3));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/orderby/engine/OrderByContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/orderby/engine/OrderByContextEngineTest.java
@@ -61,7 +61,7 @@ public final class OrderByContextEngineTest {
         OrderByItemSegment indexOrderByItemSegment2 = new IndexOrderByItemSegment(2, 3, 3, OrderDirection.ASC, OrderDirection.DESC);
         OrderBySegment orderBySegment = new OrderBySegment(0, 1, Arrays.asList(columnOrderByItemSegment, indexOrderByItemSegment1, indexOrderByItemSegment2));
         selectStatement.setOrderBy(orderBySegment);
-        GroupByContext emptyGroupByContext = new GroupByContext(Collections.<OrderByItem>emptyList(), 0);
+        GroupByContext emptyGroupByContext = new GroupByContext(Collections.emptyList(), 0);
 
         OrderByContext actualOrderByContext = new OrderByContextEngine().createOrderBy(selectStatement, emptyGroupByContext);
 
@@ -70,7 +70,7 @@ public final class OrderByContextEngineTest {
         expectedOrderByItem2.setIndex(2);
         OrderByItem expectedOrderByItem3 = new OrderByItem(indexOrderByItemSegment2);
         expectedOrderByItem3.setIndex(3);
-        assertThat(actualOrderByContext.getItems(), is((Collection<OrderByItem>) Arrays.asList(expectedOrderByItem1, expectedOrderByItem2, expectedOrderByItem3)));
+        assertThat(actualOrderByContext.getItems(), is(Arrays.asList(expectedOrderByItem1, expectedOrderByItem2, expectedOrderByItem3)));
         assertFalse(actualOrderByContext.isGenerated());
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/PaginationContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/PaginationContextTest.java
@@ -18,13 +18,17 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination;
 
 import com.google.common.collect.Lists;
-import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
-import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByItem;
-import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
+import org.apache.shardingsphere.sql.parser.core.constant.OrderDirection;
 import org.apache.shardingsphere.sql.parser.relation.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ProjectionsSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.GroupBySegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.OrderBySegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.IndexOrderByItemSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.PaginationValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.limit.NumberLiteralLimitValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.limit.ParameterMarkerLimitValueSegment;
+import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -34,8 +38,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class PaginationContextTest {
     
@@ -126,17 +128,19 @@ public final class PaginationContextTest {
     
     @Test
     public void getRevisedRowCount() {
-        SelectStatementContext selectStatementContext = mock(SelectStatementContext.class);
-        when(selectStatementContext.getProjectionsContext()).thenReturn(mock(ProjectionsContext.class));
-        when(selectStatementContext.getGroupByContext()).thenReturn(new GroupByContext(Collections.emptyList(), 0));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(new ProjectionsSegment(0, 0));
+        SelectStatementContext selectStatementContext = new SelectStatementContext(null, "", Collections.emptyList(), selectStatement);
         assertThat(new PaginationContext(getOffsetSegment(), getRowCountSegment(), getParameters()).getRevisedRowCount(selectStatementContext), is(50L));
     }
     
     @Test
     public void getRevisedRowCountWithMax() {
-        SelectStatementContext selectStatementContext = mock(SelectStatementContext.class);
-        when(selectStatementContext.getProjectionsContext()).thenReturn(mock(ProjectionsContext.class));
-        when(selectStatementContext.getGroupByContext()).thenReturn(new GroupByContext(Collections.singletonList(mock(OrderByItem.class)), 1));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(new ProjectionsSegment(0, 0));
+        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, OrderDirection.DESC))));
+        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
+        SelectStatementContext selectStatementContext = new SelectStatementContext(null, "", Collections.emptyList(), selectStatement);
         assertThat(new PaginationContext(getOffsetSegment(), getRowCountSegment(), getParameters()).getRevisedRowCount(selectStatementContext), is((long) Integer.MAX_VALUE));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/PaginationContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/PaginationContextTest.java
@@ -24,7 +24,6 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ProjectionsSegm
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.GroupBySegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.OrderBySegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.IndexOrderByItemSegment;
-import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.PaginationValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.limit.NumberLiteralLimitValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.limit.ParameterMarkerLimitValueSegment;
@@ -138,8 +137,8 @@ public final class PaginationContextTest {
     public void getRevisedRowCountWithMax() {
         SelectStatement selectStatement = new SelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
-        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, OrderDirection.DESC))));
-        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
+        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, OrderDirection.DESC))));
+        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
         SelectStatementContext selectStatementContext = new SelectStatementContext(null, "", Collections.emptyList(), selectStatement);
         assertThat(new PaginationContext(getOffsetSegment(), getRowCountSegment(), getParameters()).getRevisedRowCount(selectStatementContext), is((long) Integer.MAX_VALUE));
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/PaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/PaginationContextEngineTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.engine;
 
 import org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.PaginationContext;
+import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.Projection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.limit.LimitSegment;
@@ -28,23 +29,19 @@ import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class PaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenLimitSegmentIsPresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getLimit()).thenReturn(Optional.of(new LimitSegment(0, 10, new NumberLiteralLimitValueSegment(0, 10, 100L),
-                new NumberLiteralLimitValueSegment(0, 10, 100L))));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setLimit(new LimitSegment(0, 10, new NumberLiteralLimitValueSegment(0, 10, 100L),
+                new NumberLiteralLimitValueSegment(0, 10, 100L)));
         PaginationContext paginationContext = new PaginationContextEngine().createPaginationContext(selectStatement, null, Collections.emptyList());
         assertTrue(paginationContext.getOffsetSegment().isPresent());
         assertTrue(paginationContext.getRowCountSegment().isPresent());
@@ -52,12 +49,10 @@ public final class PaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenLimitSegmentAbsentAndTopSegmentPresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
+        SelectStatement selectStatement = new SelectStatement();
         ProjectionsSegment projections = new ProjectionsSegment(0, 0);
         projections.getProjections().add(new TopProjectionSegment(0, 10, "text", null, "rowNumberAlias"));
-        when(selectStatement.getProjections()).thenReturn(projections);
-        when(selectStatement.getLimit()).thenReturn(Optional.empty());
-        when(selectStatement.getWhere()).thenReturn(Optional.empty());
+        selectStatement.setProjections(projections);
         PaginationContext paginationContext = new PaginationContextEngine().createPaginationContext(selectStatement, null, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -65,13 +60,11 @@ public final class PaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenLimitSegmentTopSegmentAbsentAndWhereSegmentPresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getProjections()).thenReturn(new ProjectionsSegment(0, 0));
-        when(selectStatement.getLimit()).thenReturn(Optional.empty());
-        WhereSegment whereSegment = new WhereSegment(0, 10);
-        when(selectStatement.getWhere()).thenReturn(Optional.of(whereSegment));
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.empty());
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(new ProjectionsSegment(0, 0));
+        selectStatement.setWhere(new WhereSegment(0, 10));
+        
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.<Projection>emptyList(), Collections.<String>emptyList());
         PaginationContext paginationContext = new PaginationContextEngine().createPaginationContext(selectStatement, projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -79,10 +72,9 @@ public final class PaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenResultIsPaginationContext() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getProjections()).thenReturn(new ProjectionsSegment(0, 0));
-        when(selectStatement.getLimit()).thenReturn(Optional.empty());
-        when(selectStatement.getWhere()).thenReturn(Optional.empty());
-        assertThat(new PaginationContextEngine().createPaginationContext(selectStatement, mock(ProjectionsContext.class), Collections.emptyList()), instanceOf(PaginationContext.class));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(new ProjectionsSegment(0, 0));
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.<Projection>emptyList(), Collections.<String>emptyList());
+        assertThat(new PaginationContextEngine().createPaginationContext(selectStatement, projectionsContext, Collections.emptyList()), instanceOf(PaginationContext.class));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/PaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/PaginationContextEngineTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.engine;
 
 import org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.PaginationContext;
-import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.Projection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.pagination.limit.LimitSegment;
@@ -64,7 +63,7 @@ public final class PaginationContextEngineTest {
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
         selectStatement.setWhere(new WhereSegment(0, 10));
         
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.<Projection>emptyList(), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.emptyList(), Collections.emptyList());
         PaginationContext paginationContext = new PaginationContextEngine().createPaginationContext(selectStatement, projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -74,7 +73,7 @@ public final class PaginationContextEngineTest {
     public void assertCreatePaginationContextWhenResultIsPaginationContext() {
         SelectStatement selectStatement = new SelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.<Projection>emptyList(), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.emptyList(), Collections.emptyList());
         assertThat(new PaginationContextEngine().createPaginationContext(selectStatement, projectionsContext, Collections.emptyList()), instanceOf(PaginationContext.class));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
@@ -50,7 +50,7 @@ public final class RowNumberPaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenRowNumberAliasNotPresent() {
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.<Projection>emptyList(), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.emptyList(), Collections.emptyList());
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(null, projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -59,8 +59,8 @@ public final class RowNumberPaginationContextEngineTest {
     @Test
     public void assertCreatePaginationContextWhenRowNumberAliasIsPresentAndRowNumberPredicatesIsEmpty() {
         Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
-        PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.<AndPredicate>emptyList(), projectionsContext, Collections.emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.emptyList());
+        PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
     }
@@ -88,7 +88,7 @@ public final class RowNumberPaginationContextEngineTest {
     @Test
     public void assertCreatePaginationContextWhenRowNumberAliasIsPresentAndRowNumberPredicatesNotEmpty() {
         Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.emptyList());
         AndPredicate andPredicate = new AndPredicate();
         PredicateSegment predicateSegment = new PredicateSegment(0, 0, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), null);
         andPredicate.getPredicates().addAll(Collections.singleton(predicateSegment));
@@ -103,7 +103,7 @@ public final class RowNumberPaginationContextEngineTest {
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), predicateCompareRightValue));
         Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.emptyList());
         
         PaginationContext paginationContext = new RowNumberPaginationContextEngine()
                 .createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.singletonList(1));
@@ -118,7 +118,7 @@ public final class RowNumberPaginationContextEngineTest {
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), predicateCompareRightValue));
         Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.emptyList());
         
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
@@ -137,7 +137,7 @@ public final class RowNumberPaginationContextEngineTest {
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), predicateCompareRightValue));
         Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.emptyList());
         
         PaginationContext rowNumberPaginationContextEngine = new RowNumberPaginationContextEngine()
                 .createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.engine;
 
 import org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.PaginationContext;
+import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.Projection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
+import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
@@ -39,16 +41,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class RowNumberPaginationContextEngineTest {
     
+    private static final String ROW_NUMBER_COLUMN_NAME = "rownum";
+    
+    private static final String ROW_NUMBER_COLUMN_ALIAS = "predicateRowNumberAlias";
+    
     @Test
     public void assertCreatePaginationContextWhenRowNumberAliasNotPresent() {
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.empty());
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.<Projection>emptyList(), Collections.<String>emptyList());
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(null, projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -56,9 +58,9 @@ public final class RowNumberPaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenRowNumberAliasIsPresentAndRowNumberPredicatesIsEmpty() {
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
-        PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
+        Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.<AndPredicate>emptyList(), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
     }
@@ -85,12 +87,11 @@ public final class RowNumberPaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenRowNumberAliasIsPresentAndRowNumberPredicatesNotEmpty() {
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
-        AndPredicate andPredicate = mock(AndPredicate.class);
-        PredicateSegment predicateSegment = mock(PredicateSegment.class);
-        when(predicateSegment.getColumn()).thenReturn(new ColumnSegment(0, 10, new IdentifierValue("rownum")));
-        when(andPredicate.getPredicates()).thenReturn(Collections.singleton(predicateSegment));
+        Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        AndPredicate andPredicate = new AndPredicate();
+        PredicateSegment predicateSegment = new PredicateSegment(0, 0, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), null);
+        andPredicate.getPredicates().addAll(Collections.singleton(predicateSegment));
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -98,13 +99,12 @@ public final class RowNumberPaginationContextEngineTest {
     
     @Test
     public void assertCreatePaginationContextWhenParameterMarkerRowNumberValueSegment() {
-        PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
-        when(predicateCompareRightValue.getOperator()).thenReturn(">");
-        when(predicateCompareRightValue.getExpression()).thenReturn(new ParameterMarkerExpressionSegment(0, 10, 0));
+        PredicateCompareRightValue predicateCompareRightValue = new PredicateCompareRightValue(">", new ParameterMarkerExpressionSegment(0, 10, 0));
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue("rownum")), predicateCompareRightValue));
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
+        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), predicateCompareRightValue));
+        Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        
         PaginationContext paginationContext = new RowNumberPaginationContextEngine()
                 .createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.singletonList(1));
         Optional<PaginationValueSegment> offSetSegmentPaginationValue = paginationContext.getOffsetSegment();
@@ -114,13 +114,12 @@ public final class RowNumberPaginationContextEngineTest {
     }
     
     private void assertCreatePaginationContextWhenRowNumberAliasPresentAndRowNumberPredicatedNotEmptyWithGivenOperator(final String operator) {
-        PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
-        when(predicateCompareRightValue.getOperator()).thenReturn(operator);
-        when(predicateCompareRightValue.getExpression()).thenReturn(new LiteralExpressionSegment(0, 10, 100));
+        PredicateCompareRightValue predicateCompareRightValue = new PredicateCompareRightValue(operator, new LiteralExpressionSegment(0, 10, 100));
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue("rownum")), predicateCompareRightValue));
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
+        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), predicateCompareRightValue));
+        Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        
         PaginationContext paginationContext = new RowNumberPaginationContextEngine().createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         Optional<PaginationValueSegment> paginationValueSegmentOptional = paginationContext.getRowCountSegment();
@@ -134,13 +133,12 @@ public final class RowNumberPaginationContextEngineTest {
     }
     
     private void assertCreatePaginationContextWhenOffsetSegmentInstanceOfNumberLiteralRowNumberValueSegmentWithGivenOperator(final String operator) {
-        PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
-        when(predicateCompareRightValue.getOperator()).thenReturn(operator);
-        when(predicateCompareRightValue.getExpression()).thenReturn(new LiteralExpressionSegment(0, 10, 100));
+        PredicateCompareRightValue predicateCompareRightValue = new PredicateCompareRightValue(operator, new LiteralExpressionSegment(0, 10, 100));
         AndPredicate andPredicate = new AndPredicate();
-        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue("rownum")), predicateCompareRightValue));
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
+        andPredicate.getPredicates().add(new PredicateSegment(0, 10, new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME)), predicateCompareRightValue));
+        Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS);
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias), Collections.<String>emptyList());
+        
         PaginationContext rowNumberPaginationContextEngine = new RowNumberPaginationContextEngine()
                 .createPaginationContext(Collections.singleton(andPredicate), projectionsContext, Collections.emptyList());
         Optional<PaginationValueSegment> paginationValueSegment = rowNumberPaginationContextEngine.getOffsetSegment();

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/TopPaginationContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/pagination/engine/TopPaginationContextEngineTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.engine;
 
 import org.apache.shardingsphere.sql.parser.relation.segment.select.pagination.PaginationContext;
-import org.apache.shardingsphere.sql.parser.relation.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
@@ -37,16 +36,12 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class TopPaginationContextEngineTest {
     
@@ -81,12 +76,10 @@ public final class TopPaginationContextEngineTest {
     public void assertCreatePaginationContextWhenPredicateInRightValue() {
         String name = "rowNumberAlias";
         ColumnSegment columnSegment = new ColumnSegment(0, 10, new IdentifierValue(name));
-        PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, mock(PredicateInRightValue.class));
+        PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, new PredicateInRightValue(null, Collections.emptyList()));
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(predicateSegment);
         Collection<AndPredicate> andPredicates = Collections.singleton(andPredicate);
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(new TopProjectionSegment(0, 10, "text", null, name), andPredicates, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
@@ -96,15 +89,11 @@ public final class TopPaginationContextEngineTest {
     public void assertCreatePaginationContextWhenParameterMarkerRowNumberValueSegment() {
         String name = "rowNumberAlias";
         ColumnSegment columnSegment = new ColumnSegment(0, 10, new IdentifierValue(name));
-        PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
-        when(predicateCompareRightValue.getOperator()).thenReturn(">");
-        when(predicateCompareRightValue.getExpression()).thenReturn(new ParameterMarkerExpressionSegment(0, 10, 0));
+        PredicateCompareRightValue predicateCompareRightValue = new PredicateCompareRightValue(">", new ParameterMarkerExpressionSegment(0, 10, 0));
         PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, predicateCompareRightValue);
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(predicateSegment);
         Collection<AndPredicate> andPredicates = Collections.singleton(andPredicate);
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(new TopProjectionSegment(0, 10, "text", null, name), andPredicates, Collections.singletonList(1));
         assertTrue(paginationContext.getOffsetSegment().isPresent());
         PaginationValueSegment paginationValueSegment = paginationContext.getOffsetSegment().get();
@@ -119,15 +108,11 @@ public final class TopPaginationContextEngineTest {
     private void assertCreatePaginationContextWhenRowNumberPredicatePresentAndWithGivenOperator(final String operator) {
         String name = "rowNumberAlias";
         ColumnSegment columnSegment = new ColumnSegment(0, 10, new IdentifierValue(name));
-        PredicateCompareRightValue predicateCompareRightValue = mock(PredicateCompareRightValue.class);
-        when(predicateCompareRightValue.getOperator()).thenReturn(operator);
-        when(predicateCompareRightValue.getExpression()).thenReturn(new LiteralExpressionSegment(0, 10, 100));
+        PredicateCompareRightValue predicateCompareRightValue = new PredicateCompareRightValue(operator, new LiteralExpressionSegment(0, 10, 100));
         PredicateSegment predicateSegment = new PredicateSegment(0, 10, columnSegment, predicateCompareRightValue);
         AndPredicate andPredicate = new AndPredicate();
         andPredicate.getPredicates().add(predicateSegment);
         Collection<AndPredicate> andPredicates = Collections.singleton(andPredicate);
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        when(projectionsContext.findAlias(anyString())).thenReturn(Optional.of("predicateRowNumberAlias"));
         PaginationContext paginationContext = topPaginationContextEngine.createPaginationContext(new TopProjectionSegment(0, 10, "text", null, name), andPredicates, Collections.emptyList());
         assertTrue(paginationContext.getOffsetSegment().isPresent());
         PaginationValueSegment paginationValueSegment = paginationContext.getOffsetSegment().get();

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
@@ -41,11 +41,9 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class ProjectionEngineTest {
-    
+
     @Test
     public void assertCreateProjectionWhenProjectionSegmentNotMatched() {
         assertFalse(new ProjectionEngine().createProjection(null, null).isPresent());
@@ -53,8 +51,8 @@ public final class ProjectionEngineTest {
     
     @Test
     public void assertCreateProjectionWhenProjectionSegmentInstanceOfShorthandProjectionSegment() {
-        ShorthandProjectionSegment shorthandProjectionSegment = mock(ShorthandProjectionSegment.class);
-        when(shorthandProjectionSegment.getOwner()).thenReturn(Optional.of(new OwnerSegment(0, 0, new IdentifierValue("tbl"))));
+        ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 0, "text");
+        shorthandProjectionSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("tbl")));
         Optional<Projection> actual = new ProjectionEngine().createProjection(null, shorthandProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(ShorthandProjection.class));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionEngineTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class ProjectionEngineTest {
-
+    
     @Test
     public void assertCreateProjectionWhenProjectionSegmentNotMatched() {
         assertFalse(new ProjectionEngine().createProjection(null, null).isPresent());
@@ -68,7 +68,7 @@ public final class ProjectionEngineTest {
     }
 
     @Test
-    public void assertCreateProjectionWhenProjectionSegmentInstanceOfExpressionProjectionegment() {
+    public void assertCreateProjectionWhenProjectionSegmentInstanceOfExpressionProjectionSegment() {
         ExpressionProjectionSegment expressionProjectionSegment = new ExpressionProjectionSegment(0, 10, "text");
         Optional<Projection> actual = new ProjectionEngine().createProjection(null, expressionProjectionSegment);
         assertTrue(actual.isPresent());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -29,129 +29,126 @@ import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ColumnProjectio
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.ColumnOrderByItemSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.ExpressionOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.IndexOrderByItemSegment;
-import org.apache.shardingsphere.sql.parser.sql.segment.dml.order.item.TextOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class ProjectionsContextEngineTest {
+
+    private RelationMetas emptyRelationMetas;
+    
+    @Before
+    public void setUp() {
+        emptyRelationMetas = new RelationMetas(Collections.emptyMap());
+    }
     
     @Test
     public void assertProjectionsContextCreatedProperly() {
         ProjectionsContextEngine projectionsContextEngine = new ProjectionsContextEngine(null);
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getProjections()).thenReturn(mock(ProjectionsSegment.class));
-        ProjectionsContext actual = projectionsContextEngine.createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(new ProjectionsSegment(0, 0));
+        ProjectionsContext actual = projectionsContextEngine
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), new OrderByContext(Collections.emptyList(), false));
         assertNotNull(actual);
     }
     
     @Test
     public void assertProjectionsContextCreatedProperlyWhenProjectionPresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         OwnerSegment owner = new OwnerSegment(0, 10, new IdentifierValue("name"));
         shorthandProjectionSegment.setOwner(owner);
-        when(projectionsSegment.getProjections()).thenReturn(Collections.singleton(shorthandProjectionSegment));
-        ProjectionsContext actual = new ProjectionsContextEngine(mock(RelationMetas.class)).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), mock(OrderByContext.class));
+        projectionsSegment.getProjections().addAll(Collections.singleton(shorthandProjectionSegment));
+        ProjectionsContext actual = new ProjectionsContextEngine(emptyRelationMetas)
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), new OrderByContext(Collections.emptyList(), false));
         assertNotNull(actual);
     }
     
     @Test
     public void createProjectionsContextWhenOrderByContextOrderItemsPresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         OwnerSegment owner = new OwnerSegment(0, 10, new IdentifierValue("name"));
         shorthandProjectionSegment.setOwner(owner);
-        when(projectionsSegment.getProjections()).thenReturn(Collections.singleton(shorthandProjectionSegment));
-        OrderByContext orderByContext = mock(OrderByContext.class);
-        OrderByItem orderByItem = mock(OrderByItem.class);
-        when(orderByItem.getSegment()).thenReturn(mock(IndexOrderByItemSegment.class));
-        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext actual = new ProjectionsContextEngine(mock(RelationMetas.class)).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        projectionsSegment.getProjections().addAll(Collections.singleton(shorthandProjectionSegment));
+        OrderByItem orderByItem = new OrderByItem(new IndexOrderByItemSegment(0, 1, 0, OrderDirection.ASC));
+        OrderByContext orderByContext = new OrderByContext(Collections.singletonList(orderByItem), true);
+        ProjectionsContext actual = new ProjectionsContextEngine(emptyRelationMetas)
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), orderByContext);
         assertNotNull(actual);
     }
     
     @Test
     public void assertCreateProjectionsContextWithoutIndexOrderByItemSegment() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setProjections(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         OwnerSegment owner = new OwnerSegment(0, 10, new IdentifierValue("name"));
         shorthandProjectionSegment.setOwner(owner);
-        when(projectionsSegment.getProjections()).thenReturn(Collections.singleton(shorthandProjectionSegment));
-        OrderByContext orderByContext = mock(OrderByContext.class);
-        OrderByItem orderByItem = mock(OrderByItem.class);
-        when(orderByItem.getSegment()).thenReturn(mock(TextOrderByItemSegment.class));
-        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext actual = new ProjectionsContextEngine(mock(RelationMetas.class)).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        projectionsSegment.getProjections().addAll(Collections.singleton(shorthandProjectionSegment));
+        OrderByItem orderByItem = new OrderByItem(new ExpressionOrderByItemSegment(0, 1, "", OrderDirection.ASC));
+        OrderByContext orderByContext = new OrderByContext(Collections.singletonList(orderByItem), true);
+        ProjectionsContext actual = new ProjectionsContextEngine(emptyRelationMetas)
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), orderByContext);
         assertNotNull(actual);
     }
     
     @Test
     public void assertCreateProjectionsContextWhenColumnOrderByItemSegmentOwnerAbsent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getTables()).thenReturn(Collections.singletonList(new TableSegment(0, 0, new IdentifierValue("name"))));
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.getTables().addAll(Collections.singletonList(new TableSegment(0, 0, new IdentifierValue("name"))));
+        selectStatement.setProjections(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         OwnerSegment owner = new OwnerSegment(0, 10, new IdentifierValue("name"));
         shorthandProjectionSegment.setOwner(owner);
-        when(projectionsSegment.getProjections()).thenReturn(Collections.singleton(shorthandProjectionSegment));
-        OrderByContext orderByContext = mock(OrderByContext.class);
+        projectionsSegment.getProjections().addAll(Collections.singleton(shorthandProjectionSegment));
         OrderByItem orderByItem = new OrderByItem(new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("name")), OrderDirection.ASC));
-        ColumnOrderByItemSegment columnOrderByItemSegment = mock(ColumnOrderByItemSegment.class);
-        ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getOwner()).thenReturn(Optional.empty());
-        when(columnOrderByItemSegment.getColumn()).thenReturn(columnSegment);
-        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext actual = new ProjectionsContextEngine(mock(RelationMetas.class)).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        OrderByContext orderByContext = new OrderByContext(Collections.singletonList(orderByItem), true);
+        ProjectionsContext actual = new ProjectionsContextEngine(emptyRelationMetas)
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), orderByContext);
         assertNotNull(actual);
     }
     
     @Test
     public void assertCreateProjectionsContextWhenColumnOrderByItemSegmentOwnerPresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getTables()).thenReturn(Collections.singletonList(new TableSegment(0, 0, new IdentifierValue("name"))));
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.getTables().addAll(Collections.singletonList(new TableSegment(0, 0, new IdentifierValue("name"))));
+        selectStatement.setProjections(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         OwnerSegment owner = new OwnerSegment(0, 10, new IdentifierValue("name"));
         shorthandProjectionSegment.setOwner(owner);
-        when(projectionsSegment.getProjections()).thenReturn(Collections.singleton(shorthandProjectionSegment));
-        OrderByContext orderByContext = mock(OrderByContext.class);
+        projectionsSegment.getProjections().addAll(Collections.singleton(shorthandProjectionSegment));
         OrderByItem orderByItem = new OrderByItem(new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("name")), OrderDirection.ASC));
-        ColumnOrderByItemSegment columnOrderByItemSegment = mock(ColumnOrderByItemSegment.class);
-        ColumnSegment columnSegment = mock(ColumnSegment.class);
-        when(columnSegment.getOwner()).thenReturn(Optional.of(new OwnerSegment(0, 0, new IdentifierValue("tbl"))));
-        when(columnOrderByItemSegment.getColumn()).thenReturn(columnSegment);
-        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext actual = new ProjectionsContextEngine(mock(RelationMetas.class)).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        OrderByContext orderByContext = new OrderByContext(Collections.singletonList(orderByItem), true);
+        ProjectionsContext actual = new ProjectionsContextEngine(emptyRelationMetas)
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), orderByContext);
         assertNotNull(actual);
     }
     
     @Test
     public void assertCreateProjectionsContextWhenColumnOrderByItemSegmentOwnerPresentAndTablePresent() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
+        SelectStatement selectStatement = new SelectStatement();
         TableSegment tableSegment = new TableSegment(0, 10, new IdentifierValue("name"));
         tableSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("schema")));
-        when(selectStatement.getTables()).thenReturn(Collections.singletonList(tableSegment));
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        selectStatement.getTables().addAll(Collections.singletonList(tableSegment));
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        selectStatement.setProjections(projectionsSegment);
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10, "text");
         TableSegment table = new TableSegment(0, 10, new IdentifierValue("name"));
         OwnerSegment owner = new OwnerSegment(0, 10, new IdentifierValue("name"));
@@ -161,13 +158,11 @@ public final class ProjectionsContextEngineTest {
         columnSegment.setOwner(owner);
         ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment("ColumnProjectionSegment", columnSegment);
         columnProjectionSegment.setOwner(owner);
-        when(projectionsSegment.getProjections()).thenReturn(Lists.newArrayList(columnProjectionSegment, shorthandProjectionSegment));
-        OrderByContext orderByContext = mock(OrderByContext.class);
+        projectionsSegment.getProjections().addAll(Lists.newArrayList(columnProjectionSegment, shorthandProjectionSegment));
         OrderByItem orderByItem = new OrderByItem(new ColumnOrderByItemSegment(new ColumnSegment(0, 0, new IdentifierValue("name")), OrderDirection.ASC));
-        ColumnOrderByItemSegment columnOrderByItemSegment = mock(ColumnOrderByItemSegment.class);
-        when(columnOrderByItemSegment.getColumn()).thenReturn(columnSegment);
-        when(orderByContext.getItems()).thenReturn(Collections.singletonList(orderByItem));
-        ProjectionsContext actual = new ProjectionsContextEngine(mock(RelationMetas.class)).createProjectionsContext(null, selectStatement, mock(GroupByContext.class), orderByContext);
+        OrderByContext orderByContext = new OrderByContext(Collections.singleton(orderByItem), false);
+        ProjectionsContext actual = new ProjectionsContextEngine(emptyRelationMetas)
+                .createProjectionsContext(null, selectStatement, new GroupByContext(Collections.emptyList(), 0), orderByContext);
         assertNotNull(actual);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/SQLStatementContextFactoryTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/SQLStatementContextFactoryTest.java
@@ -33,24 +33,19 @@ import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class SQLStatementContextFactoryTest {
     
     @Test
     public void assertSQLStatementContextCreatedWhenSQLStatementInstanceOfSelectStatement() {
-        SelectStatement selectStatement = mock(SelectStatement.class);
-        when(selectStatement.getGroupBy()).thenReturn(Optional.empty());
-        when(selectStatement.getOrderBy()).thenReturn(Optional.empty());
-        when(selectStatement.getLimit()).thenReturn(Optional.of(new LimitSegment(0, 10, null, null)));
-        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
-        when(projectionsSegment.getProjections()).thenReturn(Collections.emptyList());
-        when(selectStatement.getProjections()).thenReturn(projectionsSegment);
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.setLimit(new LimitSegment(0, 10, null, null));
+        selectStatement.setProjections(projectionsSegment);
         SQLStatementContext sqlStatementContext = SQLStatementContextFactory.newInstance(null, null, null, selectStatement);
         assertNotNull(sqlStatementContext);
         assertTrue(sqlStatementContext instanceof SelectStatementContext);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectStatementContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.relation.statement.impl;
 
 import com.google.common.collect.Lists;
+import org.apache.shardingsphere.sql.parser.core.constant.AggregationType;
 import org.apache.shardingsphere.sql.parser.core.constant.OrderDirection;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.sql.parser.relation.segment.select.orderby.OrderByContext;
@@ -48,8 +49,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class SelectStatementContextTest {
     
@@ -127,11 +126,10 @@ public final class SelectStatementContextTest {
     
     @Test
     public void assertSetIndexWhenAggregationProjectionsPresent() {
-        ProjectionsContext projectionsContext = mock(ProjectionsContext.class);
-        AggregationProjection aggregationProjection = mock(AggregationProjection.class);
-        when(projectionsContext.getAggregationProjections()).thenReturn(Collections.singletonList(aggregationProjection));
-        when(aggregationProjection.getDerivedAggregationProjections()).thenReturn(Collections.singletonList(aggregationProjection));
-        when(aggregationProjection.getColumnLabel()).thenReturn("id");
+        AggregationProjection aggregationProjection = new AggregationProjection(AggregationType.MAX, "", "id");
+        aggregationProjection.getDerivedAggregationProjections().addAll(Collections.singletonList(aggregationProjection));
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singletonList(aggregationProjection), Collections.emptyList());
+        
         SelectStatementContext selectStatementContext = new SelectStatementContext(
                 new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), projectionsContext, null);
         Map<String, Integer> columnLabelIndexMap = new HashMap<>();

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectStatementContextTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-relation/src/test/java/org/apache/shardingsphere/sql/parser/relation/statement/impl/SelectStatementContextTest.java
@@ -63,23 +63,23 @@ public final class SelectStatementContextTest {
     @Test
     public void assertSetIndexForItemsByIndexOrderBy() {
         SelectStatementContext selectStatementContext = new SelectStatementContext(
-                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(INDEX_ORDER_BY), createProjectionsContext(), null);
-        selectStatementContext.setIndexes(Collections.<String, Integer>emptyMap());
+                new SelectStatement(), new GroupByContext(Collections.emptyList(), 0), createOrderBy(INDEX_ORDER_BY), createProjectionsContext(), null);
+        selectStatementContext.setIndexes(Collections.emptyMap());
         assertThat(selectStatementContext.getOrderByContext().getItems().iterator().next().getIndex(), is(4));
     }
     
     @Test
     public void assertSetIndexForItemsByColumnOrderByWithOwner() {
         SelectStatementContext selectStatementContext = new SelectStatementContext(
-                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITH_OWNER), createProjectionsContext(), null);
-        selectStatementContext.setIndexes(Collections.<String, Integer>emptyMap());
+                new SelectStatement(), new GroupByContext(Collections.emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITH_OWNER), createProjectionsContext(), null);
+        selectStatementContext.setIndexes(Collections.emptyMap());
         assertThat(selectStatementContext.getOrderByContext().getItems().iterator().next().getIndex(), is(1));
     }
     
     @Test
     public void assertSetIndexForItemsByColumnOrderByWithAlias() {
         SelectStatementContext selectStatementContext = new SelectStatementContext(
-                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITH_ALIAS), createProjectionsContext(), null);
+                new SelectStatement(), new GroupByContext(Collections.emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITH_ALIAS), createProjectionsContext(), null);
         Map<String, Integer> columnLabelIndexMap = new HashMap<>();
         columnLabelIndexMap.put("n", 2);
         selectStatementContext.setIndexes(columnLabelIndexMap);
@@ -89,7 +89,7 @@ public final class SelectStatementContextTest {
     @Test
     public void assertSetIndexForItemsByColumnOrderByWithoutAlias() {
         SelectStatementContext selectStatementContext = new SelectStatementContext(
-                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), createProjectionsContext(), null);
+                new SelectStatement(), new GroupByContext(Collections.emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), createProjectionsContext(), null);
         Map<String, Integer> columnLabelIndexMap = new HashMap<>();
         columnLabelIndexMap.put("id", 3);
         selectStatementContext.setIndexes(columnLabelIndexMap);
@@ -100,8 +100,8 @@ public final class SelectStatementContextTest {
     public void assertIsSameGroupByAndOrderByItems() {
         SelectStatement selectStatement = new SelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
-        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
-        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
+        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
+        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
         SelectStatementContext selectStatementContext = new SelectStatementContext(null, "", Collections.emptyList(), selectStatement);
         assertTrue(selectStatementContext.isSameGroupByAndOrderByItems());
     }
@@ -118,8 +118,8 @@ public final class SelectStatementContextTest {
     public void assertIsNotSameGroupByAndOrderByItemsWhenDifferentGroupByAndOrderBy() {
         SelectStatement selectStatement = new SelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
-        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, OrderDirection.DESC))));
-        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.<OrderByItemSegment>singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
+        selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, OrderDirection.DESC))));
+        selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, OrderDirection.DESC))));
         SelectStatementContext selectStatementContext = new SelectStatementContext(null, "", Collections.emptyList(), selectStatement);
         assertFalse(selectStatementContext.isSameGroupByAndOrderByItems());
     }
@@ -131,7 +131,7 @@ public final class SelectStatementContextTest {
         ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singletonList(aggregationProjection), Collections.emptyList());
         
         SelectStatementContext selectStatementContext = new SelectStatementContext(
-                new SelectStatement(), new GroupByContext(Collections.<OrderByItem>emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), projectionsContext, null);
+                new SelectStatement(), new GroupByContext(Collections.emptyList(), 0), createOrderBy(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS), projectionsContext, null);
         Map<String, Integer> columnLabelIndexMap = new HashMap<>();
         columnLabelIndexMap.put("id", 3);
         selectStatementContext.setIndexes(columnLabelIndexMap);
@@ -161,7 +161,7 @@ public final class SelectStatementContextTest {
     
     private ProjectionsContext createProjectionsContext() {
         return new ProjectionsContext(
-                0, 0, true, Arrays.asList(getColumnProjectionWithoutOwner(), getColumnProjectionWithoutOwner(true), getColumnProjectionWithoutOwner(false)), Collections.<String>emptyList());
+                0, 0, true, Arrays.asList(getColumnProjectionWithoutOwner(), getColumnProjectionWithoutOwner(true), getColumnProjectionWithoutOwner(false)), Collections.emptyList());
     }
     
     private Projection getColumnProjectionWithoutOwner() {


### PR DESCRIPTION
Fixes #4540.

The test cases rewritten are as follows:
- [x] ProjectionEngineTest
- [x] ProjectionsContextEngineTest
- [x] GroupByContextEngineTest
- [x] OrderByContextEngineTest
- [x] PaginationContextTest
- [x] PaginationContextEngineTest
- [x] RowNumberPaginationContextEngineTest
- [x] TopPaginationContextEngineTest
- [ ] SQLStatementContextFactoryTest
- [x] SelectStatementContextTest

#### Further Comments
- There is one reference in `SQLStatementContextFactoryTest` which mocks an interface. I couldn't find a suitable implementation to replace it with. There are few `TCL` type concerete classes implementing to `SQLStatement`, but it looks too out of place to be included in the particular test case. So, I am leaving the mock for it as such.
- Few assert conditions in `GroupByContextEngineTest.assertCreateGroupByContextWithGroupBy` and `OrderByContextEngineTest.assertCreateOrderByWithOrderBy` seemed redundant as a previous assert condition verifying the list of items returned, already asserts the matching of the indexes.
- Apart from the above two variations, everything else are straight-forward changes.
