### PR TITLE
Logic table name and logic column name toLowerCase() for Encrypt.

### DIFF
--- a/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
+++ b/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
@@ -97,18 +97,18 @@ public final class EncryptRule implements BaseRule {
     
     private void initTables(final Map<String, EncryptTableRuleConfiguration> tables) {
         for (Entry<String, EncryptTableRuleConfiguration> entry : tables.entrySet()) {
-            this.tables.put(entry.getKey(), new EncryptTable(entry.getValue()));
+            this.tables.put(entry.getKey().toLowerCase(), new EncryptTable(entry.getValue()));
         }
     }
     
     /**
      * Find encrypt table.
-     * 
+     *
      * @param logicTable logic table
      * @return encrypt table
      */
     public Optional<EncryptTable> findEncryptTable(final String logicTable) {
-        return Optional.ofNullable(tables.get(logicTable));
+        return Optional.ofNullable(tables.get(logicTable.toLowerCase()));
     }
     
     /**
@@ -119,7 +119,7 @@ public final class EncryptRule implements BaseRule {
      * @return logic column
      */
     public String getLogicColumnOfCipher(final String logicTable, final String cipherColumn) {
-        return tables.get(logicTable).getLogicColumnOfCipher(cipherColumn);
+        return tables.get(logicTable.toLowerCase()).getLogicColumnOfCipher(cipherColumn);
     }
     
     /**
@@ -130,12 +130,12 @@ public final class EncryptRule implements BaseRule {
      * @return plain column
      */
     public Optional<String> findPlainColumn(final String logicTable, final String logicColumn) {
-        Optional<String> originColumnName = findOriginColumnName(logicTable, logicColumn);
-        return originColumnName.isPresent() && tables.containsKey(logicTable) ? tables.get(logicTable).findPlainColumn(originColumnName.get()) : Optional.empty();
+        Optional<String> originColumnName = findOriginColumnName(logicTable.toLowerCase(), logicColumn);
+        return originColumnName.isPresent() && tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).findPlainColumn(originColumnName.get()) : Optional.empty();
     }
-
+    
     private Optional<String> findOriginColumnName(final String logicTable, final String logicColumn) {
-        for (String each : tables.get(logicTable).getLogicColumns()) {
+        for (String each : tables.get(logicTable.toLowerCase()).getLogicColumns()) {
             if (logicColumn.equalsIgnoreCase(each)) {
                 return Optional.of(each);
             }
@@ -151,7 +151,7 @@ public final class EncryptRule implements BaseRule {
      * @return cipher column
      */
     public String getCipherColumn(final String logicTable, final String logicColumn) {
-        return tables.get(logicTable).getCipherColumn(logicColumn);
+        return tables.get(logicTable.toLowerCase()).getCipherColumn(logicColumn);
     }
     
     /**
@@ -162,7 +162,7 @@ public final class EncryptRule implements BaseRule {
      * @return cipher column or not
      */
     public boolean isCipherColumn(final String tableName, final String columnName) {
-        return tables.containsKey(tableName) && tables.get(tableName).getCipherColumns().contains(columnName);
+        return tables.containsKey(tableName.toLowerCase()) && tables.get(tableName.toLowerCase()).getCipherColumns().contains(columnName);
     }
     
     /**
@@ -173,17 +173,17 @@ public final class EncryptRule implements BaseRule {
      * @return assisted query column
      */
     public Optional<String> findAssistedQueryColumn(final String logicTable, final String logicColumn) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).findAssistedQueryColumn(logicColumn) : Optional.empty();
+        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).findAssistedQueryColumn(logicColumn) : Optional.empty();
     }
     
     /**
      * Get assisted query columns.
-     * 
+     *
      * @param logicTable logic table
      * @return assisted query columns
      */
     public Collection<String> getAssistedQueryColumns(final String logicTable) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).getAssistedQueryColumns() : Collections.emptyList();
+        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getAssistedQueryColumns() : Collections.emptyList();
     }
     
     /**
@@ -200,7 +200,7 @@ public final class EncryptRule implements BaseRule {
     }
     
     private Collection<String> getPlainColumns(final String logicTable) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).getPlainColumns() : Collections.emptyList();
+        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getPlainColumns() : Collections.emptyList();
     }
     
     /**
@@ -210,7 +210,7 @@ public final class EncryptRule implements BaseRule {
      * @return logic and cipher columns
      */
     public Map<String, String> getLogicAndCipherColumns(final String logicTable) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).getLogicAndCipherColumns() : Collections.emptyMap();
+        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getLogicAndCipherColumns() : Collections.emptyMap();
     }
     
     /**
@@ -220,7 +220,7 @@ public final class EncryptRule implements BaseRule {
      * @return logic and plain columns
      */
     public Map<String, String> getLogicAndPlainColumns(final String logicTable) {
-        return tables.containsKey(logicTable) ? tables.get(logicTable).getLogicAndPlainColumns() : Collections.emptyMap();
+        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getLogicAndPlainColumns() : Collections.emptyMap();
     }
     
     /**
@@ -260,10 +260,10 @@ public final class EncryptRule implements BaseRule {
      * @return sharding encryptor
      */
     public Optional<Encryptor> findEncryptor(final String logicTable, final String logicColumn) {
-        if (!tables.containsKey(logicTable)) {
+        if (!tables.containsKey(logicTable.toLowerCase())) {
             return Optional.empty();
         }
-        Optional<String> encryptor = tables.get(logicTable).findEncryptor(logicColumn);
+        Optional<String> encryptor = tables.get(logicTable.toLowerCase()).findEncryptor(logicColumn);
         return encryptor.map(encryptors::get);
     }
     

--- a/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
+++ b/encrypt-core/encrypt-core-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
@@ -200,7 +200,7 @@ public final class EncryptRule implements BaseRule {
     }
     
     private Collection<String> getPlainColumns(final String logicTable) {
-        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getPlainColumns() : Collections.emptyList();
+        return Optional.ofNullable(tables.get(logicTable.toLowerCase())).map(EncryptTable::getPlainColumns).orElse(Collections.emptyList());
     }
     
     /**
@@ -210,7 +210,7 @@ public final class EncryptRule implements BaseRule {
      * @return logic and cipher columns
      */
     public Map<String, String> getLogicAndCipherColumns(final String logicTable) {
-        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getLogicAndCipherColumns() : Collections.emptyMap();
+        return Optional.ofNullable(tables.get(logicTable.toLowerCase())).map(EncryptTable::getLogicAndCipherColumns).orElse(Collections.emptyMap());
     }
     
     /**
@@ -219,8 +219,8 @@ public final class EncryptRule implements BaseRule {
      * @param logicTable logic table 
      * @return logic and plain columns
      */
-    public Map<String, String> getLogicAndPlainColumns(final String logicTable) {
-        return tables.containsKey(logicTable.toLowerCase()) ? tables.get(logicTable.toLowerCase()).getLogicAndPlainColumns() : Collections.emptyMap();
+    public Map<String, String> getLogicAndPlainColumns(final String logicTable) { 
+        return Optional.ofNullable(tables.get(logicTable.toLowerCase())).map(EncryptTable::getLogicAndPlainColumns).orElse(Collections.emptyMap());
     }
     
     /**

--- a/encrypt-core/encrypt-core-common/src/test/java/org/apache/shardingsphere/encrypt/strategy/impl/EncryptTableTest.java
+++ b/encrypt-core/encrypt-core-common/src/test/java/org/apache/shardingsphere/encrypt/strategy/impl/EncryptTableTest.java
@@ -82,4 +82,10 @@ public final class EncryptTableTest {
         assertTrue(encryptTable.findEncryptor("key").isPresent());
         assertFalse(encryptTable.findEncryptor("notExistLogicColumn").isPresent());
     }
+    
+    @Test
+    public void assertContainsLogicColumn() {
+        assertTrue(encryptTable.containsLogicColumn("key"));
+        assertFalse(encryptTable.containsLogicColumn("notExistLogicColumn"));
+    }
 }

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
@@ -68,7 +68,7 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
         Collection<SubstitutableColumnNameToken> result = new LinkedList<>();
         for (ProjectionSegment each : segment.getProjections()) {
             if (each instanceof ColumnProjectionSegment) {
-                if (encryptTable.getLogicColumns().contains(((ColumnProjectionSegment) each).getColumn().getIdentifier().getValue())) {
+                if (encryptTable.containsLogicColumn(((ColumnProjectionSegment) each).getColumn().getIdentifier().getValue())) {
                     result.add(generateSQLToken((ColumnProjectionSegment) each, tableName));
                 }
             }

--- a/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/InsertCipherNameTokenGenerator.java
+++ b/encrypt-core/encrypt-core-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/InsertCipherNameTokenGenerator.java
@@ -52,8 +52,8 @@ public final class InsertCipherNameTokenGenerator extends BaseEncryptSQLTokenGen
         Map<String, String> logicAndCipherColumns = getEncryptRule().getLogicAndCipherColumns(insertStatementContext.getSqlStatement().getTable().getTableName().getIdentifier().getValue());
         Collection<SubstitutableColumnNameToken> result = new LinkedList<>();
         for (ColumnSegment each : sqlSegment.get().getColumns()) {
-            if (logicAndCipherColumns.keySet().contains(each.getIdentifier().getValue())) {
-                result.add(new SubstitutableColumnNameToken(each.getStartIndex(), each.getStopIndex(), logicAndCipherColumns.get(each.getIdentifier().getValue())));
+            if (logicAndCipherColumns.keySet().contains(each.getIdentifier().getValue().toLowerCase())) {
+                result.add(new SubstitutableColumnNameToken(each.getStartIndex(), each.getStopIndex(), logicAndCipherColumns.get(each.getIdentifier().getValue().toLowerCase())));
             }
         }
         return result;


### PR DESCRIPTION
Fixes #4770.

Changes proposed in this pull request:
- Logic table name to lower case, for user sql's table name is inconsistent with real table name.
- Logic column name to lower case, for user sql's column name is inconsistent with real column name.
- add unit test.
