### PR TITLE
Fix #4853: Add start-index and stop-index assertion for `ColumnDefinitionSegment`

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnDefinitionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnDefinitionAssert.java
@@ -45,8 +45,7 @@ public final class ColumnDefinitionAssert {
         assertThat(assertContext.getText("Column definition data type assertion error: "), actual.getDataType(), is(expected.getType()));
         assertThat(assertContext.getText("Column definition primary key assertion error: "), actual.isPrimaryKey(), is(expected.isPrimaryKey()));
         TableAssert.assertIs(assertContext, actual.getReferencedTables(), expected.getReferencedTables());
-        // TODO assert start index and stop index
-//        assertThat(assertContext.getText("Column definition start index assertion error: "), actual.getStartIndex(), is(expected.getStartIndex()));
-//        assertThat(assertContext.getText("Column definition stop index assertion error: "), actual.getStopIndex(), is(expected.getStopIndex()));
+        assertThat(assertContext.getText("Column definition start index assertion error: "), actual.getStartIndex(), is(expected.getStartIndex()));
+        assertThat(assertContext.getText("Column definition stop index assertion error: "), actual.getStopIndex(), is(expected.getStopIndex()));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/ddl/alter-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/ddl/alter-table.xml
@@ -20,7 +20,7 @@
     <alter-table sql-case-id="alter_table">
         <table name="t_log" start-index="12" stop-index="16" />
         <add-column>
-            <column-definition type="varchar">
+            <column-definition type="varchar" start-index="22" stop-index="37">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -29,7 +29,7 @@
     <alter-table sql-case-id="alter_table_if_exists_only">
         <table name="t_log" start-index="27" stop-index="31" />
         <add-column>
-            <column-definition type="varchar">
+            <column-definition type="varchar" start-index="37" stop-index="48">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -50,7 +50,7 @@
     <alter-table sql-case-id="alter_table_add_column">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
         </add-column>
@@ -59,17 +59,17 @@
     <alter-table sql-case-id="alter_table_add_columns">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="49" stop-index="67">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="74" stop-index="92">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -78,17 +78,17 @@
     <alter-table sql-case-id="alter_table_add_columns_integer_type_mysql">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="INTEGER">
+            <column-definition type="INTEGER" start-index="24" stop-index="38">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TINYINT">
+            <column-definition type="TINYINT" start-index="45" stop-index="59">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="MEDIUMINT">
+            <column-definition type="MEDIUMINT" start-index="66" stop-index="82">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -97,17 +97,17 @@
     <alter-table sql-case-id="alter_table_add_columns_integer_type_oracle">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="INTEGER">
+            <column-definition type="INTEGER" start-index="25" stop-index="39">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="INT">
+            <column-definition type="INT" start-index="42" stop-index="52">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="SMALLINT">
+            <column-definition type="SMALLINT" start-index="55" stop-index="70">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -116,17 +116,17 @@
     <alter-table sql-case-id="alter_table_add_columns_integer_type">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="INT">
+            <column-definition type="INT" start-index="24" stop-index="34">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="SMALLINT">
+            <column-definition type="SMALLINT" start-index="41" stop-index="56">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="BIGINT">
+            <column-definition type="BIGINT" start-index="63" stop-index="76">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -135,12 +135,12 @@
     <alter-table sql-case-id="alter_table_add_columns_fixed_point_type">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="decimal">
+            <column-definition type="decimal" start-index="24" stop-index="44">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="NUMERIC">
+            <column-definition type="NUMERIC" start-index="51" stop-index="65">
                 <column name="column5" />
             </column-definition>
         </add-column>
@@ -149,12 +149,12 @@
     <alter-table sql-case-id="alter_table_add_columns_float_point_type_mysql">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="FLOAT">
+            <column-definition type="FLOAT" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="DOUBLE">
+            <column-definition type="DOUBLE" start-index="49" stop-index="68">
                 <column name="column5" />
             </column-definition>
         </add-column>
@@ -163,12 +163,12 @@
     <alter-table sql-case-id="alter_table_add_columns_float_point_type_oracle">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="FLOAT">
+            <column-definition type="FLOAT" start-index="25" stop-index="41">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="double precision">
+            <column-definition type="double precision" start-index="44" stop-index="67">
                 <column name="column5" />
             </column-definition>
         </add-column>
@@ -177,37 +177,37 @@
     <alter-table sql-case-id="alter_table_add_columns_float_point_type_postgresql">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="FLOAT">
+            <column-definition type="FLOAT" start-index="24" stop-index="36">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="double precision">
+            <column-definition type="double precision" start-index="43" stop-index="66">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="REAL">
+            <column-definition type="REAL" start-index="73" stop-index="84">
                 <column name="column6" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="SMALLSERIAL">
+            <column-definition type="SMALLSERIAL" start-index="91" stop-index="109">
                 <column name="column7" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="SERIAL">
+            <column-definition type="SERIAL" start-index="116" stop-index="129">
                 <column name="column8" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="BIGSERIAL">
+            <column-definition type="BIGSERIAL" start-index="136" stop-index="152">
                 <column name="column9" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="float4">
+            <column-definition type="float4" start-index="159" stop-index="173">
                 <column name="column10" />
             </column-definition>
         </add-column>
@@ -216,7 +216,7 @@
     <alter-table sql-case-id="alter_table_add_columns_bit_type">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="bit">
+            <column-definition type="bit" start-index="24" stop-index="34">
                 <column name="column4" />
             </column-definition>
         </add-column>
@@ -225,7 +225,7 @@
     <alter-table sql-case-id="alter_table_add_columns_date_type_mysql">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="YEAR">
+            <column-definition type="YEAR" start-index="24" stop-index="35">
                 <column name="column4" />
             </column-definition>
         </add-column>
@@ -234,17 +234,17 @@
     <alter-table sql-case-id="alter_table_add_columns_string_type">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="CHAR">
+            <column-definition type="CHAR" start-index="24" stop-index="35">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="42" stop-index="56">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TEXT">
+            <column-definition type="TEXT" start-index="63" stop-index="74">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -252,57 +252,57 @@
     <alter-table sql-case-id="alter_table_add_columns_string_type_mysql">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="BINARY">
+            <column-definition type="BINARY" start-index="24" stop-index="37">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARBINARY">
+            <column-definition type="VARBINARY" start-index="44" stop-index="60">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TINYBLOB">
+            <column-definition type="TINYBLOB" start-index="67" stop-index="82">
                 <column name="column6" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TINYTEXT">
+            <column-definition type="TINYTEXT" start-index="89" stop-index="104">
                 <column name="column7" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="BLOB">
+            <column-definition type="BLOB" start-index="111" stop-index="122">
                 <column name="column8" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="MEDIUMBLOB">
+            <column-definition type="MEDIUMBLOB" start-index="129" stop-index="146">
                 <column name="column9" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="MEDIUMTEXT">
+            <column-definition type="MEDIUMTEXT" start-index="153" stop-index="171">
                 <column name="column10" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="LONGBLOB">
+            <column-definition type="LONGBLOB" start-index="178" stop-index="194">
                 <column name="column11" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="LONGTEXT">
+            <column-definition type="LONGTEXT" start-index="201" stop-index="217">
                 <column name="column12" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="ENUM">
+            <column-definition type="ENUM" start-index="224" stop-index="236">
                 <column name="column13" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="SET">
+            <column-definition type="SET" start-index="243" stop-index="254">
                 <column name="column14" />
             </column-definition>
         </add-column>
@@ -311,12 +311,12 @@
     <alter-table sql-case-id="alter_table_add_columns_string_type_postgresql">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="CHARACTER">
+            <column-definition type="CHARACTER" start-index="24" stop-index="40">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="NAME">
+            <column-definition type="NAME" start-index="47" stop-index="58">
                 <column name="column5" />
             </column-definition>
         </add-column>
@@ -325,22 +325,22 @@
     <alter-table sql-case-id="alter_table_add_columns_date_type">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="DATE">
+            <column-definition type="DATE" start-index="24" stop-index="35">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="DATETIME">
+            <column-definition type="DATETIME" start-index="42" stop-index="57">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TIMESTAMP">
+            <column-definition type="TIMESTAMP" start-index="64" stop-index="80">
                 <column name="column6" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TIME">
+            <column-definition type="TIME" start-index="87" stop-index="98">
                 <column name="column7" />
             </column-definition>
         </add-column>
@@ -349,22 +349,22 @@
     <alter-table sql-case-id="alter_table_add_columns_date_type_oracle">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="DATE">
+            <column-definition type="DATE" start-index="25" stop-index="36">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="DATETIME">
+            <column-definition type="DATETIME" start-index="39" stop-index="54">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TIMESTAMP">
+            <column-definition type="TIMESTAMP" start-index="57" stop-index="73">
                 <column name="column6" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="TIMESTAMP WITH TIME ZONE">
+            <column-definition type="TIMESTAMP WITH TIME ZONE" start-index="76" stop-index="107">
                 <column name="column7" />
             </column-definition>
         </add-column>
@@ -373,7 +373,7 @@
     <alter-table sql-case-id="alter_table_add_column_with_first">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column3" />
             </column-definition>
             <column-position/>
@@ -383,7 +383,7 @@
     <alter-table sql-case-id="alter_table_add_column_with_after">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
             <column-position>
@@ -396,19 +396,19 @@
     <alter-table sql-case-id="alter_table_add_column_with_first_after">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column5" />
             </column-definition>
             <column-position/>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="55" stop-index="73">
                 <column name="column6" />
             </column-definition>
             <column-position/>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="86" stop-index="104">
                 <column name="column7" />
             </column-definition>
             <column-position>
@@ -416,7 +416,7 @@
             </column-position>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="125" stop-index="143">
                 <column name="column8" />
             </column-definition>
             <column-position column-name="column8">
@@ -428,7 +428,7 @@
     <alter-table sql-case-id="alter_table_modify_column">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="27" stop-index="45">
                 <column name="column4" />
             </column-definition>
         </modify-column>
@@ -437,17 +437,17 @@
     <alter-table sql-case-id="alter_table_modify_columns">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="27" stop-index="45">
                 <column name="column4" />
             </column-definition>
         </modify-column>
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="55" stop-index="73">
                 <column name="column5" />
             </column-definition>
         </modify-column>
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="83" stop-index="101">
                 <column name="column6" />
             </column-definition>
         </modify-column>
@@ -456,7 +456,7 @@
     <alter-table sql-case-id="alter_table_modify_column_with_first">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="27" stop-index="44">
                 <column name="status" />
             </column-definition>
             <column-position/>
@@ -466,7 +466,7 @@
     <alter-table sql-case-id="alter_table_modify_column_with_after">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="27" stop-index="44">
                 <column name="status" />
             </column-definition>
             <column-position>
@@ -479,13 +479,13 @@
     <alter-table sql-case-id="alter_table_modify_column_with_first_after">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="27" stop-index="44">
                 <column name="status" />
             </column-definition>
             <column-position/>
         </modify-column>
         <modify-column>
-            <column-definition type="INT">
+            <column-definition type="INT" start-index="60" stop-index="70">
                 <column name="user_id" />
             </column-definition>
             <column-position>
@@ -509,7 +509,7 @@
     <alter-table sql-case-id="alter_table_change_column">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="35" stop-index="53">
                 <column name="column4" start-index="35" stop-index="41" />
             </column-definition>
         </modify-column>
@@ -525,7 +525,7 @@
     <alter-table sql-case-id="alter_table_add_composite_primary_key">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="int">
+            <column-definition type="int" start-index="24" stop-index="33">
                 <column name="status" />
             </column-definition>
         </add-column>
@@ -600,22 +600,22 @@
     <alter-table sql-case-id="alter_table_composite_operate_columns">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="49" stop-index="67">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="74" stop-index="92">
                 <column name="column6" />
             </column-definition>
         </add-column>
         <modify-column>
-            <column-definition type="bigint">
+            <column-definition type="bigint" start-index="101" stop-index="114">
                 <column name="user_id" />
             </column-definition>
         </modify-column>
@@ -634,17 +634,17 @@
     <alter-table sql-case-id="alter_table_add_columns_oracle">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR2">
+            <column-definition type="VARCHAR2" start-index="24" stop-index="43">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR2">
+            <column-definition type="VARCHAR2" start-index="49" stop-index="68">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR2">
+            <column-definition type="VARCHAR2" start-index="74" stop-index="93">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -653,17 +653,17 @@
     <alter-table sql-case-id="alter_table_modify_columns_oracle">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR2">
+            <column-definition type="VARCHAR2" start-index="27" stop-index="46">
                 <column name="column4" />
             </column-definition>
         </modify-column>
         <modify-column>
-            <column-definition type="VARCHAR2">
+            <column-definition type="VARCHAR2" start-index="55" stop-index="74">
                 <column name="column5" />
             </column-definition>
         </modify-column>
         <modify-column>
-            <column-definition type="VARCHAR2">
+            <column-definition type="VARCHAR2" start-index="83" stop-index="102">
                 <column name="column6" />
             </column-definition>
         </modify-column>
@@ -711,17 +711,17 @@
     <alter-table sql-case-id="alter_table_alter_columns">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="20" stop-index="49">
                 <column name="column4" />
             </column-definition>
         </modify-column>
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="52" stop-index="81">
                 <column name="column5" />
             </column-definition>
         </modify-column>
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="84" stop-index="113">
                 <column name="column6" />
             </column-definition>
         </modify-column>
@@ -761,17 +761,17 @@
     <alter-table sql-case-id="alter_table_add_columns_sqlserver">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="45" stop-index="63">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="66" stop-index="84">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -799,7 +799,7 @@
     <alter-table sql-case-id="alter_table_alter_column_for_postgresql">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="20" stop-index="49">
                 <column name="column4" />
             </column-definition>
         </modify-column>
@@ -808,7 +808,7 @@
     <alter-table sql-case-id="alter_table_alter_column_for_sqlserver">
         <table name="t_order" start-index="12" stop-index="18" />
         <modify-column>
-            <column-definition type="VARCHAR">
+            <column-definition type="VARCHAR" start-index="20" stop-index="51">
                 <column name="column4" />
             </column-definition>
         </modify-column>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/ddl/create-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/ddl/create-table.xml
@@ -19,363 +19,363 @@
 <sql-parser-test-cases>
     <create-table sql-case-id="create_table">
         <table name="t_log" start-index="13" stop-index="17" />
-        <column-definition type="int" primary-key="true">
+        <column-definition type="int" primary-key="true" start-index="19" stop-index="36">
             <column name="id" />
         </column-definition>
-        <column-definition type="varchar">
+        <column-definition type="varchar" start-index="39" stop-index="56">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_keyword">
         <table name="t_log" start-index="13" stop-index="17" />
-        <column-definition type="int" primary-key="true">
+        <column-definition type="int" primary-key="true" start-index="19" stop-index="36">
             <column name="id" />
         </column-definition>
-        <column-definition type="boolean">
+        <column-definition type="boolean" start-index="39" stop-index="52">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_if_not_exists">
         <table name="t_log" start-index="27" stop-index="31" />
-        <column-definition type="int">
+        <column-definition type="int" start-index="33" stop-index="38">
             <column name="id" />
         </column-definition>
-        <column-definition type="varchar">
+        <column-definition type="varchar" start-index="41" stop-index="58">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_temporary_table_if_not_exists">
         <table name="t_temp_log" start-index="37" stop-index="46" />
-        <column-definition type="int">
+        <column-definition type="int" start-index="48" stop-index="53">
             <column name="id" />
         </column-definition>
-        <column-definition type="varchar">
+        <column-definition type="varchar" start-index="56" stop-index="73">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_global_temporary_table">
         <table name="t_temp_log" start-index="30" stop-index="39" />
-        <column-definition type="int">
+        <column-definition type="int" start-index="41" stop-index="46">
             <column name="id" />
         </column-definition>
-        <column-definition type="varchar">
+        <column-definition type="varchar" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_local_temp_table">
         <table name="t_temp_log" start-index="24" stop-index="33" />
-        <column-definition type="int">
+        <column-definition type="int" start-index="35" stop-index="40">
             <column name="id" />
         </column-definition>
-        <column-definition type="varchar">
+        <column-definition type="varchar" start-index="43" stop-index="60">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_unlogged_table">
         <table name="t_log" start-index="22" stop-index="26" />
-        <column-definition type="int">
+        <column-definition type="int" start-index="28" stop-index="33">
             <column name="id" />
         </column-definition>
-        <column-definition type="varchar">
+        <column-definition type="varchar" start-index="36" stop-index="53">
             <column name="status" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_space">
         <table name="t_order_item" start-index="17" stop-index="28" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="50">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="61" stop-index="72">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="83" stop-index="93">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="104" stop-index="121">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="132" stop-index="150">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="161" stop-index="179">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="190" stop-index="208">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_back_quota">
         <table name="t_order" start-delimiter="`" end-delimiter="`" start-index="13" stop-index="21" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="24" stop-index="37">
             <column name="order_id" start-delimiter="`" end-delimiter="`" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="52">
             <column name="user_id" start-delimiter="`" end-delimiter="`" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="55" stop-index="74">
             <column name="status" start-delimiter="`" end-delimiter="`" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="77" stop-index="97">
             <column name="column1" start-delimiter="`" end-delimiter="`" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="100" stop-index="120">
             <column name="column2" start-delimiter="`" end-delimiter="`" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="123" stop-index="143">
             <column name="column3" start-delimiter="`" end-delimiter="`" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_temporary_table">
         <table name="t_order" start-index="23" stop-index="29" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="32" stop-index="43">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="46" stop-index="56">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="59" stop-index="76">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="79" stop-index="97">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="100" stop-index="118">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="121" stop-index="139">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_not_null">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="42">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="45" stop-index="55">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="58" stop-index="75">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="78" stop-index="96">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="99" stop-index="117">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="120" stop-index="138">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_default">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="43">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="46" stop-index="56">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="59" stop-index="76">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="79" stop-index="97">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="100" stop-index="118">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="121" stop-index="139">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_increment">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="48">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="51" stop-index="61">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="64" stop-index="81">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="84" stop-index="102">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="105" stop-index="123">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="126" stop-index="144">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_generated">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="67">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="70" stop-index="80">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="83" stop-index="100">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="103" stop-index="121">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="124" stop-index="142">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="145" stop-index="163">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_comment">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="52">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="55" stop-index="65">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="68" stop-index="85">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="88" stop-index="106">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="109" stop-index="127">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="130" stop-index="148">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_primary_key">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT" primary-key="true">
+        <column-definition type="INT" primary-key="true" start-index="22" stop-index="45">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="48" stop-index="58">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="61" stop-index="78">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="81" stop-index="99">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="102" stop-index="120">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="123" stop-index="141">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_unique_key">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="40">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="43" stop-index="53">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="56" stop-index="73">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="76" stop-index="94">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="97" stop-index="115">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="118" stop-index="136">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_foreign_key">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="27" stop-index="37">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="117">
             <column name="order_id" />
             <referenced-table name="t_order" start-index="64" stop-index="70" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="120" stop-index="130">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="133" stop-index="150">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="153" stop-index="171">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="174" stop-index="192">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="195" stop-index="213">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_constraints">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT" primary-key="true">
+        <column-definition type="INT" primary-key="true" start-index="22" stop-index="52">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="55" stop-index="65">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="68" stop-index="85">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="88" stop-index="106">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="109" stop-index="127">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="130" stop-index="148">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_out_of_line_primary_key">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -386,22 +386,22 @@
     <create-table sql-case-id="create_table_with_out_of_line_composite_primary_key">
         <table name="t_order" start-index="13" stop-index="19" />
         <!-- FIXME cannot parse pk -->
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -413,22 +413,22 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_unique_key">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <constraint-definition />
@@ -436,22 +436,22 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_composite_unique_key">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <constraint-definition />
@@ -459,25 +459,25 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_foreign_key">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="27" stop-index="37">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="51">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="54" stop-index="64">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="67" stop-index="84">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="87" stop-index="105">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="108" stop-index="126">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="129" stop-index="147">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -487,25 +487,25 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_composite_foreign_key">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="27" stop-index="37">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="51">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="54" stop-index="64">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="67" stop-index="84">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="87" stop-index="105">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="108" stop-index="126">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="129" stop-index="147">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -515,22 +515,22 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_check">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <constraint-definition />
@@ -538,25 +538,25 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_constraints">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="27" stop-index="37">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="51">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="54" stop-index="64">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="67" stop-index="84">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="87" stop-index="105">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="108" stop-index="126">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="129" stop-index="147">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -571,22 +571,22 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_index">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <!-- FIXME cannot parse index -->
@@ -595,22 +595,22 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_composite_index">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <!-- FIXME cannot parse index -->
@@ -619,22 +619,22 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_btree_index">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
         <!-- FIXME cannot parse index name -->
@@ -643,44 +643,44 @@
     
     <create-table sql-case-id="create_table_with_comment">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_partition">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="90" stop-index="108">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="111" stop-index="129">
             <column name="column3" />
         </column-definition>
     </create-table>
@@ -697,187 +697,187 @@
     
     <create-table sql-case-id="create_table_with_quota">
         <table name="t_order" start-delimiter="&quot;" end-delimiter="&quot;" start-index="13" stop-index="21" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="24" stop-index="44">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="47" stop-index="66">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="69" stop-index="89">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="92" stop-index="113">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="116" stop-index="137">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="140" stop-index="161">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_on_null_default">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="22" stop-index="58">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="61" stop-index="78">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="81" stop-index="99">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="102" stop-index="121">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="124" stop-index="143">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="146" stop-index="165">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_identity">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="22" stop-index="99">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="102" stop-index="119">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="122" stop-index="140">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="143" stop-index="162">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="165" stop-index="184">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="187" stop-index="206">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_encrypt">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="22" stop-index="97">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="100" stop-index="117">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="120" stop-index="138">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="141" stop-index="160">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="163" stop-index="182">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="185" stop-index="204">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_foreign_key_reference">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="27" stop-index="44">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="47" stop-index="136">
             <column name="order_id" />
             <referenced-table name="t_order" start-index="101" stop-index="107" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="139" stop-index="156">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="159" stop-index="177">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="180" stop-index="199">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="202" stop-index="221">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="224" stop-index="243">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_check">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="22" stop-index="85">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="88" stop-index="105">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="108" stop-index="126">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="129" stop-index="148">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="151" stop-index="170">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="173" stop-index="192">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_constraints_cascade">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="NUMBER" primary-key="true">
+        <column-definition type="NUMBER" primary-key="true" start-index="27" stop-index="93">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="96" stop-index="185">
             <column name="order_id" />
             <referenced-table name="t_order" start-index="150" stop-index="156" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="188" stop-index="205">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="208" stop-index="231">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="234" stop-index="253">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="256" stop-index="275">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="278" stop-index="297">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_out_of_line_foreign_key_oracle">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="27" stop-index="44">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="47" stop-index="65">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="68" stop-index="85">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="88" stop-index="106">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="109" stop-index="128">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="131" stop-index="150">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="153" stop-index="172">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -887,25 +887,25 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_composite_foreign_key_oracle">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="27" stop-index="44">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="47" stop-index="65">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="68" stop-index="85">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="88" stop-index="106">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="109" stop-index="128">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="131" stop-index="150">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="153" stop-index="172">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -915,25 +915,25 @@
     
     <create-table sql-case-id="create_table_with_out_of_line_constraints_oracle">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="27" stop-index="44">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="47" stop-index="65">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="68" stop-index="85">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="88" stop-index="106">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="109" stop-index="128">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="131" stop-index="150">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="153" stop-index="172">
             <column name="column3" />
         </column-definition>
         <constraint-definition>
@@ -994,88 +994,88 @@
     
     <create-table sql-case-id="create_table_with_partition_oracle">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="22" stop-index="40">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="NUMBER">
+        <column-definition type="NUMBER" start-index="43" stop-index="60">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="63" stop-index="81">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="84" stop-index="103">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="106" stop-index="125">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR2">
+        <column-definition type="VARCHAR2" start-index="128" stop-index="147">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_double_quota">
         <table name="t_order" start-delimiter="&quot;" end-delimiter="&quot;" start-index="13" stop-index="21" />
-        <column-definition type="INTEGER">
+        <column-definition type="INTEGER" start-index="24" stop-index="41">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INTEGER">
+        <column-definition type="INTEGER" start-index="44" stop-index="60">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="63" stop-index="82">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="85" stop-index="105">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="108" stop-index="128">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="131" stop-index="151">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_local_temporary_table">
         <table name="t_order" start-index="29" stop-index="35" />
-        <column-definition type="INTEGER">
+        <column-definition type="INTEGER" start-index="38" stop-index="53">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INTEGER">
+        <column-definition type="INTEGER" start-index="56" stop-index="70">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="73" stop-index="90">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="93" stop-index="111">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="114" stop-index="132">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="135" stop-index="153">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_range_partition">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INTEGER">
+        <column-definition type="INTEGER" start-index="22" stop-index="37">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INTEGER">
+        <column-definition type="INTEGER" start-index="40" stop-index="54">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="57" stop-index="74">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="77" stop-index="95">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="98" stop-index="116">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="119" stop-index="137">
             <column name="column3" />
         </column-definition>
     </create-table>
@@ -1092,180 +1092,180 @@
     
     <create-table sql-case-id="create_table_with_bracket">
         <table name="t_order" start-delimiter="[" end-delimiter="]" start-index="13" stop-index="21" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="24" stop-index="37">
             <column name="order_id" start-delimiter="[" end-delimiter="]" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="52">
             <column name="user_id" start-delimiter="[" end-delimiter="]" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="55" stop-index="74">
             <column name="status" start-delimiter="[" end-delimiter="]" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="77" stop-index="97">
             <column name="column1" start-delimiter="[" end-delimiter="]" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="100" stop-index="120">
             <column name="column2" start-delimiter="[" end-delimiter="]" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="123" stop-index="143">
             <column name="column3" start-delimiter="[" end-delimiter="]" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_identity">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="42">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="45" stop-index="55">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="58" stop-index="75">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="78" stop-index="96">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="99" stop-index="117">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="120" stop-index="138">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_as">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="33">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="36" stop-index="46">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="49" stop-index="66">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="69" stop-index="87">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="116" stop-index="134">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="137" stop-index="155">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_column_encrypt_algorithm">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="158">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="161" stop-index="171">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="174" stop-index="191">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="194" stop-index="212">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="215" stop-index="233">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="236" stop-index="254">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_primary_key_sqlserver">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT" primary-key="true">
+        <column-definition type="INT" primary-key="true" start-index="22" stop-index="68">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="71" stop-index="81">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="84" stop-index="101">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="104" stop-index="122">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="125" stop-index="143">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="146" stop-index="164">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_unique_key_sqlserver">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="63">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="66" stop-index="76">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="79" stop-index="96">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="99" stop-index="117">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="120" stop-index="138">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="141" stop-index="159">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_foreign_key_sqlserver">
         <table name="t_order_item" start-index="13" stop-index="24" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="27" stop-index="37">
             <column name="item_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="40" stop-index="140">
             <column name="order_id" />
             <referenced-table name="t_order" start-index="87" stop-index="93" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="143" stop-index="153">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="156" stop-index="173">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="176" stop-index="194">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="197" stop-index="215">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="218" stop-index="236">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_index">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="51">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="54" stop-index="64">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="67" stop-index="84">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="87" stop-index="105">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="108" stop-index="126">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="129" stop-index="147">
             <column name="column3" />
         </column-definition>
         <!-- FIXME cannot parse index -->
@@ -1274,44 +1274,44 @@
     
     <create-table sql-case-id="create_table_with_inline_check_sqlserver">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="22" stop-index="78">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="81" stop-index="91">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="94" stop-index="111">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="114" stop-index="132">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="135" stop-index="153">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="156" stop-index="174">
             <column name="column3" />
         </column-definition>
     </create-table>
     
     <create-table sql-case-id="create_table_with_inline_constraints_sqlserver">
         <table name="t_order" start-index="13" stop-index="19" />
-        <column-definition type="INT" primary-key="true">
+        <column-definition type="INT" primary-key="true" start-index="22" stop-index="73">
             <column name="order_id" />
         </column-definition>
-        <column-definition type="INT">
+        <column-definition type="INT" start-index="76" stop-index="86">
             <column name="user_id" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="89" stop-index="106">
             <column name="status" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="109" stop-index="127">
             <column name="column1" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="130" stop-index="148">
             <column name="column2" />
         </column-definition>
-        <column-definition type="VARCHAR">
+        <column-definition type="VARCHAR" start-index="151" stop-index="169">
             <column name="column3" />
         </column-definition>
     </create-table>


### PR DESCRIPTION
Fixes #4853.

Changes proposed in this pull request:
- Remove comment of test case to be fixed in ColumnDefinitionAssert class.
- Add start-index and stop-index attributions for column-definition tags in alter-table.xml
- Add start-index and stop-index attributions for column-definition tags in create-table.xml
