### PR TITLE
Fix #4889: Add start-index and stop-index assertion for ColumnPositionSegment

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnPositionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/java/org/apache/shardingsphere/sql/parser/integrate/asserts/segment/definition/ColumnPositionAssert.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.integrate.asserts.segment.definitio
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.integrate.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.sql.parser.integrate.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.sql.parser.integrate.jaxb.domain.segment.impl.definition.ExpectedColumnPosition;
 import org.apache.shardingsphere.sql.parser.sql.segment.ddl.column.position.ColumnAfterPositionSegment;
 import org.apache.shardingsphere.sql.parser.sql.segment.ddl.column.position.ColumnPositionSegment;
@@ -59,7 +60,6 @@ public final class ColumnPositionAssert {
         } else {
             assertNull(assertContext.getText("Assignments should not exist."), expected.getColumn());
         }
-        // TODO assert start index and stop index
-//        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/ddl/alter-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/test/resources/sql/ddl/alter-table.xml
@@ -376,7 +376,7 @@
             <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column3" />
             </column-definition>
-            <column-position/>
+            <column-position start-index="44" stop-index="48" />
         </add-column>
     </alter-table>
     
@@ -386,7 +386,7 @@
             <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column4" />
             </column-definition>
-            <column-position>
+            <column-position start-index="44" stop-index="57">
                 <column name="order_id" />
                 <after-column name="order_id" />
             </column-position>
@@ -399,19 +399,19 @@
             <column-definition type="VARCHAR" start-index="24" stop-index="42">
                 <column name="column5" />
             </column-definition>
-            <column-position/>
+            <column-position start-index="44" stop-index="48" />
         </add-column>
         <add-column>
             <column-definition type="VARCHAR" start-index="55" stop-index="73">
                 <column name="column6" />
             </column-definition>
-            <column-position/>
+            <column-position start-index="75" stop-index="79" />
         </add-column>
         <add-column>
             <column-definition type="VARCHAR" start-index="86" stop-index="104">
                 <column name="column7" />
             </column-definition>
-            <column-position>
+            <column-position start-index="106" stop-index="118">
                 <column name="column5" />
             </column-position>
         </add-column>
@@ -419,7 +419,7 @@
             <column-definition type="VARCHAR" start-index="125" stop-index="143">
                 <column name="column8" />
             </column-definition>
-            <column-position column-name="column8">
+            <column-position column-name="column8" start-index="145" stop-index="157">
                 <column name="column6" />
             </column-position>
         </add-column>
@@ -459,7 +459,7 @@
             <column-definition type="VARCHAR" start-index="27" stop-index="44">
                 <column name="status" />
             </column-definition>
-            <column-position/>
+            <column-position start-index="46" stop-index="50" />
         </modify-column>
     </alter-table>
     
@@ -469,7 +469,7 @@
             <column-definition type="VARCHAR" start-index="27" stop-index="44">
                 <column name="status" />
             </column-definition>
-            <column-position>
+            <column-position start-index="46" stop-index="59">
                 <column name="order_id" />
                 <after-column name="order_id" />
             </column-position>
@@ -482,13 +482,13 @@
             <column-definition type="VARCHAR" start-index="27" stop-index="44">
                 <column name="status" />
             </column-definition>
-            <column-position/>
+            <column-position start-index="46" stop-index="50" />
         </modify-column>
         <modify-column>
             <column-definition type="INT" start-index="60" stop-index="70">
                 <column name="user_id" />
             </column-definition>
-            <column-position>
+            <column-position start-index="72" stop-index="83">
                 <column name="status" />
                 <after-column name="status" />
             </column-position>


### PR DESCRIPTION

Fixes #4889.

Changes proposed in this pull request:
- Uncomment SQLSegmentAssert.assertIs line in ColumnPositionAssert class.
- Add start-index and stop-index attributes for column-position tags in alter-table.xml
-
