### PR TITLE
fix statement containing columnsegment

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLDDLVisitor.java
@@ -228,7 +228,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
         boolean isPrimaryKey = isPrimaryKey(ctx);
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(
-                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getIdentifier().getValue(), dataType.getValue(), isPrimaryKey);
+                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), isPrimaryKey);
         result.getReferencedTables().addAll(getReferencedTables(ctx));
         return result;
     }
@@ -303,7 +303,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
     @Override
     public ASTNode visitRenameColumnSpecification(final RenameColumnSpecificationContext ctx) {
         return new RenameColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                ((ColumnSegment) visit(ctx.columnName(0))).getIdentifier().getValue(), ((ColumnSegment) visit(ctx.columnName(1))).getIdentifier().getValue());
+                (ColumnSegment) visit(ctx.columnName(0)), (ColumnSegment) visit(ctx.columnName(1)));
     }
     
     @Override
@@ -328,9 +328,9 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
     
     @Override
     public ASTNode visitFirstOrAfterColumn(final FirstOrAfterColumnContext ctx) {
-        String columnName = null;
+        ColumnSegment columnName = null;
         if (null != ctx.columnName()) {
-            columnName = ((ColumnSegment) visit(ctx.columnName())).getQualifiedName();
+            columnName = (ColumnSegment) visit(ctx.columnName());
         }
         return null == ctx.columnName() ? new ColumnFirstPositionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnName)
                 : new ColumnAfterPositionSegment(

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/impl/OracleDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/impl/OracleDDLVisitor.java
@@ -109,7 +109,7 @@ public final class OracleDDLVisitor extends OracleVisitor implements DDLVisitor 
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
         boolean isPrimaryKey = isPrimaryKey(ctx);
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(
-                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getIdentifier().getValue(), dataType.getValue(), isPrimaryKey);
+                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), isPrimaryKey);
         for (InlineConstraintContext each : ctx.inlineConstraint()) {
             if (null != each.referencesClause()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.referencesClause().tableName()));
@@ -221,7 +221,7 @@ public final class OracleDDLVisitor extends OracleVisitor implements DDLVisitor 
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
         // TODO visit pk and reference table
-        return new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getQualifiedName(), dataType.getValue(), false);
+        return new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), false);
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/impl/PostgreSQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/impl/PostgreSQLDDLVisitor.java
@@ -165,7 +165,7 @@ public final class PostgreSQLDDLVisitor extends PostgreSQLVisitor implements DDL
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
         boolean isPrimaryKey = isPrimaryKey(ctx);
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(
-                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getIdentifier().getValue(), dataType.getValue(), isPrimaryKey);
+                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), isPrimaryKey);
         for (ColumnConstraintContext each : ctx.columnConstraint()) {
             if (null != each.columnConstraintOption().tableName()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.columnConstraintOption().tableName()));
@@ -201,7 +201,7 @@ public final class PostgreSQLDDLVisitor extends PostgreSQLVisitor implements DDL
         // TODO visit pk and table ref
         ColumnSegment column = (ColumnSegment) visit(ctx.modifyColumn().columnName());
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
-        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getQualifiedName(), dataType.getValue(), false);
+        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), false);
         return new ModifyColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnDefinition);
     }
     
@@ -214,7 +214,7 @@ public final class PostgreSQLDDLVisitor extends PostgreSQLVisitor implements DDL
     @Override
     public ASTNode visitRenameColumnSpecification(final RenameColumnSpecificationContext ctx) {
         return new RenameColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                ((ColumnSegment) visit(ctx.columnName(0))).getIdentifier().getValue(), ((ColumnSegment) visit(ctx.columnName(1))).getIdentifier().getValue());
+                (ColumnSegment) visit(ctx.columnName(0)), (ColumnSegment) visit(ctx.columnName(1)));
     }
     
     @SuppressWarnings("unchecked")

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/impl/SQL92DDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/impl/SQL92DDLVisitor.java
@@ -91,7 +91,7 @@ public final class SQL92DDLVisitor extends SQL92Visitor implements DDLVisitor {
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
         boolean isPrimaryKey = isPrimaryKey(ctx);
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(
-                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getIdentifier().getValue(), dataType.getValue(), isPrimaryKey);
+                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), isPrimaryKey);
         for (DataTypeOptionContext each : ctx.dataTypeOption()) {
             if (null != each.referenceDefinition()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.referenceDefinition().tableName()));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/impl/SQLServerDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/impl/SQLServerDDLVisitor.java
@@ -105,7 +105,7 @@ public final class SQLServerDDLVisitor extends SQLServerVisitor implements DDLVi
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
         boolean isPrimaryKey = isPrimaryKey(ctx);
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(
-                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getIdentifier().getValue(), dataType.getValue(), isPrimaryKey);
+                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), isPrimaryKey);
         for (ColumnDefinitionOptionContext each : ctx.columnDefinitionOption()) {
             for (ColumnConstraintContext columnConstraint : each.columnConstraint()) {
                 if (null != columnConstraint.columnForeignKeyConstraint()) {
@@ -212,7 +212,7 @@ public final class SQLServerDDLVisitor extends SQLServerVisitor implements DDLVi
         // TODO visit pk and table ref
         ColumnSegment column = (ColumnSegment) visit(ctx.alterColumnOperation().columnName());
         KeywordValue dataType = (KeywordValue) visit(ctx.dataType().dataTypeName());
-        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column.getQualifiedName(), dataType.getValue(), false);
+        ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType.getValue(), false);
         return new ModifyColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnDefinition);
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/ColumnDefinitionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/ColumnDefinitionSegment.java
@@ -20,9 +20,8 @@ package org.apache.shardingsphere.sql.parser.sql.segment.ddl.column;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.segment.ddl.CreateDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.generic.table.SimpleTableSegment;
-import org.apache.shardingsphere.sql.parser.sql.util.SQLUtil;
-
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -37,7 +36,7 @@ public final class ColumnDefinitionSegment implements CreateDefinitionSegment {
     
     private final int stopIndex;
     
-    private String columnName;
+    private ColumnSegment columnName;
     
     private String dataType;
     
@@ -45,10 +44,10 @@ public final class ColumnDefinitionSegment implements CreateDefinitionSegment {
     
     private final Collection<SimpleTableSegment> referencedTables = new LinkedList<>();
     
-    public ColumnDefinitionSegment(final int startIndex, final int stopIndex, final String columnName, final String dataType, final boolean primaryKey) {
+    public ColumnDefinitionSegment(final int startIndex, final int stopIndex, final ColumnSegment columnName, final String dataType, final boolean primaryKey) {
         this.startIndex = startIndex;
         this.stopIndex = stopIndex;
-        this.columnName = SQLUtil.getExactlyValue(columnName);
+        this.columnName = columnName;
         this.dataType = dataType;
         this.primaryKey = primaryKey;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/alter/RenameColumnSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/alter/RenameColumnSegment.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.sql.segment.ddl.column.alter;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 
 /**
  * Rename column segment.
@@ -32,7 +33,7 @@ public final class RenameColumnSegment implements SQLSegment {
     
     private final int stopIndex;
     
-    private final String oldColumnName;
+    private final ColumnSegment oldColumnName;
     
-    private final String columnName;
+    private final ColumnSegment columnName;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/position/ColumnAfterPositionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/position/ColumnAfterPositionSegment.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.sql.segment.ddl.column.position;
 
 import lombok.Getter;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 
 /**
  * Column after position segment.
@@ -27,7 +28,7 @@ public final class ColumnAfterPositionSegment extends ColumnPositionSegment {
     
     private final String afterColumnName;
     
-    public ColumnAfterPositionSegment(final int startIndex, final int stopIndex, final String columnName, final String afterColumnName) {
+    public ColumnAfterPositionSegment(final int startIndex, final int stopIndex, final ColumnSegment columnName, final String afterColumnName) {
         super(startIndex, stopIndex, columnName);
         this.afterColumnName = afterColumnName;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/position/ColumnFirstPositionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/position/ColumnFirstPositionSegment.java
@@ -17,12 +17,14 @@
 
 package org.apache.shardingsphere.sql.parser.sql.segment.ddl.column.position;
 
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
+
 /**
  * Column first position segment.
  */
 public final class ColumnFirstPositionSegment extends ColumnPositionSegment {
     
-    public ColumnFirstPositionSegment(final int startIndex, final int stopIndex, final String columnName) {
+    public ColumnFirstPositionSegment(final int startIndex, final int stopIndex, final ColumnSegment columnName) {
         super(startIndex, stopIndex, columnName);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/position/ColumnPositionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/segment/ddl/column/position/ColumnPositionSegment.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.sql.segment.ddl.column.position;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.segment.dml.column.ColumnSegment;
 
 /**
  * Column position segment.
@@ -32,7 +33,7 @@ public abstract class ColumnPositionSegment implements SQLSegment, Comparable<Co
     
     private final int stopIndex;
     
-    private final String columnName;
+    private final ColumnSegment columnName;
     
     @Override
     public final int compareTo(final ColumnPositionSegment o) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnDefinitionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnDefinitionAssert.java
@@ -41,7 +41,7 @@ public final class ColumnDefinitionAssert {
      * @param expected expected column definition
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnDefinitionSegment actual, final ExpectedColumnDefinition expected) {
-        assertThat(assertContext.getText("Column definition name assertion error: "), actual.getColumnName(), is(expected.getColumn().getName()));
+        assertThat(assertContext.getText("Column definition name assertion error: "), actual.getColumnName().getIdentifier().getValue(), is(expected.getColumn().getName()));
         assertThat(assertContext.getText("Column definition data type assertion error: "), actual.getDataType(), is(expected.getType()));
         assertThat(assertContext.getText("Column definition primary key assertion error: "), actual.isPrimaryKey(), is(expected.isPrimaryKey()));
         TableAssert.assertIs(assertContext, actual.getReferencedTables(), expected.getReferencedTables());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnPositionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnPositionAssert.java
@@ -43,7 +43,11 @@ public final class ColumnPositionAssert {
      * @param expected expected column position
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnPositionSegment actual, final ExpectedColumnPosition expected) {
-        assertThat(assertContext.getText("Column change position name assertion error: "), actual.getColumnName(), is(expected.getColumn().getName()));
+        String columnname = null;
+        if (null != actual.getColumnName()) {
+            columnname = actual.getColumnName().getQualifiedName();
+        }
+        assertThat(assertContext.getText("Column change position name assertion error: "), columnname, is(expected.getColumn().getName()));
         // TODO assert start index and stop index
         if (actual instanceof ColumnAfterPositionSegment) {
             assertNotNull(assertContext.getText("Assignments should exist."), expected.getAfterColumn());


### PR DESCRIPTION
ref #4671.

Changes proposed in this pull request:
- Instead of columnName, parse ColumnSegment as  member of RenameColumnSegment
- Instead of columnName, parse ColumnSegment as  member of ColumnAfterPositionSegment
- Instead of columnName, parse ColumnSegment as  member of ColumnPositionSegment
- Instead of columnName, parse ColumnSegment as  member of ColumnDefinitionSegment
