### PR TITLE
Opt curator-client in unit test 

### DIFF
--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/main/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepository.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/main/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepository.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -131,12 +132,7 @@ public final class CuratorZookeeperCenterRepository implements ConfigCenterRepos
     }
     
     private TreeCache findTreeCache(final String key) {
-        for (Entry<String, TreeCache> entry : caches.entrySet()) {
-            if (key.startsWith(entry.getKey())) {
-                return entry.getValue();
-            }
-        }
-        return null;
+        return caches.entrySet().stream().filter(entry -> key.startsWith(entry.getKey())).findFirst().map(Map.Entry::getValue).orElse(null);
     }
     
     @Override
@@ -258,9 +254,7 @@ public final class CuratorZookeeperCenterRepository implements ConfigCenterRepos
     
     @Override
     public void close() {
-        for (Entry<String, TreeCache> each : caches.entrySet()) {
-            each.getValue().close();
-        }
+        caches.values().forEach(TreeCache::close);
         waitForCacheClose();
         CloseableUtils.closeQuietly(client);
     }

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/main/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepository.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/main/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepository.java
@@ -45,8 +45,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepositoryTest.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepositoryTest.java
@@ -41,8 +41,6 @@ import static org.junit.Assert.assertThat;
 public final class CuratorZookeeperCenterRepositoryTest {
     
     private static CuratorZookeeperCenterRepository centerRepository = new CuratorZookeeperCenterRepository();
-    
-    private static CuratorFramework client;
 
     private static String SERVER_LISTS;
     
@@ -54,9 +52,6 @@ public final class CuratorZookeeperCenterRepositoryTest {
         CenterConfiguration configuration = new CenterConfiguration(centerRepository.getType(), new Properties());
         configuration.setServerLists(SERVER_LISTS);
         centerRepository.init(configuration);
-        Field field = CuratorZookeeperCenterRepository.class.getDeclaredField("client");
-        field.setAccessible(true);
-        client = (CuratorFramework) field.get(centerRepository);
     }
     
     @Test
@@ -105,6 +100,9 @@ public final class CuratorZookeeperCenterRepositoryTest {
         centerRepository.persist("/test/children_deleted/5", "value5");
         SettableFuture<DataChangedEvent> future = SettableFuture.create();
         centerRepository.watch("/test/children_deleted/5", future::set);
+        Field field = CuratorZookeeperCenterRepository.class.getDeclaredField("client");
+        field.setAccessible(true);
+        CuratorFramework client = (CuratorFramework) field.get(centerRepository);
         client.delete().forPath("/test/children_deleted/5");
         DataChangedEvent dataChangedEvent = future.get(5, TimeUnit.SECONDS);
         assertNotNull(dataChangedEvent);

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepositoryTest.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepositoryTest.java
@@ -42,15 +42,15 @@ public final class CuratorZookeeperCenterRepositoryTest {
     
     private static CuratorZookeeperCenterRepository centerRepository = new CuratorZookeeperCenterRepository();
 
-    private static String SERVER_LISTS;
+    private static String serverLists;
     
     @BeforeClass
     @SneakyThrows
     public static void init() {
         EmbedTestingServer.start();
-        SERVER_LISTS = EmbedTestingServer.getTestingServerConnectionString();
+        serverLists = EmbedTestingServer.getTestingServerConnectionString();
         CenterConfiguration configuration = new CenterConfiguration(centerRepository.getType(), new Properties());
-        configuration.setServerLists(SERVER_LISTS);
+        configuration.setServerLists(serverLists);
         centerRepository.init(configuration);
     }
     
@@ -134,7 +134,7 @@ public final class CuratorZookeeperCenterRepositoryTest {
         properties.setProperty(ZookeeperPropertyKey.TIME_TO_LIVE_SECONDS.getKey(), "100");
         properties.setProperty(ZookeeperPropertyKey.OPERATION_TIMEOUT_MILLISECONDS.getKey(), "1000");
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
-        configuration.setServerLists(SERVER_LISTS);
+        configuration.setServerLists(serverLists);
         customCenterRepository.setProperties(properties);
         customCenterRepository.init(configuration);
         assertThat(customCenterRepository.getProperties().getProperty(ZookeeperPropertyKey.RETRY_INTERVAL_MILLISECONDS.getKey()), is("1000"));
@@ -151,7 +151,7 @@ public final class CuratorZookeeperCenterRepositoryTest {
         Properties properties = new Properties();
         properties.setProperty(ZookeeperPropertyKey.TIME_TO_LIVE_SECONDS.getKey(), "0");
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
-        configuration.setServerLists(SERVER_LISTS);
+        configuration.setServerLists(serverLists);
         customCenterRepository.setProperties(properties);
         customCenterRepository.init(configuration);
         assertThat(customCenterRepository.getProperties().getProperty(ZookeeperPropertyKey.TIME_TO_LIVE_SECONDS.getKey()), is("0"));
@@ -165,7 +165,7 @@ public final class CuratorZookeeperCenterRepositoryTest {
         Properties properties = new Properties();
         properties.setProperty(ZookeeperPropertyKey.OPERATION_TIMEOUT_MILLISECONDS.getKey(), "0");
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
-        configuration.setServerLists(SERVER_LISTS);
+        configuration.setServerLists(serverLists);
         customCenterRepository.setProperties(properties);
         customCenterRepository.init(configuration);
         assertThat(customCenterRepository.getProperties().getProperty(ZookeeperPropertyKey.OPERATION_TIMEOUT_MILLISECONDS.getKey()), is("0"));
@@ -179,7 +179,7 @@ public final class CuratorZookeeperCenterRepositoryTest {
         Properties properties = new Properties();
         properties.setProperty(ZookeeperPropertyKey.DIGEST.getKey(), "any");
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
-        configuration.setServerLists(SERVER_LISTS);
+        configuration.setServerLists(serverLists);
         customCenterRepository.setProperties(properties);
         customCenterRepository.init(configuration);
         assertThat(customCenterRepository.getProperties().getProperty(ZookeeperPropertyKey.DIGEST.getKey()), is("any"));

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepositoryTest.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/instance/CuratorZookeeperCenterRepositoryTest.java
@@ -135,7 +135,6 @@ public final class CuratorZookeeperCenterRepositoryTest {
         properties.setProperty(ZookeeperPropertyKey.MAX_RETRIES.getKey(), "1");
         properties.setProperty(ZookeeperPropertyKey.TIME_TO_LIVE_SECONDS.getKey(), "100");
         properties.setProperty(ZookeeperPropertyKey.OPERATION_TIMEOUT_MILLISECONDS.getKey(), "1000");
-        EmbedTestingServer.start();
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
         configuration.setServerLists(SERVER_LISTS);
         customCenterRepository.setProperties(properties);
@@ -153,7 +152,6 @@ public final class CuratorZookeeperCenterRepositoryTest {
         final CuratorZookeeperCenterRepository customCenterRepository = new CuratorZookeeperCenterRepository();
         Properties properties = new Properties();
         properties.setProperty(ZookeeperPropertyKey.TIME_TO_LIVE_SECONDS.getKey(), "0");
-        EmbedTestingServer.start();
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
         configuration.setServerLists(SERVER_LISTS);
         customCenterRepository.setProperties(properties);
@@ -168,7 +166,6 @@ public final class CuratorZookeeperCenterRepositoryTest {
         final CuratorZookeeperCenterRepository customCenterRepository = new CuratorZookeeperCenterRepository();
         Properties properties = new Properties();
         properties.setProperty(ZookeeperPropertyKey.OPERATION_TIMEOUT_MILLISECONDS.getKey(), "0");
-        EmbedTestingServer.start();
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
         configuration.setServerLists(SERVER_LISTS);
         customCenterRepository.setProperties(properties);
@@ -183,7 +180,6 @@ public final class CuratorZookeeperCenterRepositoryTest {
         final CuratorZookeeperCenterRepository customCenterRepository = new CuratorZookeeperCenterRepository();
         Properties properties = new Properties();
         properties.setProperty(ZookeeperPropertyKey.DIGEST.getKey(), "any");
-        EmbedTestingServer.start();
         CenterConfiguration configuration = new CenterConfiguration(customCenterRepository.getType(), new Properties());
         configuration.setServerLists(SERVER_LISTS);
         customCenterRepository.setProperties(properties);

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/util/EmbedTestingServer.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/util/EmbedTestingServer.java
@@ -56,6 +56,13 @@ public final class EmbedTestingServer {
             }));
         }
     }
+
+    /**
+     * Get testingServer connection string.
+     */
+    public static String getTestingServerConnectionString(){
+        return testingServer.getConnectString();
+    }
     
     private static boolean isIgnoredException(final Throwable cause) {
         return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;

--- a/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/util/EmbedTestingServer.java
+++ b/sharding-orchestration/sharding-orchestration-center/sharding-orchestration-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/orchestration/center/util/EmbedTestingServer.java
@@ -59,8 +59,10 @@ public final class EmbedTestingServer {
 
     /**
      * Get testingServer connection string.
+     *
+     * @return connection string
      */
-    public static String getTestingServerConnectionString(){
+    public static String getTestingServerConnectionString() {
         return testingServer.getConnectString();
     }
     


### PR DESCRIPTION
Fixes #4773 .

Changes proposed in this pull request:
- 1、Remove testserver renewing and keep only one server during this test class running
- 2、Use final CenterRepository "client" instead of clientA， keep only one client