### PR TITLE
make key-generator as a spring bean on spring namespace.

### DIFF
--- a/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfiguration.java
+++ b/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfiguration.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.api.config.sharding;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.Getter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 /**
  * Key generator configuration.
@@ -30,11 +30,11 @@ public final class KeyGeneratorConfiguration {
     
     private final String column;
     
-    private final ShardingKeyGenerator keyGenerator;
+    private final KeyGenerateAlgorithm keyGenerateAlgorithm;
     
-    public KeyGeneratorConfiguration(final String column, final ShardingKeyGenerator keyGenerator) {
+    public KeyGeneratorConfiguration(final String column, final KeyGenerateAlgorithm keyGenerateAlgorithm) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(column), "Column is required.");
         this.column = column;
-        this.keyGenerator = keyGenerator;
+        this.keyGenerateAlgorithm = keyGenerateAlgorithm;
     }
 }

--- a/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfiguration.java
+++ b/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfiguration.java
@@ -27,11 +27,11 @@ import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
 */
 @Getter
 public final class KeyGeneratorConfiguration {
-
+    
     private final String column;
-
+    
     private final ShardingKeyGenerator keyGenerator;
-
+    
     public KeyGeneratorConfiguration(final String column, final ShardingKeyGenerator keyGenerator) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(column), "Column is required.");
         this.column = column;

--- a/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfiguration.java
+++ b/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfiguration.java
@@ -20,27 +20,21 @@ package org.apache.shardingsphere.api.config.sharding;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.Getter;
-import org.apache.shardingsphere.underlying.common.config.TypeBasedSPIConfiguration;
-
-import java.util.Properties;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
 
 /**
  * Key generator configuration.
 */
 @Getter
-public final class KeyGeneratorConfiguration extends TypeBasedSPIConfiguration {
-    
+public final class KeyGeneratorConfiguration {
+
     private final String column;
-    
-    public KeyGeneratorConfiguration(final String type, final String column) {
-        super(type);
+
+    private final ShardingKeyGenerator keyGenerator;
+
+    public KeyGeneratorConfiguration(final String column, final ShardingKeyGenerator keyGenerator) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(column), "Column is required.");
         this.column = column;
-    }
-    
-    public KeyGeneratorConfiguration(final String type, final String column, final Properties properties) {
-        super(type, properties);
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(column), "Column is required.");
-        this.column = column;
+        this.keyGenerator = keyGenerator;
     }
 }

--- a/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/spi/keygen/KeyGenerateAlgorithm.java
+++ b/sharding-core/sharding-core-api/src/main/java/org/apache/shardingsphere/spi/keygen/KeyGenerateAlgorithm.java
@@ -15,31 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.core.strategy.keygen;
+package org.apache.shardingsphere.spi.keygen;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
-
-import java.util.Properties;
-import java.util.UUID;
+import org.apache.shardingsphere.spi.TypeBasedSPI;
 
 /**
- * UUID key generator.
+ * Key generate algorithm.
  */
-@Getter
-@Setter
-public final class UUIDShardingKeyGenerator implements ShardingKeyGenerator {
+public interface KeyGenerateAlgorithm extends TypeBasedSPI {
     
-    private Properties properties = new Properties();
-    
-    @Override
-    public String getType() {
-        return "UUID";
-    }
-    
-    @Override
-    public synchronized Comparable<?> generateKey() {
-        return UUID.randomUUID().toString().replaceAll("-", "");
-    }
+    /**
+     * Generate key.
+     * 
+     * @return generated key
+     */
+    Comparable<?> generateKey();
 }

--- a/sharding-core/sharding-core-api/src/test/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfigurationTest.java
+++ b/sharding-core/sharding-core-api/src/test/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfigurationTest.java
@@ -20,12 +20,12 @@ package org.apache.shardingsphere.api.config.sharding;
 import org.junit.Test;
 
 public final class KeyGeneratorConfigurationTest {
-
+    
     @Test
     public void assertConstructorWithoutKeyGenerator() {
         new KeyGeneratorConfiguration("id", null);
     }
-
+    
     @Test(expected = IllegalArgumentException.class)
     public void assertConstructorWithoutColumn() {
         new KeyGeneratorConfiguration("", null);

--- a/sharding-core/sharding-core-api/src/test/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfigurationTest.java
+++ b/sharding-core/sharding-core-api/src/test/java/org/apache/shardingsphere/api/config/sharding/KeyGeneratorConfigurationTest.java
@@ -19,38 +19,15 @@ package org.apache.shardingsphere.api.config.sharding;
 
 import org.junit.Test;
 
-import java.util.Properties;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
 public final class KeyGeneratorConfigurationTest {
-    
-    @Test(expected = IllegalArgumentException.class)
-    public void assertConstructorWithoutType() {
-        new KeyGeneratorConfiguration("", "id", new Properties());
+
+    @Test
+    public void assertConstructorWithoutKeyGenerator() {
+        new KeyGeneratorConfiguration("id", null);
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void assertConstructorWithoutColumn() {
-        new KeyGeneratorConfiguration("TEST", "", new Properties());
-    }
-    
-    @Test
-    public void assertConstructorWithoutProperties() {
-        KeyGeneratorConfiguration actual = new KeyGeneratorConfiguration("TEST", "id", null);
-        assertThat(actual.getType(), is("TEST"));
-        assertThat(actual.getColumn(), is("id"));
-        assertThat(actual.getProperties(), is(new Properties()));
-    }
-    
-    @Test
-    public void assertConstructorWithFullArguments() {
-        Properties props = new Properties();
-        props.setProperty("key", "value");
-        KeyGeneratorConfiguration actual = new KeyGeneratorConfiguration("TEST", "id", props);
-        assertThat(actual.getType(), is("TEST"));
-        assertThat(actual.getColumn(), is("id"));
-        assertThat(actual.getProperties(), is(props));
+        new KeyGeneratorConfiguration("", null);
     }
 }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
@@ -110,11 +110,10 @@ public class ShardingRule implements BaseRule {
     
     private KeyGenerateAlgorithm createDefaultKeyGenerateAlgorithm(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
         KeyGenerateAlgorithmServiceLoader serviceLoader = new KeyGenerateAlgorithmServiceLoader();
-        return containsKeyGeneratorConfiguration(keyGeneratorConfiguration)
-                ? keyGeneratorConfiguration.getKeyGenerateAlgorithm() : serviceLoader.newService();
+        return containsKeyGenerateAlgorithm(keyGeneratorConfiguration) ? keyGeneratorConfiguration.getKeyGenerateAlgorithm() : serviceLoader.newService();
     }
     
-    private boolean containsKeyGeneratorConfiguration(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
+    private boolean containsKeyGenerateAlgorithm(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
         return null != keyGeneratorConfiguration && null != keyGeneratorConfiguration.getKeyGenerateAlgorithm();
     }
     

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
@@ -30,8 +30,8 @@ import org.apache.shardingsphere.core.strategy.route.ShardingStrategyFactory;
 import org.apache.shardingsphere.core.strategy.route.none.NoneShardingStrategy;
 import org.apache.shardingsphere.encrypt.api.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.underlying.common.rule.BaseRule;
 import org.apache.shardingsphere.underlying.common.rule.DataNode;
@@ -65,7 +65,7 @@ public class ShardingRule implements BaseRule {
     
     private final ShardingStrategy defaultTableShardingStrategy;
     
-    private final ShardingKeyGenerator defaultShardingKeyGenerator;
+    private final KeyGenerateAlgorithm defaultKeyGenerateAlgorithm;
     
     private final Collection<MasterSlaveRule> masterSlaveRules;
     
@@ -81,7 +81,7 @@ public class ShardingRule implements BaseRule {
         bindingTableRules = createBindingTableRules(shardingRuleConfig.getBindingTableGroups());
         defaultDatabaseShardingStrategy = createDefaultShardingStrategy(shardingRuleConfig.getDefaultDatabaseShardingStrategyConfig());
         defaultTableShardingStrategy = createDefaultShardingStrategy(shardingRuleConfig.getDefaultTableShardingStrategyConfig());
-        defaultShardingKeyGenerator = createDefaultKeyGenerator(shardingRuleConfig.getDefaultKeyGeneratorConfig());
+        defaultKeyGenerateAlgorithm = createDefaultKeyGenerateAlgorithm(shardingRuleConfig.getDefaultKeyGeneratorConfig());
         masterSlaveRules = createMasterSlaveRules(shardingRuleConfig.getMasterSlaveRuleConfigs());
         encryptRule = createEncryptRule(shardingRuleConfig.getEncryptRuleConfig());
     }
@@ -108,14 +108,14 @@ public class ShardingRule implements BaseRule {
         return Optional.ofNullable(shardingStrategyConfiguration).map(ShardingStrategyFactory::newInstance).orElse(new NoneShardingStrategy());
     }
     
-    private ShardingKeyGenerator createDefaultKeyGenerator(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
-        ShardingKeyGeneratorServiceLoader serviceLoader = new ShardingKeyGeneratorServiceLoader();
+    private KeyGenerateAlgorithm createDefaultKeyGenerateAlgorithm(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
+        KeyGenerateAlgorithmServiceLoader serviceLoader = new KeyGenerateAlgorithmServiceLoader();
         return containsKeyGeneratorConfiguration(keyGeneratorConfiguration)
-                ? keyGeneratorConfiguration.getKeyGenerator() : serviceLoader.newService();
+                ? keyGeneratorConfiguration.getKeyGenerateAlgorithm() : serviceLoader.newService();
     }
     
     private boolean containsKeyGeneratorConfiguration(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
-        return null != keyGeneratorConfiguration && null != keyGeneratorConfiguration.getKeyGenerator();
+        return null != keyGeneratorConfiguration && null != keyGeneratorConfiguration.getKeyGenerateAlgorithm();
     }
     
     private Collection<MasterSlaveRule> createMasterSlaveRules(final Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigurations) {
@@ -320,7 +320,7 @@ public class ShardingRule implements BaseRule {
         if (!tableRule.isPresent()) {
             throw new ShardingSphereConfigurationException("Cannot find strategy for generate keys.");
         }
-        return Optional.ofNullable(tableRule.get().getShardingKeyGenerator()).orElse(defaultShardingKeyGenerator).generateKey();
+        return Optional.ofNullable(tableRule.get().getKeyGenerateAlgorithm()).orElse(defaultKeyGenerateAlgorithm).generateKey();
     }
     
     /**

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/ShardingRule.java
@@ -111,11 +111,11 @@ public class ShardingRule implements BaseRule {
     private ShardingKeyGenerator createDefaultKeyGenerator(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
         ShardingKeyGeneratorServiceLoader serviceLoader = new ShardingKeyGeneratorServiceLoader();
         return containsKeyGeneratorConfiguration(keyGeneratorConfiguration)
-                ? serviceLoader.newService(keyGeneratorConfiguration.getType(), keyGeneratorConfiguration.getProperties()) : serviceLoader.newService();
+                ? keyGeneratorConfiguration.getKeyGenerator() : serviceLoader.newService();
     }
     
     private boolean containsKeyGeneratorConfiguration(final KeyGeneratorConfiguration keyGeneratorConfiguration) {
-        return null != keyGeneratorConfiguration && !Strings.isNullOrEmpty(keyGeneratorConfiguration.getType());
+        return null != keyGeneratorConfiguration && null != keyGeneratorConfiguration.getKeyGenerator();
     }
     
     private Collection<MasterSlaveRule> createMasterSlaveRules(final Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigurations) {

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
@@ -26,7 +26,7 @@ import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategyFactory;
 import org.apache.shardingsphere.core.strategy.route.none.NoneShardingStrategy;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.underlying.common.config.inline.InlineExpressionParser;
 import org.apache.shardingsphere.underlying.common.exception.ShardingSphereException;
@@ -68,7 +68,7 @@ public final class TableRule {
     @Getter(AccessLevel.NONE)
     private final String generateKeyColumn;
     
-    private final ShardingKeyGenerator shardingKeyGenerator;
+    private final KeyGenerateAlgorithm keyGenerateAlgorithm;
     
     private final Collection<String> actualDatasourceNames = new LinkedHashSet<>();
     
@@ -83,7 +83,7 @@ public final class TableRule {
         databaseShardingStrategy = null;
         tableShardingStrategy = null;
         generateKeyColumn = null;
-        shardingKeyGenerator = null;
+        keyGenerateAlgorithm = null;
     }
     
     public TableRule(final Collection<String> dataSourceNames, final String logicTableName) {
@@ -94,7 +94,7 @@ public final class TableRule {
         databaseShardingStrategy = null;
         tableShardingStrategy = null;
         generateKeyColumn = null;
-        shardingKeyGenerator = null;
+        keyGenerateAlgorithm = null;
     }
     
     public TableRule(final TableRuleConfiguration tableRuleConfig, final ShardingDataSourceNames shardingDataSourceNames, final String defaultGenerateKeyColumn) {
@@ -108,8 +108,8 @@ public final class TableRule {
         tableShardingStrategy = null == tableRuleConfig.getTableShardingStrategyConfig() ? null : ShardingStrategyFactory.newInstance(tableRuleConfig.getTableShardingStrategyConfig());
         final KeyGeneratorConfiguration keyGeneratorConfiguration = tableRuleConfig.getKeyGeneratorConfig();
         generateKeyColumn = null != keyGeneratorConfiguration && !Strings.isNullOrEmpty(keyGeneratorConfiguration.getColumn()) ? keyGeneratorConfiguration.getColumn() : defaultGenerateKeyColumn;
-        shardingKeyGenerator = containsKeyGeneratorConfiguration(tableRuleConfig)
-                ? tableRuleConfig.getKeyGeneratorConfig().getKeyGenerator() : null;
+        keyGenerateAlgorithm = containsKeyGeneratorConfiguration(tableRuleConfig)
+                ? tableRuleConfig.getKeyGeneratorConfig().getKeyGenerateAlgorithm() : null;
         checkRule(dataNodes);
     }
     
@@ -129,7 +129,7 @@ public final class TableRule {
     }
     
     private boolean containsKeyGeneratorConfiguration(final TableRuleConfiguration tableRuleConfiguration) {
-        return null != tableRuleConfiguration.getKeyGeneratorConfig() && null != tableRuleConfiguration.getKeyGeneratorConfig().getKeyGenerator();
+        return null != tableRuleConfiguration.getKeyGeneratorConfig() && null != tableRuleConfiguration.getKeyGeneratorConfig().getKeyGenerateAlgorithm();
     }
     
     private boolean isEmptyDataNodes(final List<String> dataNodes) {

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
@@ -110,7 +110,7 @@ public final class TableRule {
         final KeyGeneratorConfiguration keyGeneratorConfiguration = tableRuleConfig.getKeyGeneratorConfig();
         generateKeyColumn = null != keyGeneratorConfiguration && !Strings.isNullOrEmpty(keyGeneratorConfiguration.getColumn()) ? keyGeneratorConfiguration.getColumn() : defaultGenerateKeyColumn;
         shardingKeyGenerator = containsKeyGeneratorConfiguration(tableRuleConfig)
-                ? new ShardingKeyGeneratorServiceLoader().newService(tableRuleConfig.getKeyGeneratorConfig().getType(), tableRuleConfig.getKeyGeneratorConfig().getProperties()) : null;
+                ? tableRuleConfig.getKeyGeneratorConfig().getKeyGenerator() : null;
         checkRule(dataNodes);
     }
     
@@ -130,9 +130,9 @@ public final class TableRule {
     }
     
     private boolean containsKeyGeneratorConfiguration(final TableRuleConfiguration tableRuleConfiguration) {
-        return null != tableRuleConfiguration.getKeyGeneratorConfig() && !Strings.isNullOrEmpty(tableRuleConfiguration.getKeyGeneratorConfig().getType());
+        return null != tableRuleConfiguration.getKeyGeneratorConfig() && null != tableRuleConfiguration.getKeyGeneratorConfig().getKeyGenerator();
     }
-    
+
     private boolean isEmptyDataNodes(final List<String> dataNodes) {
         return null == dataNodes || dataNodes.isEmpty();
     }
@@ -217,10 +217,10 @@ public final class TableRule {
             throw new ShardingSphereConfigurationException("ActualDataNodes must be configured if want to shard tables for logicTable [%s]", logicTable);
         }
     }
-    
+
     /**
      * Get generate key column.
-     * 
+     *
      * @return generate key column
      */
     public Optional<String> getGenerateKeyColumn() {

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
@@ -108,8 +108,7 @@ public final class TableRule {
         tableShardingStrategy = null == tableRuleConfig.getTableShardingStrategyConfig() ? null : ShardingStrategyFactory.newInstance(tableRuleConfig.getTableShardingStrategyConfig());
         final KeyGeneratorConfiguration keyGeneratorConfiguration = tableRuleConfig.getKeyGeneratorConfig();
         generateKeyColumn = null != keyGeneratorConfiguration && !Strings.isNullOrEmpty(keyGeneratorConfiguration.getColumn()) ? keyGeneratorConfiguration.getColumn() : defaultGenerateKeyColumn;
-        keyGenerateAlgorithm = containsKeyGeneratorConfiguration(tableRuleConfig)
-                ? tableRuleConfig.getKeyGeneratorConfig().getKeyGenerateAlgorithm() : null;
+        keyGenerateAlgorithm = containsKeyGenerateAlgorithm(tableRuleConfig) ? tableRuleConfig.getKeyGeneratorConfig().getKeyGenerateAlgorithm() : null;
         checkRule(dataNodes);
     }
     
@@ -128,7 +127,7 @@ public final class TableRule {
         datasourceToTablesMap.computeIfAbsent(datasourceName, k -> new LinkedHashSet<>()).add(tableName);
     }
     
-    private boolean containsKeyGeneratorConfiguration(final TableRuleConfiguration tableRuleConfiguration) {
+    private boolean containsKeyGenerateAlgorithm(final TableRuleConfiguration tableRuleConfiguration) {
         return null != tableRuleConfiguration.getKeyGeneratorConfig() && null != tableRuleConfiguration.getKeyGeneratorConfig().getKeyGenerateAlgorithm();
     }
     

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
@@ -131,7 +131,7 @@ public final class TableRule {
     private boolean containsKeyGeneratorConfiguration(final TableRuleConfiguration tableRuleConfiguration) {
         return null != tableRuleConfiguration.getKeyGeneratorConfig() && null != tableRuleConfiguration.getKeyGeneratorConfig().getKeyGenerator();
     }
-
+    
     private boolean isEmptyDataNodes(final List<String> dataNodes) {
         return null == dataNodes || dataNodes.isEmpty();
     }
@@ -216,7 +216,7 @@ public final class TableRule {
             throw new ShardingSphereConfigurationException("ActualDataNodes must be configured if want to shard tables for logicTable [%s]", logicTable);
         }
     }
-
+    
     /**
      * Get generate key column.
      *

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/TableRule.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategyFactory;
 import org.apache.shardingsphere.core.strategy.route.none.NoneShardingStrategy;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
 import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.underlying.common.config.inline.InlineExpressionParser;

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/keygen/SnowflakeKeyGenerateAlgorithm.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/keygen/SnowflakeKeyGenerateAlgorithm.java
@@ -21,13 +21,13 @@ import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Calendar;
 import java.util.Properties;
 
 /**
- * Snowflake distributed primary key generator.
+ * Snowflake distributed primary key generate algorithm.
  * 
  * <p>
  * Use snowflake algorithm. Length is 64 bit.
@@ -41,14 +41,14 @@ import java.util.Properties;
  * </pre>
  * 
  * <p>
- * Call @{@code SnowflakeShardingKeyGenerator.setWorkerId} to set worker id, default value is 0.
+ * Call @{@code SnowflakeKeyGenerateAlgorithm.setWorkerId} to set worker id, default value is 0.
  * </p>
  * 
  * <p>
- * Call @{@code SnowflakeShardingKeyGenerator.setMaxTolerateTimeDifferenceMilliseconds} to set max tolerate time difference milliseconds, default value is 0.
+ * Call @{@code SnowflakeKeyGenerateAlgorithm.setMaxTolerateTimeDifferenceMilliseconds} to set max tolerate time difference milliseconds, default value is 0.
  * </p>
  */
-public final class SnowflakeShardingKeyGenerator implements ShardingKeyGenerator {
+public final class SnowflakeKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
     public static final long EPOCH;
     

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/keygen/UUIDKeyGenerateAlgorithm.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/keygen/UUIDKeyGenerateAlgorithm.java
@@ -15,28 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.core.strategy.keygen.fixture;
+package org.apache.shardingsphere.core.strategy.keygen;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.UUID;
 
-public final class IncrementShardingKeyGenerator implements ShardingKeyGenerator {
+/**
+ * UUID key generate algorithm.
+ */
+@Getter
+@Setter
+public final class UUIDKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
-    @Getter
-    private final String type = "INCREMENT";
-    
-    private final AtomicInteger count = new AtomicInteger();
-    
-    @Getter
-    @Setter
     private Properties properties = new Properties();
     
     @Override
-    public Comparable<?> generateKey() {
-        return count.incrementAndGet();
+    public String getType() {
+        return "UUID";
+    }
+    
+    @Override
+    public synchronized Comparable<?> generateKey() {
+        return UUID.randomUUID().toString().replaceAll("-", "");
     }
 }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapper.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapper.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.core.yaml.swapper;
 
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlKeyGeneratorConfiguration;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.underlying.common.yaml.swapper.YamlSwapper;
 
 /**
@@ -31,15 +31,15 @@ public final class KeyGeneratorConfigurationYamlSwapper implements YamlSwapper<Y
     @Override
     public YamlKeyGeneratorConfiguration swap(final KeyGeneratorConfiguration data) {
         YamlKeyGeneratorConfiguration result = new YamlKeyGeneratorConfiguration();
-        result.setType(data.getKeyGenerator().getType());
+        result.setType(data.getKeyGenerateAlgorithm().getType());
         result.setColumn(data.getColumn());
-        result.setProps(data.getKeyGenerator().getProperties());
+        result.setProps(data.getKeyGenerateAlgorithm().getProperties());
         return result;
     }
     
     @Override
     public KeyGeneratorConfiguration swap(final YamlKeyGeneratorConfiguration yamlConfiguration) {
-        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService(yamlConfiguration.getType(), yamlConfiguration.getProps());
-        return new KeyGeneratorConfiguration(yamlConfiguration.getColumn(), keyGenerator);
+        KeyGenerateAlgorithm keyGenerateAlgorithm = new KeyGenerateAlgorithmServiceLoader().newService(yamlConfiguration.getType(), yamlConfiguration.getProps());
+        return new KeyGeneratorConfiguration(yamlConfiguration.getColumn(), keyGenerateAlgorithm);
     }
 }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapper.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapper.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.core.yaml.swapper;
 
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlKeyGeneratorConfiguration;
+import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
 import org.apache.shardingsphere.underlying.common.yaml.swapper.YamlSwapper;
 
 /**
@@ -29,14 +31,15 @@ public final class KeyGeneratorConfigurationYamlSwapper implements YamlSwapper<Y
     @Override
     public YamlKeyGeneratorConfiguration swap(final KeyGeneratorConfiguration data) {
         YamlKeyGeneratorConfiguration result = new YamlKeyGeneratorConfiguration();
-        result.setType(data.getType());
+        result.setType(data.getKeyGenerator().getType());
         result.setColumn(data.getColumn());
-        result.setProps(data.getProperties());
+        result.setProps(data.getKeyGenerator().getProperties());
         return result;
     }
     
     @Override
     public KeyGeneratorConfiguration swap(final YamlKeyGeneratorConfiguration yamlConfiguration) {
-        return new KeyGeneratorConfiguration(yamlConfiguration.getType(), yamlConfiguration.getColumn(), yamlConfiguration.getProps());
+        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService(yamlConfiguration.getType(), yamlConfiguration.getProps());
+        return new KeyGeneratorConfiguration(yamlConfiguration.getColumn(), keyGenerator);
     }
 }

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/spi/algorithm/keygen/KeyGenerateAlgorithmServiceLoader.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/spi/algorithm/keygen/KeyGenerateAlgorithmServiceLoader.java
@@ -15,28 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture;
+package org.apache.shardingsphere.spi.algorithm.keygen;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.NewInstanceServiceLoader;
+import org.apache.shardingsphere.spi.TypeBasedSPIServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
-
-public final class IncrementShardingKeyGenerator implements ShardingKeyGenerator {
+/**
+ * Key generate algorithm service loader.
+ */
+public final class KeyGenerateAlgorithmServiceLoader extends TypeBasedSPIServiceLoader<KeyGenerateAlgorithm> {
     
-    private static final AtomicInteger SEQUENCE = new AtomicInteger(100);
+    static {
+        NewInstanceServiceLoader.register(KeyGenerateAlgorithm.class);
+    }
     
-    @Getter
-    private final String type = "INCREMENT";
-    
-    @Getter
-    @Setter
-    private Properties properties = new Properties();
-    
-    @Override
-    public Comparable<?> generateKey() {
-        return SEQUENCE.incrementAndGet();
+    public KeyGenerateAlgorithmServiceLoader() {
+        super(KeyGenerateAlgorithm.class);
     }
 }

--- a/sharding-core/sharding-core-common/src/main/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-core/sharding-core-common/src/main/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,7 +15,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.core.strategy.keygen.SnowflakeShardingKeyGenerator
-org.apache.shardingsphere.core.strategy.keygen.UUIDShardingKeyGenerator
-org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture.DecrementShardingKeyGenerator
-org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture.IncrementShardingKeyGenerator
+org.apache.shardingsphere.core.strategy.keygen.SnowflakeKeyGenerateAlgorithm
+org.apache.shardingsphere.core.strategy.keygen.UUIDKeyGenerateAlgorithm

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -37,13 +37,13 @@ import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStra
 import org.apache.shardingsphere.api.config.sharding.strategy.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.StandardShardingStrategyConfiguration;
 import org.apache.shardingsphere.core.shard.fixture.PreciseShardingAlgorithmFixture;
-import org.apache.shardingsphere.core.strategy.keygen.SnowflakeShardingKeyGenerator;
-import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementShardingKeyGenerator;
+import org.apache.shardingsphere.core.strategy.keygen.SnowflakeKeyGenerateAlgorithm;
+import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementKeyGenerateAlgorithm;
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.inline.InlineShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.none.NoneShardingStrategy;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.underlying.common.rule.DataNode;
 import org.junit.Test;
@@ -64,7 +64,7 @@ public final class ShardingRuleTest {
         assertThat(actual.getBroadcastTables(), is(Collections.singletonList("BROADCAST_TABLE")));
         assertThat(actual.getDefaultDatabaseShardingStrategy(), instanceOf(InlineShardingStrategy.class));
         assertThat(actual.getDefaultTableShardingStrategy(), instanceOf(InlineShardingStrategy.class));
-        assertThat(actual.getDefaultShardingKeyGenerator(), instanceOf(IncrementShardingKeyGenerator.class));
+        assertThat(actual.getDefaultKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @Test
@@ -75,7 +75,7 @@ public final class ShardingRuleTest {
         assertTrue(actual.getBroadcastTables().isEmpty());
         assertThat(actual.getDefaultDatabaseShardingStrategy(), instanceOf(NoneShardingStrategy.class));
         assertThat(actual.getDefaultTableShardingStrategy(), instanceOf(NoneShardingStrategy.class));
-        assertThat(actual.getDefaultShardingKeyGenerator(), instanceOf(SnowflakeShardingKeyGenerator.class));
+        assertThat(actual.getDefaultKeyGenerateAlgorithm(), instanceOf(SnowflakeKeyGenerateAlgorithm.class));
     }
     
     @Test
@@ -398,8 +398,8 @@ public final class ShardingRuleTest {
         ShardingRuleConfiguration shardingRuleConfiguration = new ShardingRuleConfiguration();
         shardingRuleConfiguration.setDefaultDataSourceName("ds_0");
         TableRuleConfiguration tableRuleConfiguration = createTableRuleConfiguration("LOGIC_TABLE", "ds_${0..1}.table_${0..2}");
-        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService("INCREMENT", new Properties());
-        tableRuleConfiguration.setKeyGeneratorConfig(new KeyGeneratorConfiguration("id", keyGenerator));
+        KeyGenerateAlgorithm keyGenerateAlgorithm = new KeyGenerateAlgorithmServiceLoader().newService("INCREMENT", new Properties());
+        tableRuleConfiguration.setKeyGeneratorConfig(new KeyGeneratorConfiguration("id", keyGenerateAlgorithm));
         TableRuleConfiguration subTableRuleConfiguration = createTableRuleConfiguration("SUB_LOGIC_TABLE", "ds_${0..1}.sub_table_${0..2}");
         shardingRuleConfiguration.getTableRuleConfigs().add(tableRuleConfiguration);
         shardingRuleConfiguration.getTableRuleConfigs().add(subTableRuleConfiguration);
@@ -407,8 +407,8 @@ public final class ShardingRuleTest {
         shardingRuleConfiguration.getBroadcastTables().add("BROADCAST_TABLE");
         shardingRuleConfiguration.setDefaultDatabaseShardingStrategyConfig(new InlineShardingStrategyConfiguration("ds_id", "ds_%{ds_id % 2}"));
         shardingRuleConfiguration.setDefaultTableShardingStrategyConfig(new InlineShardingStrategyConfiguration("table_id", "table_%{table_id % 2}"));
-        ShardingKeyGenerator defaultKeyGenerator = new ShardingKeyGeneratorServiceLoader().newService("INCREMENT", new Properties());
-        shardingRuleConfiguration.setDefaultKeyGeneratorConfig(new KeyGeneratorConfiguration("id", defaultKeyGenerator));
+        KeyGenerateAlgorithm defaultKeyGenerateAlgorithm = new KeyGenerateAlgorithmServiceLoader().newService("INCREMENT", new Properties());
+        shardingRuleConfiguration.setDefaultKeyGeneratorConfig(new KeyGeneratorConfiguration("id", defaultKeyGenerateAlgorithm));
         return new ShardingRule(shardingRuleConfiguration, createDataSourceNames());
     }
     

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -17,6 +17,18 @@
 
 package org.apache.shardingsphere.core.rule;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
@@ -30,22 +42,11 @@ import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementShardingK
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.inline.InlineShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.none.NoneShardingStrategy;
+import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.underlying.common.rule.DataNode;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Properties;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class ShardingRuleTest {
     
@@ -397,7 +398,8 @@ public final class ShardingRuleTest {
         ShardingRuleConfiguration shardingRuleConfiguration = new ShardingRuleConfiguration();
         shardingRuleConfiguration.setDefaultDataSourceName("ds_0");
         TableRuleConfiguration tableRuleConfiguration = createTableRuleConfiguration("LOGIC_TABLE", "ds_${0..1}.table_${0..2}");
-        tableRuleConfiguration.setKeyGeneratorConfig(new KeyGeneratorConfiguration("INCREMENT", "id", new Properties()));
+        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService("INCREMENT", new Properties());
+        tableRuleConfiguration.setKeyGeneratorConfig(new KeyGeneratorConfiguration("id", keyGenerator));
         TableRuleConfiguration subTableRuleConfiguration = createTableRuleConfiguration("SUB_LOGIC_TABLE", "ds_${0..1}.sub_table_${0..2}");
         shardingRuleConfiguration.getTableRuleConfigs().add(tableRuleConfiguration);
         shardingRuleConfiguration.getTableRuleConfigs().add(subTableRuleConfiguration);
@@ -405,7 +407,8 @@ public final class ShardingRuleTest {
         shardingRuleConfiguration.getBroadcastTables().add("BROADCAST_TABLE");
         shardingRuleConfiguration.setDefaultDatabaseShardingStrategyConfig(new InlineShardingStrategyConfiguration("ds_id", "ds_%{ds_id % 2}"));
         shardingRuleConfiguration.setDefaultTableShardingStrategyConfig(new InlineShardingStrategyConfiguration("table_id", "table_%{table_id % 2}"));
-        shardingRuleConfiguration.setDefaultKeyGeneratorConfig(new KeyGeneratorConfiguration("INCREMENT", "id", new Properties()));
+        ShardingKeyGenerator defaultKeyGenerator = new ShardingKeyGeneratorServiceLoader().newService("INCREMENT", new Properties());
+        shardingRuleConfiguration.setDefaultKeyGeneratorConfig(new KeyGeneratorConfiguration("id", defaultKeyGenerator));
         return new ShardingRule(shardingRuleConfiguration, createDataSourceNames());
     }
     

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/TableRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/TableRuleTest.java
@@ -34,9 +34,9 @@ import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.NoneShardingStrategyConfiguration;
-import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementShardingKeyGenerator;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementKeyGenerateAlgorithm;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.underlying.common.rule.DataNode;
 import org.junit.Test;
@@ -60,8 +60,8 @@ public final class TableRuleTest {
         TableRuleConfiguration tableRuleConfig = new TableRuleConfiguration("LOGIC_TABLE", "ds${0..1}.table_${0..2}");
         tableRuleConfig.setDatabaseShardingStrategyConfig(new NoneShardingStrategyConfiguration());
         tableRuleConfig.setTableShardingStrategyConfig(new NoneShardingStrategyConfiguration());
-        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService("INCREMENT", new Properties());
-        tableRuleConfig.setKeyGeneratorConfig(new KeyGeneratorConfiguration("col_1", keyGenerator));
+        KeyGenerateAlgorithm keyGenerateAlgorithm = new KeyGenerateAlgorithmServiceLoader().newService("INCREMENT", new Properties());
+        tableRuleConfig.setKeyGeneratorConfig(new KeyGeneratorConfiguration("col_1", keyGenerateAlgorithm));
         TableRule actual = new TableRule(tableRuleConfig, createShardingDataSourceNames(), null);
         assertThat(actual.getLogicTable(), is("logic_table"));
         assertThat(actual.getActualDataNodes().size(), is(6));
@@ -75,7 +75,7 @@ public final class TableRuleTest {
         assertNotNull(actual.getTableShardingStrategy());
         assertTrue(actual.getGenerateKeyColumn().isPresent());
         assertThat(actual.getGenerateKeyColumn().get(), is("col_1"));
-        assertThat(actual.getShardingKeyGenerator(), instanceOf(IncrementShardingKeyGenerator.class));
+        assertThat(actual.getKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @Test

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/TableRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/TableRuleTest.java
@@ -17,21 +17,6 @@
 
 package org.apache.shardingsphere.core.rule;
 
-import com.google.common.collect.Sets;
-import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
-import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
-import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
-import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
-import org.apache.shardingsphere.api.config.sharding.strategy.NoneShardingStrategyConfiguration;
-import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementShardingKeyGenerator;
-import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
-import org.apache.shardingsphere.underlying.common.rule.DataNode;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Properties;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -39,6 +24,22 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
+import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
+import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
+import org.apache.shardingsphere.api.config.sharding.strategy.NoneShardingStrategyConfiguration;
+import org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementShardingKeyGenerator;
+import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
+import org.apache.shardingsphere.underlying.common.rule.DataNode;
+import org.junit.Test;
 
 public final class TableRuleTest {
     
@@ -59,7 +60,8 @@ public final class TableRuleTest {
         TableRuleConfiguration tableRuleConfig = new TableRuleConfiguration("LOGIC_TABLE", "ds${0..1}.table_${0..2}");
         tableRuleConfig.setDatabaseShardingStrategyConfig(new NoneShardingStrategyConfiguration());
         tableRuleConfig.setTableShardingStrategyConfig(new NoneShardingStrategyConfiguration());
-        tableRuleConfig.setKeyGeneratorConfig(new KeyGeneratorConfiguration("INCREMENT", "col_1", new Properties()));
+        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService("INCREMENT", new Properties());
+        tableRuleConfig.setKeyGeneratorConfig(new KeyGeneratorConfiguration("col_1", keyGenerator));
         TableRule actual = new TableRule(tableRuleConfig, createShardingDataSourceNames(), null);
         assertThat(actual.getLogicTable(), is("logic_table"));
         assertThat(actual.getActualDataNodes().size(), is(6));

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/KeyGenerateAlgorithmServiceLoaderTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/KeyGenerateAlgorithmServiceLoaderTest.java
@@ -17,30 +17,29 @@
 
 package org.apache.shardingsphere.core.strategy.keygen;
 
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.junit.Test;
-
-import java.util.Properties;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
-public final class ShardingKeyGeneratorServiceLoaderTest {
+import java.util.Properties;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.junit.Test;
+
+public final class KeyGenerateAlgorithmServiceLoaderTest {
     
-    private ShardingKeyGeneratorServiceLoader serviceLoader = new ShardingKeyGeneratorServiceLoader();
+    private KeyGenerateAlgorithmServiceLoader serviceLoader = new KeyGenerateAlgorithmServiceLoader();
     
     @Test
-    public void assertNewSnowflakeKeyGenerator() {
-        assertThat(serviceLoader.newService("SNOWFLAKE", new Properties()), instanceOf(SnowflakeShardingKeyGenerator.class));
+    public void assertNewSnowflakeKeyGenerateAlgorithm() {
+        assertThat(serviceLoader.newService("SNOWFLAKE", new Properties()), instanceOf(SnowflakeKeyGenerateAlgorithm.class));
     }
     
     @Test
-    public void assertNewUUIDKeyGenerator() {
-        assertThat(serviceLoader.newService("UUID", new Properties()), instanceOf(UUIDShardingKeyGenerator.class));
+    public void assertNewUUIDKeyGenerateAlgorithm() {
+        assertThat(serviceLoader.newService("UUID", new Properties()), instanceOf(UUIDKeyGenerateAlgorithm.class));
     }
     
     @Test
-    public void assertNewDefaultKeyGenerator() {
-        assertThat(serviceLoader.newService(), instanceOf(SnowflakeShardingKeyGenerator.class));
+    public void assertNewDefaultKeyGenerateAlgorithm() {
+        assertThat(serviceLoader.newService(), instanceOf(SnowflakeKeyGenerateAlgorithm.class));
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/SnowflakeKeyGenerateAlgorithmTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/SnowflakeKeyGenerateAlgorithmTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.core.strategy.keygen;
 
-import lombok.SneakyThrows;
-import org.apache.shardingsphere.core.strategy.keygen.fixture.FixedTimeService;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -31,12 +31,11 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.core.strategy.keygen.fixture.FixedTimeService;
+import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-
-public final class SnowflakeShardingKeyGeneratorTest {
+public final class SnowflakeKeyGenerateAlgorithmTest {
     
     private static final long DEFAULT_SEQUENCE_BITS = 12L;
     
@@ -48,76 +47,76 @@ public final class SnowflakeShardingKeyGeneratorTest {
         int threadNumber = Runtime.getRuntime().availableProcessors() << 1;
         ExecutorService executor = Executors.newFixedThreadPool(threadNumber);
         int taskNumber = threadNumber << 2;
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
-        keyGenerator.setProperties(new Properties());
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
+        keyGenerateAlgorithm.setProperties(new Properties());
         Set<Comparable<?>> actual = new HashSet<>();
         for (int i = 0; i < taskNumber; i++) {
-            actual.add(executor.submit((Callable<Comparable<?>>) keyGenerator::generateKey).get());
+            actual.add(executor.submit((Callable<Comparable<?>>) keyGenerateAlgorithm::generateKey).get());
         }
         assertThat(actual.size(), is(taskNumber));
     }
     
     @Test
     public void assertGenerateKeyWithSingleThread() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
-        keyGenerator.setProperties(new Properties());
-        SnowflakeShardingKeyGenerator.setTimeService(new FixedTimeService(1));
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
+        keyGenerateAlgorithm.setProperties(new Properties());
+        SnowflakeKeyGenerateAlgorithm.setTimeService(new FixedTimeService(1));
         List<Comparable<?>> expected = Arrays.asList(0L, 4194305L, 4194306L, 8388608L, 8388609L, 12582913L, 12582914L, 16777216L, 16777217L, 20971521L);
         List<Comparable<?>> actual = new ArrayList<>();
         for (int i = 0; i < DEFAULT_KEY_AMOUNT; i++) {
-            actual.add(keyGenerator.generateKey());
+            actual.add(keyGenerateAlgorithm.generateKey());
         }
         assertThat(actual, is(expected));
     }
     
     @Test
     public void assertLastDigitalOfGenerateKeySameMillisecond() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
-        SnowflakeShardingKeyGenerator.setTimeService(new FixedTimeService(5));
+        SnowflakeKeyGenerateAlgorithm.setTimeService(new FixedTimeService(5));
         properties.setProperty("max.vibration.offset", String.valueOf(3));
-        keyGenerator.setProperties(properties);
-        assertThat(keyGenerator.generateKey(), is((Comparable) 0L));
-        assertThat(keyGenerator.generateKey(), is((Comparable) 1L));
-        assertThat(keyGenerator.generateKey(), is((Comparable) 2L));
-        assertThat(keyGenerator.generateKey(), is((Comparable) 3L));
-        assertThat(keyGenerator.generateKey(), is((Comparable) 4L));
+        keyGenerateAlgorithm.setProperties(properties);
+        assertThat(keyGenerateAlgorithm.generateKey(), is((Comparable) 0L));
+        assertThat(keyGenerateAlgorithm.generateKey(), is((Comparable) 1L));
+        assertThat(keyGenerateAlgorithm.generateKey(), is((Comparable) 2L));
+        assertThat(keyGenerateAlgorithm.generateKey(), is((Comparable) 3L));
+        assertThat(keyGenerateAlgorithm.generateKey(), is((Comparable) 4L));
     }
     
     @Test
     public void assertLastDigitalOfGenerateKeyDifferentMillisecond() throws InterruptedException {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
-        SnowflakeShardingKeyGenerator.setTimeService(new TimeService());
+        SnowflakeKeyGenerateAlgorithm.setTimeService(new TimeService());
         properties.setProperty("max.vibration.offset", String.valueOf(3));
-        keyGenerator.setProperties(properties);
-        String actualGenerateKeyBinaryString0 = Long.toBinaryString(Long.parseLong(keyGenerator.generateKey().toString()));
+        keyGenerateAlgorithm.setProperties(properties);
+        String actualGenerateKeyBinaryString0 = Long.toBinaryString(Long.parseLong(keyGenerateAlgorithm.generateKey().toString()));
         assertThat(Integer.parseInt(actualGenerateKeyBinaryString0.substring(actualGenerateKeyBinaryString0.length() - 3), 2), is(0));
         Thread.sleep(2L);
-        String actualGenerateKeyBinaryString1 = Long.toBinaryString(Long.parseLong(keyGenerator.generateKey().toString()));
+        String actualGenerateKeyBinaryString1 = Long.toBinaryString(Long.parseLong(keyGenerateAlgorithm.generateKey().toString()));
         assertThat(Integer.parseInt(actualGenerateKeyBinaryString1.substring(actualGenerateKeyBinaryString1.length() - 3), 2), is(1));
         Thread.sleep(2L);
-        String actualGenerateKeyBinaryString2 = Long.toBinaryString(Long.parseLong(keyGenerator.generateKey().toString()));
+        String actualGenerateKeyBinaryString2 = Long.toBinaryString(Long.parseLong(keyGenerateAlgorithm.generateKey().toString()));
         assertThat(Integer.parseInt(actualGenerateKeyBinaryString2.substring(actualGenerateKeyBinaryString2.length() - 3), 2), is(2));
         Thread.sleep(2L);
-        String actualGenerateKeyBinaryString3 = Long.toBinaryString(Long.parseLong(keyGenerator.generateKey().toString()));
+        String actualGenerateKeyBinaryString3 = Long.toBinaryString(Long.parseLong(keyGenerateAlgorithm.generateKey().toString()));
         assertThat(Integer.parseInt(actualGenerateKeyBinaryString3.substring(actualGenerateKeyBinaryString3.length() - 3), 2), is(3));
         Thread.sleep(2L);
-        String actualGenerateKeyBinaryString4 = Long.toBinaryString(Long.parseLong(keyGenerator.generateKey().toString()));
+        String actualGenerateKeyBinaryString4 = Long.toBinaryString(Long.parseLong(keyGenerateAlgorithm.generateKey().toString()));
         assertThat(Integer.parseInt(actualGenerateKeyBinaryString4.substring(actualGenerateKeyBinaryString4.length() - 3), 2), is(0));
     }
     
     @Test
     public void assertGenerateKeyWithClockCallBack() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         TimeService timeService = new FixedTimeService(1);
-        SnowflakeShardingKeyGenerator.setTimeService(timeService);
-        keyGenerator.setProperties(new Properties());
-        setLastMilliseconds(keyGenerator, timeService.getCurrentMillis() + 2);
+        SnowflakeKeyGenerateAlgorithm.setTimeService(timeService);
+        keyGenerateAlgorithm.setProperties(new Properties());
+        setLastMilliseconds(keyGenerateAlgorithm, timeService.getCurrentMillis() + 2);
         List<Comparable<?>> expected = Arrays.asList(4194304L, 8388609L, 8388610L, 12582912L, 12582913L, 16777217L, 16777218L, 20971520L, 20971521L, 25165825L);
         List<Comparable<?>> actual = new ArrayList<>();
         for (int i = 0; i < DEFAULT_KEY_AMOUNT; i++) {
-            actual.add(keyGenerator.generateKey());
+            actual.add(keyGenerateAlgorithm.generateKey());
         }
         assertThat(actual, is(expected));
     }
@@ -125,108 +124,108 @@ public final class SnowflakeShardingKeyGeneratorTest {
     @Test(expected = IllegalStateException.class)
     @SneakyThrows
     public void assertGenerateKeyWithClockCallBackBeyondTolerateTime() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         TimeService timeService = new FixedTimeService(1);
-        SnowflakeShardingKeyGenerator.setTimeService(timeService);
-        keyGenerator.setProperties(new Properties());
+        SnowflakeKeyGenerateAlgorithm.setTimeService(timeService);
+        keyGenerateAlgorithm.setProperties(new Properties());
         Properties properties = new Properties();
         properties.setProperty("max.tolerate.time.difference.milliseconds", String.valueOf(0));
-        keyGenerator.setProperties(properties);
-        setLastMilliseconds(keyGenerator, timeService.getCurrentMillis() + 2);
+        keyGenerateAlgorithm.setProperties(properties);
+        setLastMilliseconds(keyGenerateAlgorithm, timeService.getCurrentMillis() + 2);
         List<Comparable<?>> actual = new ArrayList<>();
         for (int i = 0; i < DEFAULT_KEY_AMOUNT; i++) {
-            actual.add(keyGenerator.generateKey());
+            actual.add(keyGenerateAlgorithm.generateKey());
         }
         assertNotEquals(actual.size(), 10);
     }
     
     @Test
     public void assertGenerateKeyBeyondMaxSequencePerMilliSecond() {
-        final SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        final SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         TimeService timeService = new FixedTimeService(2);
-        SnowflakeShardingKeyGenerator.setTimeService(timeService);
-        keyGenerator.setProperties(new Properties());
-        setLastMilliseconds(keyGenerator, timeService.getCurrentMillis());
-        setSequence(keyGenerator, (1 << DEFAULT_SEQUENCE_BITS) - 1);
+        SnowflakeKeyGenerateAlgorithm.setTimeService(timeService);
+        keyGenerateAlgorithm.setProperties(new Properties());
+        setLastMilliseconds(keyGenerateAlgorithm, timeService.getCurrentMillis());
+        setSequence(keyGenerateAlgorithm, (1 << DEFAULT_SEQUENCE_BITS) - 1);
         List<Comparable<?>> expected = Arrays.asList(4194304L, 4194305L, 4194306L, 8388608L, 8388609L, 8388610L, 12582913L, 12582914L, 12582915L, 16777216L);
         List<Comparable<?>> actual = new ArrayList<>();
         for (int i = 0; i < DEFAULT_KEY_AMOUNT; i++) {
-            actual.add(keyGenerator.generateKey());
+            actual.add(keyGenerateAlgorithm.generateKey());
         }
         assertThat(actual, is(expected));
     }
     
     @SneakyThrows
-    private void setSequence(final SnowflakeShardingKeyGenerator keyGenerator, final Number value) {
-        Field sequence = SnowflakeShardingKeyGenerator.class.getDeclaredField("sequence");
+    private void setSequence(final SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm, final Number value) {
+        Field sequence = SnowflakeKeyGenerateAlgorithm.class.getDeclaredField("sequence");
         sequence.setAccessible(true);
-        sequence.set(keyGenerator, value);
+        sequence.set(keyGenerateAlgorithm, value);
     }
     
     @SneakyThrows
-    private void setLastMilliseconds(final SnowflakeShardingKeyGenerator keyGenerator, final Number value) {
-        Field lastMilliseconds = SnowflakeShardingKeyGenerator.class.getDeclaredField("lastMilliseconds");
+    private void setLastMilliseconds(final SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm, final Number value) {
+        Field lastMilliseconds = SnowflakeKeyGenerateAlgorithm.class.getDeclaredField("lastMilliseconds");
         lastMilliseconds.setAccessible(true);
-        lastMilliseconds.set(keyGenerator, value);
+        lastMilliseconds.set(keyGenerateAlgorithm, value);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void assertSetWorkerIdFailureWhenNegative() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
         properties.setProperty("worker.id", String.valueOf(-1L));
-        keyGenerator.setProperties(properties);
-        keyGenerator.generateKey();
+        keyGenerateAlgorithm.setProperties(properties);
+        keyGenerateAlgorithm.generateKey();
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void assertSetMaxVibrationOffsetFailureWhenNegative() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
         properties.setProperty("max.vibration.offset", String.valueOf(-1));
-        keyGenerator.setProperties(properties);
-        keyGenerator.generateKey();
+        keyGenerateAlgorithm.setProperties(properties);
+        keyGenerateAlgorithm.generateKey();
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void assertSetWorkerIdFailureWhenOutOfRange() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
         properties.setProperty("worker.id", String.valueOf(Long.MIN_VALUE));
-        keyGenerator.setProperties(properties);
-        keyGenerator.generateKey();
+        keyGenerateAlgorithm.setProperties(properties);
+        keyGenerateAlgorithm.generateKey();
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void assertSetMaxVibrationOffsetFailureWhenOutOfRange() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
         properties.setProperty("max.vibration.offset", String.valueOf(4096));
-        keyGenerator.setProperties(properties);
-        keyGenerator.generateKey();
+        keyGenerateAlgorithm.setProperties(properties);
+        keyGenerateAlgorithm.generateKey();
     }
     
     @Test
     @SneakyThrows
     public void assertSetWorkerIdSuccess() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
         properties.setProperty("worker.id", String.valueOf(1L));
-        keyGenerator.setProperties(properties);
-        Field props = keyGenerator.getClass().getDeclaredField("properties");
+        keyGenerateAlgorithm.setProperties(properties);
+        Field props = keyGenerateAlgorithm.getClass().getDeclaredField("properties");
         props.setAccessible(true);
-        assertThat(((Properties) props.get(keyGenerator)).get("worker.id"), is("1"));
+        assertThat(((Properties) props.get(keyGenerateAlgorithm)).get("worker.id"), is("1"));
     }
     
     @Test
     @SneakyThrows
     public void assertSetMaxTolerateTimeDifferenceMilliseconds() {
-        SnowflakeShardingKeyGenerator keyGenerator = new SnowflakeShardingKeyGenerator();
+        SnowflakeKeyGenerateAlgorithm keyGenerateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
         Properties properties = new Properties();
         properties.setProperty("max.tolerate.time.difference.milliseconds", String.valueOf(1));
-        keyGenerator.setProperties(properties);
-        Field props = keyGenerator.getClass().getDeclaredField("properties");
+        keyGenerateAlgorithm.setProperties(properties);
+        Field props = keyGenerateAlgorithm.getClass().getDeclaredField("properties");
         props.setAccessible(true);
-        assertThat(((Properties) props.get(keyGenerator)).get("max.tolerate.time.difference.milliseconds"), is("1"));
+        assertThat(((Properties) props.get(keyGenerateAlgorithm)).get("max.tolerate.time.difference.milliseconds"), is("1"));
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/UUIDKeyGenerateAlgorithmTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/UUIDKeyGenerateAlgorithmTest.java
@@ -17,32 +17,31 @@
 
 package org.apache.shardingsphere.core.strategy.keygen;
 
-import org.junit.Test;
-
-import java.util.Properties;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public final class UUIDShardingKeyGeneratorTest {
+import java.util.Properties;
+import org.junit.Test;
+
+public final class UUIDKeyGenerateAlgorithmTest {
     
-    private UUIDShardingKeyGenerator uuidKeyGenerator = new UUIDShardingKeyGenerator();
+    private UUIDKeyGenerateAlgorithm uuidKeyGenerateAlgorithm = new UUIDKeyGenerateAlgorithm();
     
     @Test
     public void assertGenerateKey() {
-        assertThat(((String) uuidKeyGenerator.generateKey()).length(), is(32));
+        assertThat(((String) uuidKeyGenerateAlgorithm.generateKey()).length(), is(32));
     }
     
     @Test
     public void assertGetProperties() {
-        assertThat(uuidKeyGenerator.getProperties().entrySet().size(), is(0));
+        assertThat(uuidKeyGenerateAlgorithm.getProperties().entrySet().size(), is(0));
     }
     
     @Test
     public void assertSetProperties() {
         Properties properties = new Properties();
         properties.setProperty("key1", "value1");
-        uuidKeyGenerator.setProperties(properties);
-        assertThat(uuidKeyGenerator.getProperties().get("key1"), is("value1"));
+        uuidKeyGenerateAlgorithm.setProperties(properties);
+        assertThat(uuidKeyGenerateAlgorithm.getProperties().get("key1"), is("value1"));
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/fixture/FixedTimeService.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/fixture/FixedTimeService.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.core.strategy.keygen.fixture;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.core.strategy.keygen.SnowflakeShardingKeyGenerator;
+import org.apache.shardingsphere.core.strategy.keygen.SnowflakeKeyGenerateAlgorithm;
 import org.apache.shardingsphere.core.strategy.keygen.TimeService;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,7 +30,7 @@ public final class FixedTimeService extends TimeService {
     
     private final AtomicInteger invokedTimes = new AtomicInteger();
     
-    private long current = SnowflakeShardingKeyGenerator.EPOCH;
+    private long current = SnowflakeKeyGenerateAlgorithm.EPOCH;
     
     @Override
     public long getCurrentMillis() {

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/fixture/IncrementKeyGenerateAlgorithm.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/keygen/fixture/IncrementKeyGenerateAlgorithm.java
@@ -15,21 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture;
+package org.apache.shardingsphere.core.strategy.keygen.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class DecrementShardingKeyGenerator implements ShardingKeyGenerator {
+public final class IncrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
     @Getter
-    private final String type = "DECREMENT";
+    private final String type = "INCREMENT";
     
-    private final AtomicInteger sequence = new AtomicInteger(100);
+    private final AtomicInteger count = new AtomicInteger();
     
     @Getter
     @Setter
@@ -37,6 +37,6 @@ public final class DecrementShardingKeyGenerator implements ShardingKeyGenerator
     
     @Override
     public Comparable<?> generateKey() {
-        return sequence.decrementAndGet();
+        return count.incrementAndGet();
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapperTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapperTest.java
@@ -17,20 +17,22 @@
 
 package org.apache.shardingsphere.core.yaml.swapper;
 
-import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
-import org.apache.shardingsphere.core.yaml.config.sharding.YamlKeyGeneratorConfiguration;
-import org.junit.Test;
-
-import java.util.Properties;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
+import org.apache.shardingsphere.core.yaml.config.sharding.YamlKeyGeneratorConfiguration;
+import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.junit.Test;
 
 public final class KeyGeneratorConfigurationYamlSwapperTest {
     
     @Test
     public void assertSwapToYaml() {
-        YamlKeyGeneratorConfiguration actual = new KeyGeneratorConfigurationYamlSwapper().swap(new KeyGeneratorConfiguration("UUID", "id", new Properties()));
+        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService("UUID", new Properties());
+        YamlKeyGeneratorConfiguration actual = new KeyGeneratorConfigurationYamlSwapper().swap(new KeyGeneratorConfiguration("id", keyGenerator));
         assertThat(actual.getType(), is("UUID"));
         assertThat(actual.getColumn(), is("id"));
         assertThat(actual.getProps(), is(new Properties()));
@@ -42,8 +44,8 @@ public final class KeyGeneratorConfigurationYamlSwapperTest {
         yamlConfiguration.setType("UUID");
         yamlConfiguration.setColumn("id");
         KeyGeneratorConfiguration actual = new KeyGeneratorConfigurationYamlSwapper().swap(yamlConfiguration);
-        assertThat(actual.getType(), is("UUID"));
+        assertThat(actual.getKeyGenerator().getType(), is("UUID"));
         assertThat(actual.getColumn(), is("id"));
-        assertThat(actual.getProperties(), is(new Properties()));
+        assertThat(actual.getKeyGenerator().getProperties(), is(new Properties()));
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapperTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapperTest.java
@@ -23,16 +23,16 @@ import static org.junit.Assert.assertThat;
 import java.util.Properties;
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlKeyGeneratorConfiguration;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.junit.Test;
 
 public final class KeyGeneratorConfigurationYamlSwapperTest {
     
     @Test
     public void assertSwapToYaml() {
-        ShardingKeyGenerator keyGenerator = new ShardingKeyGeneratorServiceLoader().newService("UUID", new Properties());
-        YamlKeyGeneratorConfiguration actual = new KeyGeneratorConfigurationYamlSwapper().swap(new KeyGeneratorConfiguration("id", keyGenerator));
+        KeyGenerateAlgorithm keyGenerateAlgorithm = new KeyGenerateAlgorithmServiceLoader().newService("UUID", new Properties());
+        YamlKeyGeneratorConfiguration actual = new KeyGeneratorConfigurationYamlSwapper().swap(new KeyGeneratorConfiguration("id", keyGenerateAlgorithm));
         assertThat(actual.getType(), is("UUID"));
         assertThat(actual.getColumn(), is("id"));
         assertThat(actual.getProps(), is(new Properties()));
@@ -44,8 +44,8 @@ public final class KeyGeneratorConfigurationYamlSwapperTest {
         yamlConfiguration.setType("UUID");
         yamlConfiguration.setColumn("id");
         KeyGeneratorConfiguration actual = new KeyGeneratorConfigurationYamlSwapper().swap(yamlConfiguration);
-        assertThat(actual.getKeyGenerator().getType(), is("UUID"));
+        assertThat(actual.getKeyGenerateAlgorithm().getType(), is("UUID"));
         assertThat(actual.getColumn(), is("id"));
-        assertThat(actual.getKeyGenerator().getProperties(), is(new Properties()));
+        assertThat(actual.getKeyGenerateAlgorithm().getProperties(), is(new Properties()));
     }
 }

--- a/sharding-core/sharding-core-common/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-core/sharding-core-common/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,6 +15,6 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.core.strategy.keygen.SnowflakeShardingKeyGenerator
-org.apache.shardingsphere.core.strategy.keygen.UUIDShardingKeyGenerator
-org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementShardingKeyGenerator
+org.apache.shardingsphere.core.strategy.keygen.SnowflakeKeyGenerateAlgorithm
+org.apache.shardingsphere.core.strategy.keygen.UUIDKeyGenerateAlgorithm
+org.apache.shardingsphere.core.strategy.keygen.fixture.IncrementKeyGenerateAlgorithm

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/KeyGenerateAlgorithmFixture.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/KeyGenerateAlgorithmFixture.java
@@ -15,19 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.spi.keygen;
+package org.apache.shardingsphere.sharding.rewrite.fixture;
 
-import org.apache.shardingsphere.spi.TypeBasedSPI;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
-/**
- * Key generator.
- */
-public interface ShardingKeyGenerator extends TypeBasedSPI {
+import java.util.Properties;
+
+@Getter
+@Setter
+public final class KeyGenerateAlgorithmFixture implements KeyGenerateAlgorithm {
     
-    /**
-     * Generate key.
-     * 
-     * @return generated key
-     */
-    Comparable<?> generateKey();
+    private Properties properties = new Properties();
+    
+    @Override
+    public Comparable<?> generateKey() {
+        return 1;
+    }
+    
+    @Override
+    public String getType() {
+        return "TEST";
+    }
 }

--- a/sharding-core/sharding-core-rewrite/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-core/sharding-core-rewrite/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.shardingjdbc.spring.fixture.DecrementKeyGenerator
-org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerator
+org.apache.shardingsphere.sharding.rewrite.fixture.KeyGenerateAlgorithmFixture

--- a/sharding-integration-test/sharding-jdbc-test/src/test/java/org/apache/shardingsphere/dbtest/fixture/ConstantKeyGenerateAlgorithm.java
+++ b/sharding-integration-test/sharding-jdbc-test/src/test/java/org/apache/shardingsphere/dbtest/fixture/ConstantKeyGenerateAlgorithm.java
@@ -15,21 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.shardingjdbc.fixture;
+package org.apache.shardingsphere.dbtest.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 
-public final class IncrementShardingKeyGenerator implements ShardingKeyGenerator {
+public final class ConstantKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
     @Getter
-    private final String type = "INCREMENT";
-    
-    private final AtomicInteger count = new AtomicInteger();
+    private final String type = "CONSTANT";
     
     @Getter
     @Setter
@@ -37,6 +34,6 @@ public final class IncrementShardingKeyGenerator implements ShardingKeyGenerator
     
     @Override
     public Comparable<?> generateKey() {
-        return count.incrementAndGet();
+        return 1;
     }
 }

--- a/sharding-integration-test/sharding-jdbc-test/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-integration-test/sharding-jdbc-test/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -32,5 +32,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.dbtest.fixture.ConstantShardingKeyGenerator
+org.apache.shardingsphere.dbtest.fixture.ConstantKeyGenerateAlgorithm
 

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/fixture/IncrementKeyGenerateAlgorithm.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/fixture/IncrementKeyGenerateAlgorithm.java
@@ -15,30 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture;
+package org.apache.shardingsphere.shardingjdbc.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class DecrementKeyGenerator implements ShardingKeyGenerator {
+public final class IncrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
+    
+    @Getter
+    private final String type = "INCREMENT";
+    
+    private final AtomicInteger count = new AtomicInteger();
     
     @Getter
     @Setter
     private Properties properties = new Properties();
     
-    private final AtomicInteger sequence = new AtomicInteger(100);
-    
-    @Override
-    public String getType() {
-        return "DECREMENT";
-    }
-    
     @Override
     public Comparable<?> generateKey() {
-        return sequence.decrementAndGet();
+        return count.incrementAndGet();
     }
 }

--- a/sharding-jdbc/sharding-jdbc-core/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,5 +15,6 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.core.strategy.keygen.SnowflakeShardingKeyGenerator
-org.apache.shardingsphere.core.strategy.keygen.UUIDShardingKeyGenerator
+org.apache.shardingsphere.core.strategy.keygen.SnowflakeKeyGenerateAlgorithm
+org.apache.shardingsphere.core.strategy.keygen.UUIDKeyGenerateAlgorithm
+org.apache.shardingsphere.shardingjdbc.fixture.IncrementKeyGenerateAlgorithm

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/fixture/DecrementKeyGenerateAlgorithm.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/fixture/DecrementKeyGenerateAlgorithm.java
@@ -15,30 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture;
+package org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class IncrementKeyGenerator implements ShardingKeyGenerator {
+public final class DecrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
+    
+    @Getter
+    private final String type = "DECREMENT";
+    
+    private final AtomicInteger sequence = new AtomicInteger(100);
     
     @Getter
     @Setter
     private Properties properties = new Properties();
     
-    private final AtomicInteger sequence = new AtomicInteger(100);
-    
-    @Override
-    public String getType() {
-        return "INCREMENT";
-    }
-    
     @Override
     public Comparable<?> generateKey() {
-        return sequence.incrementAndGet();
+        return sequence.decrementAndGet();
     }
 }

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/fixture/IncrementKeyGenerateAlgorithm.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/fixture/IncrementKeyGenerateAlgorithm.java
@@ -15,27 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.fixture;
+package org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
-@Getter
-@Setter
-public final class ShardingKeyGeneratorFixture implements ShardingKeyGenerator {
+public final class IncrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
+    private static final AtomicInteger SEQUENCE = new AtomicInteger(100);
+    
+    @Getter
+    private final String type = "INCREMENT";
+    
+    @Getter
+    @Setter
     private Properties properties = new Properties();
     
     @Override
     public Comparable<?> generateKey() {
-        return 1;
-    }
-    
-    @Override
-    public String getType() {
-        return "TEST";
+        return SEQUENCE.incrementAndGet();
     }
 }

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,5 +15,7 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.DecrementKeyGenerator
-org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.IncrementKeyGenerator
+org.apache.shardingsphere.core.strategy.keygen.SnowflakeKeyGenerateAlgorithm
+org.apache.shardingsphere.core.strategy.keygen.UUIDKeyGenerateAlgorithm
+org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture.DecrementKeyGenerateAlgorithm
+org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml.fixture.IncrementKeyGenerateAlgorithm

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/OrchestrationShardingMasterSlaveNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/OrchestrationShardingMasterSlaveNamespaceTest.java
@@ -17,25 +17,24 @@
 
 package org.apache.shardingsphere.shardingjdbc.orchestration.spring;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+import javax.sql.DataSource;
 import org.apache.shardingsphere.core.rule.ShardingRule;
 import org.apache.shardingsphere.core.strategy.masterslave.RoundRobinMasterSlaveLoadBalanceAlgorithm;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
 import org.apache.shardingsphere.shardingjdbc.orchestration.spring.datasource.OrchestrationSpringShardingDataSource;
-import org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.IncrementKeyGenerator;
+import org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.IncrementKeyGenerateAlgorithm;
 import org.apache.shardingsphere.shardingjdbc.orchestration.spring.util.EmbedTestingServer;
 import org.apache.shardingsphere.shardingjdbc.orchestration.spring.util.FieldValueUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
-
-import javax.sql.DataSource;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 @ContextConfiguration(locations = "classpath:META-INF/rdb/shardingMasterSlaveOrchestration.xml")
 public class OrchestrationShardingMasterSlaveNamespaceTest extends AbstractJUnit4SpringContextTests {
@@ -70,7 +69,7 @@ public class OrchestrationShardingMasterSlaveNamespaceTest extends AbstractJUnit
         assertThat(shardingRule.getMasterSlaveRules().iterator().next().getLoadBalanceAlgorithm(), instanceOf(RoundRobinMasterSlaveLoadBalanceAlgorithm.class));
         assertThat(shardingRule.getTableRules().size(), is(1));
         assertThat(shardingRule.getTableRules().iterator().next().getLogicTable(), is("t_order"));
-        assertThat(shardingRule.getDefaultShardingKeyGenerator(), instanceOf(IncrementKeyGenerator.class));
+        assertThat(shardingRule.getDefaultKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @SuppressWarnings("unchecked")

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/OrchestrationShardingNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/OrchestrationShardingNamespaceTest.java
@@ -17,34 +17,33 @@
 
 package org.apache.shardingsphere.shardingjdbc.orchestration.spring;
 
-import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
-import org.apache.shardingsphere.api.config.sharding.strategy.StandardShardingStrategyConfiguration;
-import org.apache.shardingsphere.core.rule.BindingTableRule;
-import org.apache.shardingsphere.underlying.common.rule.DataNode;
-import org.apache.shardingsphere.core.rule.ShardingRule;
-import org.apache.shardingsphere.core.rule.TableRule;
-import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
-import org.apache.shardingsphere.shardingjdbc.orchestration.spring.datasource.OrchestrationSpringShardingDataSource;
-import org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.IncrementKeyGenerator;
-import org.apache.shardingsphere.shardingjdbc.orchestration.spring.util.EmbedTestingServer;
-import org.apache.shardingsphere.shardingjdbc.orchestration.spring.util.FieldValueUtil;
-import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationPropertyKey;
-import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationProperties;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
-
-import javax.sql.DataSource;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
+import org.apache.shardingsphere.api.config.sharding.strategy.StandardShardingStrategyConfiguration;
+import org.apache.shardingsphere.core.rule.BindingTableRule;
+import org.apache.shardingsphere.core.rule.ShardingRule;
+import org.apache.shardingsphere.core.rule.TableRule;
+import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
+import org.apache.shardingsphere.shardingjdbc.orchestration.spring.datasource.OrchestrationSpringShardingDataSource;
+import org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.IncrementKeyGenerateAlgorithm;
+import org.apache.shardingsphere.shardingjdbc.orchestration.spring.util.EmbedTestingServer;
+import org.apache.shardingsphere.shardingjdbc.orchestration.spring.util.FieldValueUtil;
+import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationProperties;
+import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationPropertyKey;
+import org.apache.shardingsphere.underlying.common.rule.DataNode;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 @ContextConfiguration(locations = "classpath:META-INF/rdb/shardingOrchestration.xml")
 public class OrchestrationShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
@@ -74,7 +73,7 @@ public class OrchestrationShardingNamespaceTest extends AbstractJUnit4SpringCont
                 new String[]{applicationContext.getBean("standardStrategy", StandardShardingStrategyConfiguration.class).getShardingColumn()}));
         assertTrue(Arrays.equals(shardingRule.getDefaultTableShardingStrategy().getShardingColumns().toArray(new String[]{}),
                 new String[]{applicationContext.getBean("inlineStrategy", InlineShardingStrategyConfiguration.class).getShardingColumn()}));
-        assertThat(shardingRule.getDefaultShardingKeyGenerator().getClass().getName(), is(IncrementKeyGenerator.class.getCanonicalName()));
+        assertThat(shardingRule.getDefaultKeyGenerateAlgorithm().getClass().getName(), is(IncrementKeyGenerateAlgorithm.class.getCanonicalName()));
     }
     
     @Test
@@ -98,7 +97,7 @@ public class OrchestrationShardingNamespaceTest extends AbstractJUnit4SpringCont
                 new String[]{applicationContext.getBean("inlineStrategy", InlineShardingStrategyConfiguration.class).getShardingColumn()}));
         assertTrue(tableRule.getGenerateKeyColumn().isPresent());
         assertThat(tableRule.getGenerateKeyColumn().get(), is("order_id"));
-        assertThat(tableRule.getShardingKeyGenerator().getClass().getName(), is(IncrementKeyGenerator.class.getCanonicalName()));
+        assertThat(tableRule.getKeyGenerateAlgorithm().getClass().getName(), is(IncrementKeyGenerateAlgorithm.class.getCanonicalName()));
     }
     
     @Test

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/fixture/DecrementKeyGenerateAlgorithm.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/fixture/DecrementKeyGenerateAlgorithm.java
@@ -15,30 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.shardingjdbc.spring.fixture;
+package org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class IncrementKeyGenerator implements ShardingKeyGenerator {
-    
-    private final AtomicInteger sequence = new AtomicInteger(100);
+public final class DecrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
     @Getter
     @Setter
     private Properties properties = new Properties();
     
+    private final AtomicInteger sequence = new AtomicInteger(100);
+    
     @Override
     public String getType() {
-        return "INCREMENT";
+        return "DECREMENT";
     }
     
     @Override
     public Comparable<?> generateKey() {
-        return sequence.incrementAndGet();
+        return sequence.decrementAndGet();
     }
 }

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/fixture/IncrementKeyGenerateAlgorithm.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/fixture/IncrementKeyGenerateAlgorithm.java
@@ -15,25 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.dbtest.fixture;
+package org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public final class ConstantShardingKeyGenerator implements ShardingKeyGenerator {
-    
-    @Getter
-    private final String type = "CONSTANT";
+public final class IncrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
     @Getter
     @Setter
     private Properties properties = new Properties();
     
+    private final AtomicInteger sequence = new AtomicInteger(100);
+    
+    @Override
+    public String getType() {
+        return "INCREMENT";
+    }
+    
     @Override
     public Comparable<?> generateKey() {
-        return 1;
+        return sequence.incrementAndGet();
     }
 }

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
@@ -31,10 +31,10 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="orderIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
-        <constructor-arg value="INCREMENT"/>
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+        <property name="type" value="INCREMENT" />
     </bean>
-
+    
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" range-algorithm-ref="rangeModuloTableShardingAlgorithm" />
     <sharding:complex-strategy id="complexStrategy" sharding-columns="order_id,user_id" algorithm-ref="defaultComplexKeysShardingAlgorithm" />
@@ -42,7 +42,7 @@
     <sharding:hint-strategy id="hintStrategy" algorithm-ref="defaultHintShardingAlgorithm" />
     <sharding:none-strategy id="noneStrategy" />
     
-    <sharding:key-generator id="keyGenerator" column="order_id" generator-ref="orderIncrementKeyGenerator" />
+    <sharding:key-generator id="keyGenerator" column="order_id" algorithm-ref="incrementAlgorithm" />
     
     <sharding:data-source id="simpleShardingDataSource">
         <sharding:sharding-rule data-source-names="dbtbl_0">

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
@@ -31,7 +31,10 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    
+    <bean id="orderIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
+        <constructor-arg value="INCREMENT"/>
+    </bean>
+
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" range-algorithm-ref="rangeModuloTableShardingAlgorithm" />
     <sharding:complex-strategy id="complexStrategy" sharding-columns="order_id,user_id" algorithm-ref="defaultComplexKeysShardingAlgorithm" />
@@ -39,7 +42,7 @@
     <sharding:hint-strategy id="hintStrategy" algorithm-ref="defaultHintShardingAlgorithm" />
     <sharding:none-strategy id="noneStrategy" />
     
-    <sharding:key-generator id="keyGenerator" type="INCREMENT" column="order_id" />
+    <sharding:key-generator id="keyGenerator" column="order_id" generator-ref="orderIncrementKeyGenerator" />
     
     <sharding:data-source id="simpleShardingDataSource">
         <sharding:sharding-rule data-source-names="dbtbl_0">

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
@@ -31,7 +31,7 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
         <property name="type" value="INCREMENT" />
     </bean>
     

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
@@ -35,7 +35,7 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
         <property name="type" value="INCREMENT" />
     </bean>
     

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
@@ -35,17 +35,17 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="orderIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
-        <constructor-arg value="INCREMENT"/>
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+        <property name="type" value="INCREMENT" />
     </bean>
-
+    
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" range-algorithm-ref="rangeModuloTableShardingAlgorithm" />
     <sharding:inline-strategy id="inlineStrategy" sharding-column="order_id" algorithm-expression="t_order_${order_id % 4}" />
     <sharding:hint-strategy id="hintStrategy" algorithm-ref="defaultHintShardingAlgorithm" />
     <sharding:none-strategy id="noneStrategy" />
     
-    <sharding:key-generator id="keyGenerator" column="order_id" generator-ref="orderIncrementKeyGenerator" />
+    <sharding:key-generator id="keyGenerator" column="order_id" algorithm-ref="incrementAlgorithm" />
     <master-slave:load-balance-algorithm id="randomLoadBalanceAlgorithm" type="RANDOM"/>
 
     <sharding:data-source id="masterSlaveShardingDataSourceByDefaultStrategy">

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
@@ -35,14 +35,17 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    
+    <bean id="orderIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
+        <constructor-arg value="INCREMENT"/>
+    </bean>
+
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" range-algorithm-ref="rangeModuloTableShardingAlgorithm" />
     <sharding:inline-strategy id="inlineStrategy" sharding-column="order_id" algorithm-expression="t_order_${order_id % 4}" />
     <sharding:hint-strategy id="hintStrategy" algorithm-ref="defaultHintShardingAlgorithm" />
     <sharding:none-strategy id="noneStrategy" />
     
-    <sharding:key-generator id="keyGenerator" type="INCREMENT" column="order_id" />
+    <sharding:key-generator id="keyGenerator" column="order_id" generator-ref="orderIncrementKeyGenerator" />
     <master-slave:load-balance-algorithm id="randomLoadBalanceAlgorithm" type="RANDOM"/>
 
     <sharding:data-source id="masterSlaveShardingDataSourceByDefaultStrategy">

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,4 +15,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.sharding.rewrite.fixture.ShardingKeyGeneratorFixture
+org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.DecrementKeyGenerateAlgorithm
+org.apache.shardingsphere.shardingjdbc.orchestration.spring.fixture.IncrementKeyGenerateAlgorithm

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/constants/ShardingDataSourceBeanDefinitionParserTag.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/constants/ShardingDataSourceBeanDefinitionParserTag.java
@@ -76,7 +76,7 @@ public final class ShardingDataSourceBeanDefinitionParserTag {
     
     public static final String GENERATE_KEY_COLUMN_ATTRIBUTE = "column";
     
-    public static final String GENERATE_KEY_TYPE_ATTRIBUTE = "type";
+    public static final String GENERATE_REF_TAG = "generator-ref";
     
     public static final String GENERATE_KEY_PROPERTY_REF_ATTRIBUTE = "props-ref";
     

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/constants/ShardingDataSourceBeanDefinitionParserTag.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/constants/ShardingDataSourceBeanDefinitionParserTag.java
@@ -76,9 +76,7 @@ public final class ShardingDataSourceBeanDefinitionParserTag {
     
     public static final String GENERATE_KEY_COLUMN_ATTRIBUTE = "column";
     
-    public static final String GENERATE_REF_TAG = "generator-ref";
-    
-    public static final String GENERATE_KEY_PROPERTY_REF_ATTRIBUTE = "props-ref";
+    public static final String GENERATE_KEY_ALGORITHM_REF_TAG = "algorithm-ref";
     
     public static final String LOGIC_INDEX = "logic-index";
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGenerateAlgorithmFactoryBean.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGenerateAlgorithmFactoryBean.java
@@ -22,30 +22,30 @@ import com.google.common.base.Strings;
 import java.util.Properties;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.algorithm.keygen.KeyGenerateAlgorithmServiceLoader;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 
 /**
- * Sharding key generator FactoryBean.
+ * key generate algorithm FactoryBean.
  */
 @Setter
 @Getter
-public class KeyGeneratorAlgorithmFactoryBean implements FactoryBean<ShardingKeyGenerator>, InitializingBean {
+public class KeyGenerateAlgorithmFactoryBean implements FactoryBean<KeyGenerateAlgorithm>, InitializingBean {
     
     private String type;
     
     private Properties properties;
     
     @Override
-    public ShardingKeyGenerator getObject() throws Exception {
-        return new ShardingKeyGeneratorServiceLoader().newService(type, properties);
+    public KeyGenerateAlgorithm getObject() throws Exception {
+        return new KeyGenerateAlgorithmServiceLoader().newService(type, properties);
     }
     
     @Override
     public Class<?> getObjectType() {
-        return ShardingKeyGenerator.class;
+        return KeyGenerateAlgorithm.class;
     }
     
     @Override
@@ -55,6 +55,6 @@ public class KeyGeneratorAlgorithmFactoryBean implements FactoryBean<ShardingKey
     
     @Override
     public void afterPropertiesSet() throws Exception {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "The type of keyGeneratorAlgorithm is required.");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "The type of keyGenerateAlgorithm is required.");
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGeneratorAlgorithmFactoryBean.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGeneratorAlgorithmFactoryBean.java
@@ -17,37 +17,44 @@
 
 package org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.util.Properties;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
 import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
-import org.apache.shardingsphere.underlying.common.config.TypeBasedSPIConfiguration;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
 
 /**
  * Sharding key generator FactoryBean.
  */
-public class KeyGeneratorFactoryBean extends TypeBasedSPIConfiguration implements FactoryBean<ShardingKeyGenerator> {
-
-    public KeyGeneratorFactoryBean(final String type) {
-        super(type);
-    }
-
-    public KeyGeneratorFactoryBean(final String type, final Properties properties) {
-        super(type, properties);
-    }
-
+@Setter
+@Getter
+public class KeyGeneratorAlgorithmFactoryBean implements FactoryBean<ShardingKeyGenerator>, InitializingBean {
+    
+    private String type;
+    
+    private Properties properties;
+    
     @Override
     public ShardingKeyGenerator getObject() throws Exception {
-        return new ShardingKeyGeneratorServiceLoader().newService(getType(), getProperties());
+        return new ShardingKeyGeneratorServiceLoader().newService(type, properties);
     }
-
+    
     @Override
     public Class<?> getObjectType() {
         return ShardingKeyGenerator.class;
     }
-
+    
     @Override
     public boolean isSingleton() {
         return true;
+    }
+    
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "The type of keyGeneratorAlgorithm is required.");
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGeneratorFactoryBean.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGeneratorFactoryBean.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean;
+
+import java.util.Properties;
+import org.apache.shardingsphere.spi.algorithm.keygen.ShardingKeyGeneratorServiceLoader;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.underlying.common.config.TypeBasedSPIConfiguration;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Sharding key generator FactoryBean.
+ */
+public class KeyGeneratorFactoryBean extends TypeBasedSPIConfiguration implements FactoryBean<ShardingKeyGenerator> {
+
+    public KeyGeneratorFactoryBean(final String type) {
+        super(type);
+    }
+
+    public KeyGeneratorFactoryBean(final String type, final Properties properties) {
+        super(type, properties);
+    }
+
+    @Override
+    public ShardingKeyGenerator getObject() throws Exception {
+        return new ShardingKeyGeneratorServiceLoader().newService(getType(), getProperties());
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return ShardingKeyGenerator.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/parser/KeyGeneratorBeanDefinitionParser.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/parser/KeyGeneratorBeanDefinitionParser.java
@@ -17,16 +17,13 @@
 
 package org.apache.shardingsphere.shardingjdbc.spring.namespace.parser;
 
-import com.google.common.base.Strings;
-import org.apache.shardingsphere.shardingjdbc.spring.namespace.constants.ShardingDataSourceBeanDefinitionParserTag;
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.constants.ShardingDataSourceBeanDefinitionParserTag;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
-
-import java.util.Properties;
 
 /**
  * Key generator bean parser for spring namespace.
@@ -36,18 +33,8 @@ public final class KeyGeneratorBeanDefinitionParser extends AbstractBeanDefiniti
     @Override
     protected AbstractBeanDefinition parseInternal(final Element element, final ParserContext parserContext) {
         BeanDefinitionBuilder factory = BeanDefinitionBuilder.rootBeanDefinition(KeyGeneratorConfiguration.class);
-        factory.addConstructorArgValue(element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_KEY_TYPE_ATTRIBUTE));
         factory.addConstructorArgValue(element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_KEY_COLUMN_ATTRIBUTE));
-        parseProperties(element, factory);
+        factory.addConstructorArgReference(element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_REF_TAG));
         return factory.getBeanDefinition();
-    }
-    
-    private void parseProperties(final Element element, final BeanDefinitionBuilder factory) {
-        String properties = element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_KEY_PROPERTY_REF_ATTRIBUTE);
-        if (!Strings.isNullOrEmpty(properties)) {
-            factory.addConstructorArgReference(properties);
-        } else {
-            factory.addConstructorArgValue(new Properties());
-        }
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/parser/KeyGeneratorBeanDefinitionParser.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/parser/KeyGeneratorBeanDefinitionParser.java
@@ -34,7 +34,7 @@ public final class KeyGeneratorBeanDefinitionParser extends AbstractBeanDefiniti
     protected AbstractBeanDefinition parseInternal(final Element element, final ParserContext parserContext) {
         BeanDefinitionBuilder factory = BeanDefinitionBuilder.rootBeanDefinition(KeyGeneratorConfiguration.class);
         factory.addConstructorArgValue(element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_KEY_COLUMN_ATTRIBUTE));
-        factory.addConstructorArgReference(element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_REF_TAG));
+        factory.addConstructorArgReference(element.getAttribute(ShardingDataSourceBeanDefinitionParserTag.GENERATE_KEY_ALGORITHM_REF_TAG));
         return factory.getBeanDefinition();
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/sharding.xsd
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/sharding.xsd
@@ -144,8 +144,7 @@
         <xsd:complexType>
             <xsd:attribute name="id" type="xsd:string" use="required" />
             <xsd:attribute name="column" type="xsd:string" />
-            <xsd:attribute name="type" type="xsd:string" />
-            <xsd:attribute name="props-ref" type="xsd:string" />
+            <xsd:attribute name="generator-ref" type="xsd:string" />
         </xsd:complexType>
     </xsd:element>
     <xsd:element name="props">

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/sharding.xsd
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/sharding.xsd
@@ -144,7 +144,7 @@
         <xsd:complexType>
             <xsd:attribute name="id" type="xsd:string" use="required" />
             <xsd:attribute name="column" type="xsd:string" />
-            <xsd:attribute name="generator-ref" type="xsd:string" />
+            <xsd:attribute name="algorithm-ref" type="xsd:string" />
         </xsd:complexType>
     </xsd:element>
     <xsd:element name="props">

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/GenerateKeyAlgorithmTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/GenerateKeyAlgorithmTest.java
@@ -19,9 +19,9 @@ package org.apache.shardingsphere.shardingjdbc.spring;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerator;
-import org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerateAlgorithm;
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -34,22 +34,22 @@ import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 public final class GenerateKeyAlgorithmTest extends AbstractJUnit4SpringContextTests {
     
     @Test(expected = BeanCreationException.class)
-    public void assertTypelessKeyGeneratorAlgorithm() {
+    public void assertTypelessKeyGenerateAlgorithm() {
         GenericApplicationContext context = (GenericApplicationContext) applicationContext;
-        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGeneratorAlgorithmFactoryBean.class);
+        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGenerateAlgorithmFactoryBean.class);
         BeanDefinition beanDefinition = builder.getBeanDefinition();
         context.registerBeanDefinition("typelessAlgorithm", beanDefinition);
         context.getBean("typelessAlgorithm");
     }
     
     @Test
-    public void assertKeyGeneratorAlgorithm() {
+    public void assertKeyGenerateAlgorithm() {
         GenericApplicationContext context = (GenericApplicationContext) applicationContext;
-        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGeneratorAlgorithmFactoryBean.class).addPropertyValue("type", "INCREMENT");
+        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGenerateAlgorithmFactoryBean.class).addPropertyValue("type", "INCREMENT");
         BeanDefinition beanDefinition = builder.getBeanDefinition();
         context.registerBeanDefinition("incrementAlgorithm", beanDefinition);
-        ShardingKeyGenerator incrementKeyGenerator = (ShardingKeyGenerator) context.getBean("incrementAlgorithm");
-        ShardingKeyGenerator directIncrementKeyGenerator = new IncrementKeyGenerator();
-        assertEquals(incrementKeyGenerator.generateKey(), directIncrementKeyGenerator.generateKey());
+        KeyGenerateAlgorithm incrementKeyGenerateAlgorithm = (KeyGenerateAlgorithm) context.getBean("incrementAlgorithm");
+        KeyGenerateAlgorithm directIncrementKeyGenerateAlgorithm = new IncrementKeyGenerateAlgorithm();
+        assertEquals(incrementKeyGenerateAlgorithm.generateKey(), directIncrementKeyGenerateAlgorithm.generateKey());
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/GenerateKeyAlgorithmTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/GenerateKeyAlgorithmTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shardingjdbc.spring;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerator;
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.junit.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+@ContextConfiguration(locations = "classpath:META-INF/rdb/datasource/dataSource.xml")
+public final class GenerateKeyAlgorithmTest extends AbstractJUnit4SpringContextTests {
+    
+    @Test(expected = BeanCreationException.class)
+    public void assertTypelessKeyGeneratorAlgorithm() {
+        GenericApplicationContext context = (GenericApplicationContext) applicationContext;
+        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGeneratorAlgorithmFactoryBean.class);
+        BeanDefinition beanDefinition = builder.getBeanDefinition();
+        context.registerBeanDefinition("typelessAlgorithm", beanDefinition);
+        context.getBean("typelessAlgorithm");
+    }
+    
+    @Test
+    public void assertKeyGeneratorAlgorithm() {
+        GenericApplicationContext context = (GenericApplicationContext) applicationContext;
+        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGeneratorAlgorithmFactoryBean.class).addPropertyValue("type", "INCREMENT");
+        BeanDefinition beanDefinition = builder.getBeanDefinition();
+        context.registerBeanDefinition("incrementAlgorithm", beanDefinition);
+        ShardingKeyGenerator incrementKeyGenerator = (ShardingKeyGenerator) context.getBean("incrementAlgorithm");
+        ShardingKeyGenerator directIncrementKeyGenerator = new IncrementKeyGenerator();
+        assertEquals(incrementKeyGenerator.generateKey(), directIncrementKeyGenerator.generateKey());
+    }
+}

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/GenerateKeyJUnitTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/GenerateKeyJUnitTest.java
@@ -17,29 +17,28 @@
 
 package org.apache.shardingsphere.shardingjdbc.spring;
 
-import org.apache.shardingsphere.core.rule.ShardingRule;
-import org.apache.shardingsphere.core.rule.TableRule;
-import org.apache.shardingsphere.shardingjdbc.jdbc.core.context.ShardingRuntimeContext;
-import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
-import org.apache.shardingsphere.shardingjdbc.spring.fixture.DecrementKeyGenerator;
-import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerator;
-import org.apache.shardingsphere.shardingjdbc.spring.util.FieldValueUtil;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
-import org.junit.Test;
-import org.springframework.test.context.ContextConfiguration;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-import javax.annotation.Resource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
 import java.util.Iterator;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import javax.annotation.Resource;
+import org.apache.shardingsphere.core.rule.ShardingRule;
+import org.apache.shardingsphere.core.rule.TableRule;
+import org.apache.shardingsphere.shardingjdbc.jdbc.core.context.ShardingRuntimeContext;
+import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
+import org.apache.shardingsphere.shardingjdbc.spring.fixture.DecrementKeyGenerateAlgorithm;
+import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerateAlgorithm;
+import org.apache.shardingsphere.shardingjdbc.spring.util.FieldValueUtil;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(locations = "classpath:META-INF/rdb/withNamespaceGenerateKeyColumns.xml")
 public class GenerateKeyJUnitTest extends AbstractSpringJUnitTest {
@@ -69,9 +68,9 @@ public class GenerateKeyJUnitTest extends AbstractSpringJUnitTest {
         assertNotNull(runtimeContext);
         ShardingRule shardingRule = runtimeContext.getRule();
         assertNotNull(shardingRule);
-        ShardingKeyGenerator defaultKeyGenerator = shardingRule.getDefaultShardingKeyGenerator();
-        assertNotNull(defaultKeyGenerator);
-        assertTrue(defaultKeyGenerator instanceof IncrementKeyGenerator);
+        KeyGenerateAlgorithm defaultKeyGenerateAlgorithm = shardingRule.getDefaultKeyGenerateAlgorithm();
+        assertNotNull(defaultKeyGenerateAlgorithm);
+        assertTrue(defaultKeyGenerateAlgorithm instanceof IncrementKeyGenerateAlgorithm);
         Object tableRules = FieldValueUtil.getFieldValue(shardingRule, "tableRules");
         assertNotNull(tableRules);
         assertThat(((Collection<TableRule>) tableRules).size(), is(2));
@@ -82,6 +81,6 @@ public class GenerateKeyJUnitTest extends AbstractSpringJUnitTest {
         TableRule orderItemRule = tableRuleIterator.next();
         assertTrue(orderItemRule.getGenerateKeyColumn().isPresent());
         assertThat(orderItemRule.getGenerateKeyColumn().get(), is("order_item_id"));
-        assertTrue(orderItemRule.getShardingKeyGenerator() instanceof DecrementKeyGenerator);
+        assertTrue(orderItemRule.getKeyGenerateAlgorithm() instanceof DecrementKeyGenerateAlgorithm);
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/MasterSlaveNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/MasterSlaveNamespaceTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.shardingsphere.shardingjdbc.spring;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.shardingsphere.api.config.masterslave.LoadBalanceStrategyConfiguration;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
 import org.apache.shardingsphere.core.strategy.masterslave.RandomMasterSlaveLoadBalanceAlgorithm;
@@ -26,11 +31,6 @@ import org.apache.shardingsphere.spi.masterslave.MasterSlaveLoadBalanceAlgorithm
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/rdb/masterSlaveNamespace.xml")
 public class MasterSlaveNamespaceTest extends AbstractJUnit4SpringContextTests {

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
@@ -50,9 +50,9 @@ import org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloData
 import org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloTableShardingAlgorithm;
 import org.apache.shardingsphere.shardingjdbc.spring.algorithm.RangeModuloTableShardingAlgorithm;
 import org.apache.shardingsphere.shardingjdbc.spring.datasource.SpringShardingDataSource;
-import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerator;
+import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerateAlgorithm;
 import org.apache.shardingsphere.shardingjdbc.spring.util.FieldValueUtil;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationPropertyKey;
 import org.junit.Test;
@@ -64,10 +64,10 @@ public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
     
     @Test
     public void assertKeyGenerator() {
-        assertThat(applicationContext.getBean("incrementAlgorithm"), instanceOf(ShardingKeyGenerator.class));
-        ShardingKeyGenerator incrementKeyGenerator = (ShardingKeyGenerator) applicationContext.getBean("incrementAlgorithm");
-        ShardingKeyGenerator directIncrementKeyGenerator = new IncrementKeyGenerator();
-        assertEquals(incrementKeyGenerator.generateKey(), directIncrementKeyGenerator.generateKey());
+        assertThat(applicationContext.getBean("incrementAlgorithm"), instanceOf(KeyGenerateAlgorithm.class));
+        KeyGenerateAlgorithm incrementKeyGenerateAlgorithm = (KeyGenerateAlgorithm) applicationContext.getBean("incrementAlgorithm");
+        KeyGenerateAlgorithm directIncrementKeyGenerateAlgorithm = new IncrementKeyGenerateAlgorithm();
+        assertEquals(incrementKeyGenerateAlgorithm.generateKey(), directIncrementKeyGenerateAlgorithm.generateKey());
     }
     
     @Test
@@ -135,7 +135,7 @@ public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
         assertThat(shardingRule.getMasterSlaveRules().iterator().next().getLoadBalanceAlgorithm(), instanceOf(RoundRobinMasterSlaveLoadBalanceAlgorithm.class));
         assertThat(shardingRule.getTableRules().size(), is(1));
         assertThat(shardingRule.getTableRules().iterator().next().getLogicTable(), is("t_order"));
-        assertThat(shardingRule.getDefaultShardingKeyGenerator(), instanceOf(IncrementKeyGenerator.class));
+        assertThat(shardingRule.getDefaultKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @Test
@@ -149,7 +149,7 @@ public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
         assertThat(shardingRule.getMasterSlaveRules().iterator().next().getLoadBalanceAlgorithm(), instanceOf(RandomMasterSlaveLoadBalanceAlgorithm.class));
         assertThat(shardingRule.getTableRules().size(), is(1));
         assertThat(shardingRule.getTableRules().iterator().next().getLogicTable(), is("t_order"));
-        assertThat(shardingRule.getDefaultShardingKeyGenerator(), instanceOf(IncrementKeyGenerator.class));
+        assertThat(shardingRule.getDefaultKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @Test
@@ -163,7 +163,7 @@ public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
                 new String[]{applicationContext.getBean("standardStrategy", StandardShardingStrategyConfiguration.class).getShardingColumn()}));
         assertTrue(Arrays.equals(shardingRule.getDefaultTableShardingStrategy().getShardingColumns().toArray(new String[]{}), 
                 new String[]{applicationContext.getBean("inlineStrategy", InlineShardingStrategyConfiguration.class).getShardingColumn()}));
-        assertThat(shardingRule.getDefaultShardingKeyGenerator(), instanceOf(IncrementKeyGenerator.class));
+        assertThat(shardingRule.getDefaultKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @Test
@@ -187,7 +187,7 @@ public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
                 new String[]{applicationContext.getBean("inlineStrategy", InlineShardingStrategyConfiguration.class).getShardingColumn()}));
         assertTrue(tableRule.getGenerateKeyColumn().isPresent());
         assertThat(tableRule.getGenerateKeyColumn().get(), is("order_id"));
-        assertThat(tableRule.getShardingKeyGenerator(), instanceOf(IncrementKeyGenerator.class));
+        assertThat(tableRule.getKeyGenerateAlgorithm(), instanceOf(IncrementKeyGenerateAlgorithm.class));
     }
     
     @Test

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
@@ -17,6 +17,18 @@
 
 package org.apache.shardingsphere.shardingjdbc.spring;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import javax.sql.DataSource;
 import org.apache.shardingsphere.api.config.sharding.strategy.ComplexShardingStrategyConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.HintShardingStrategyConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
@@ -40,27 +52,24 @@ import org.apache.shardingsphere.shardingjdbc.spring.algorithm.RangeModuloTableS
 import org.apache.shardingsphere.shardingjdbc.spring.datasource.SpringShardingDataSource;
 import org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerator;
 import org.apache.shardingsphere.shardingjdbc.spring.util.FieldValueUtil;
-import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationPropertyKey;
+import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
 import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationProperties;
+import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationPropertyKey;
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
-import javax.sql.DataSource;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 @ContextConfiguration(locations = "classpath:META-INF/rdb/shardingNamespace.xml")
 public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
-    
+
+    @Test
+    public void assertKeyGenerator() {
+        assertThat(applicationContext.getBean("orderIncrementKeyGenerator"), instanceOf(ShardingKeyGenerator.class));
+        ShardingKeyGenerator orderIncrementKeyGenerator = (ShardingKeyGenerator) applicationContext.getBean("orderIncrementKeyGenerator");
+        ShardingKeyGenerator incrementKeyGenerator = new IncrementKeyGenerator();
+        assertEquals(orderIncrementKeyGenerator.generateKey(), incrementKeyGenerator.generateKey());
+    }
+
     @Test
     public void assertStandardStrategy() {
         StandardShardingStrategyConfiguration standardStrategy = applicationContext.getBean("standardStrategy", StandardShardingStrategyConfiguration.class);

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
@@ -61,15 +61,15 @@ import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 @ContextConfiguration(locations = "classpath:META-INF/rdb/shardingNamespace.xml")
 public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
-
+    
     @Test
     public void assertKeyGenerator() {
-        assertThat(applicationContext.getBean("orderIncrementKeyGenerator"), instanceOf(ShardingKeyGenerator.class));
-        ShardingKeyGenerator orderIncrementKeyGenerator = (ShardingKeyGenerator) applicationContext.getBean("orderIncrementKeyGenerator");
-        ShardingKeyGenerator incrementKeyGenerator = new IncrementKeyGenerator();
-        assertEquals(orderIncrementKeyGenerator.generateKey(), incrementKeyGenerator.generateKey());
+        assertThat(applicationContext.getBean("incrementAlgorithm"), instanceOf(ShardingKeyGenerator.class));
+        ShardingKeyGenerator incrementKeyGenerator = (ShardingKeyGenerator) applicationContext.getBean("incrementAlgorithm");
+        ShardingKeyGenerator directIncrementKeyGenerator = new IncrementKeyGenerator();
+        assertEquals(incrementKeyGenerator.generateKey(), directIncrementKeyGenerator.generateKey());
     }
-
+    
     @Test
     public void assertStandardStrategy() {
         StandardShardingStrategyConfiguration standardStrategy = applicationContext.getBean("standardStrategy", StandardShardingStrategyConfiguration.class);

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/fixture/DecrementKeyGenerateAlgorithm.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/fixture/DecrementKeyGenerateAlgorithm.java
@@ -19,12 +19,12 @@ package org.apache.shardingsphere.shardingjdbc.spring.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class DecrementKeyGenerator implements ShardingKeyGenerator {
+public final class DecrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
     private final AtomicInteger sequence = new AtomicInteger(100);
     

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/fixture/IncrementKeyGenerateAlgorithm.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/fixture/IncrementKeyGenerateAlgorithm.java
@@ -15,22 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.spi.algorithm.keygen;
+package org.apache.shardingsphere.shardingjdbc.spring.fixture;
 
-import org.apache.shardingsphere.spi.NewInstanceServiceLoader;
-import org.apache.shardingsphere.spi.TypeBasedSPIServiceLoader;
-import org.apache.shardingsphere.spi.keygen.ShardingKeyGenerator;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 
-/**
- * Key generator service loader.
- */
-public final class ShardingKeyGeneratorServiceLoader extends TypeBasedSPIServiceLoader<ShardingKeyGenerator> {
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class IncrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
-    static {
-        NewInstanceServiceLoader.register(ShardingKeyGenerator.class);
+    private final AtomicInteger sequence = new AtomicInteger(100);
+    
+    @Getter
+    @Setter
+    private Properties properties = new Properties();
+    
+    @Override
+    public String getType() {
+        return "INCREMENT";
     }
     
-    public ShardingKeyGeneratorServiceLoader() {
-        super(ShardingKeyGenerator.class);
+    @Override
+    public Comparable<?> generateKey() {
+        return sequence.incrementAndGet();
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
@@ -37,25 +37,21 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="defaultIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
-        <constructor-arg value="INCREMENT"/>
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+        <property name="type" value="INCREMENT" />
     </bean>
-    <bean id="orderIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
-        <constructor-arg value="INCREMENT"/>
-    </bean>
-
+    
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" range-algorithm-ref="rangeModuloTableShardingAlgorithm" />
     <sharding:complex-strategy id="complexStrategy" sharding-columns="order_id,user_id" algorithm-ref="defaultComplexKeysShardingAlgorithm" />
     <sharding:inline-strategy id="inlineStrategy" sharding-column="order_id" algorithm-expression="t_order_${order_id % 4}" />
     <sharding:hint-strategy id="hintStrategy" algorithm-ref="defaultHintShardingAlgorithm" />
     <sharding:none-strategy id="noneStrategy" />
-
+    
+    <sharding:key-generator id="defaultKeyGenerator" column="id" algorithm-ref="incrementAlgorithm" />
+    <sharding:key-generator id="orderKeyGenerator" column="order_id" algorithm-ref="incrementAlgorithm" />
     <master-slave:load-balance-algorithm id="randomLoadBalanceAlgorithm" type="RANDOM" />
-
-    <sharding:key-generator id="defaultKeyGeneratorConfig" column="id" generator-ref="defaultIncrementKeyGenerator" />
-    <sharding:key-generator id="orderKeyGeneratorConfig" column="order_id" generator-ref="orderIncrementKeyGenerator" />
-
+    
     <bean:properties id="props">
         <prop key="appToken">business</prop>
     </bean:properties>
@@ -81,25 +77,25 @@
     </sharding:data-source>
 
     <sharding:data-source id="masterSlaveShardingDataSourceByDefaultStrategy">
-        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGeneratorConfig">
+        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGenerator">
             <sharding:master-slave-rules>
                 <sharding:master-slave-rule id="dbtbl_0" master-data-source-name="dbtbl_0_master" slave-data-source-names="dbtbl_0_slave_0,dbtbl_0_slave_1"/>
                 <sharding:master-slave-rule id="dbtbl_1" master-data-source-name="dbtbl_1_master" slave-data-source-names="dbtbl_1_slave_0,dbtbl_1_slave_1"/>
             </sharding:master-slave-rules>
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGeneratorConfig" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGenerator" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>
 
     <sharding:data-source id="masterSlaveShardingDataSourceByUserStrategy">
-        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGeneratorConfig">
+        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGenerator">
             <sharding:master-slave-rules>
                 <sharding:master-slave-rule id="dbtbl_0" master-data-source-name="dbtbl_0_master" slave-data-source-names="dbtbl_0_slave_0,dbtbl_0_slave_1" strategy-ref="randomLoadBalanceAlgorithm"/>
                 <sharding:master-slave-rule id="dbtbl_1" master-data-source-name="dbtbl_1_master" slave-data-source-names="dbtbl_1_slave_0,dbtbl_1_slave_1" strategy-ref="randomLoadBalanceAlgorithm"/>
             </sharding:master-slave-rules>
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGeneratorConfig" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGenerator" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>
@@ -110,7 +106,7 @@
             default-data-source-name="dbtbl_0"
             default-database-strategy-ref="standardStrategy"
             default-table-strategy-ref="inlineStrategy"
-            default-key-generator-ref="defaultKeyGeneratorConfig">
+            default-key-generator-ref="defaultKeyGenerator">
             <sharding:table-rules>
                 <sharding:table-rule logic-table="t_order" />
             </sharding:table-rules>
@@ -120,7 +116,7 @@
     <sharding:data-source id="tableRuleWithAttributesDataSource">
         <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1">
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGeneratorConfig" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGenerator" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
@@ -17,18 +17,19 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:master-slave="http://shardingsphere.apache.org/schema/shardingsphere/masterslave"
-       xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
-       xmlns:bean="http://www.springframework.org/schema/util"
-       xmlns:encrypt="http://shardingsphere.apache.org/schema/shardingsphere/encrypt"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:master-slave="http://shardingsphere.apache.org/schema/shardingsphere/masterslave"
+  xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
+  xmlns:bean="http://www.springframework.org/schema/util"
+  xmlns:encrypt="http://shardingsphere.apache.org/schema/shardingsphere/encrypt"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
                         http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave/master-slave.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd
-                        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://shardingsphere.apache.org/schema/shardingsphere/encrypt http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd">
+                        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://shardingsphere.apache.org/schema/shardingsphere/encrypt http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
     <import resource="datasource/dataSource.xml" />
     <import resource="datasource/masterSlaveDataSource.xml" />
 
@@ -37,18 +38,25 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultHintShardingAlgorithm" />
-    
+    <bean id="defaultIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
+        <constructor-arg value="INCREMENT"/>
+    </bean>
+    <bean id="orderIncrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
+        <constructor-arg value="INCREMENT"/>
+    </bean>
+
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" range-algorithm-ref="rangeModuloTableShardingAlgorithm" />
     <sharding:complex-strategy id="complexStrategy" sharding-columns="order_id,user_id" algorithm-ref="defaultComplexKeysShardingAlgorithm" />
     <sharding:inline-strategy id="inlineStrategy" sharding-column="order_id" algorithm-expression="t_order_${order_id % 4}" />
     <sharding:hint-strategy id="hintStrategy" algorithm-ref="defaultHintShardingAlgorithm" />
     <sharding:none-strategy id="noneStrategy" />
-    
-    <sharding:key-generator id="defaultKeyGenerator" type="INCREMENT" column="id" />
-    <sharding:key-generator id="orderKeyGenerator" type="INCREMENT" column="order_id" />
+
     <master-slave:load-balance-algorithm id="randomLoadBalanceAlgorithm" type="RANDOM" />
-    
+
+    <sharding:key-generator id="defaultKeyGenerator" column="id" generator-ref="defaultIncrementKeyGenerator" />
+    <sharding:key-generator id="orderKeyGenerator" column="order_id" generator-ref="orderIncrementKeyGenerator" />
+
     <bean:properties id="props">
         <prop key="appToken">business</prop>
     </bean:properties>

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
@@ -17,19 +17,18 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:master-slave="http://shardingsphere.apache.org/schema/shardingsphere/masterslave"
-  xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
-  xmlns:bean="http://www.springframework.org/schema/util"
-  xmlns:encrypt="http://shardingsphere.apache.org/schema/shardingsphere/encrypt"
-  xmlns:context="http://www.springframework.org/schema/context"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:master-slave="http://shardingsphere.apache.org/schema/shardingsphere/masterslave"
+       xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
+       xmlns:bean="http://www.springframework.org/schema/util"
+       xmlns:encrypt="http://shardingsphere.apache.org/schema/shardingsphere/encrypt"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
                         http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave/master-slave.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd
-                        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://shardingsphere.apache.org/schema/shardingsphere/encrypt http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+                        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://shardingsphere.apache.org/schema/shardingsphere/encrypt http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd">
     <import resource="datasource/dataSource.xml" />
     <import resource="datasource/masterSlaveDataSource.xml" />
 
@@ -54,8 +53,8 @@
 
     <master-slave:load-balance-algorithm id="randomLoadBalanceAlgorithm" type="RANDOM" />
 
-    <sharding:key-generator id="defaultKeyGenerator" column="id" generator-ref="defaultIncrementKeyGenerator" />
-    <sharding:key-generator id="orderKeyGenerator" column="order_id" generator-ref="orderIncrementKeyGenerator" />
+    <sharding:key-generator id="defaultKeyGeneratorConfig" column="id" generator-ref="defaultIncrementKeyGenerator" />
+    <sharding:key-generator id="orderKeyGeneratorConfig" column="order_id" generator-ref="orderIncrementKeyGenerator" />
 
     <bean:properties id="props">
         <prop key="appToken">business</prop>
@@ -82,25 +81,25 @@
     </sharding:data-source>
 
     <sharding:data-source id="masterSlaveShardingDataSourceByDefaultStrategy">
-        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGenerator">
+        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGeneratorConfig">
             <sharding:master-slave-rules>
                 <sharding:master-slave-rule id="dbtbl_0" master-data-source-name="dbtbl_0_master" slave-data-source-names="dbtbl_0_slave_0,dbtbl_0_slave_1"/>
                 <sharding:master-slave-rule id="dbtbl_1" master-data-source-name="dbtbl_1_master" slave-data-source-names="dbtbl_1_slave_0,dbtbl_1_slave_1"/>
             </sharding:master-slave-rules>
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGenerator" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGeneratorConfig" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>
 
     <sharding:data-source id="masterSlaveShardingDataSourceByUserStrategy">
-        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGenerator">
+        <sharding:sharding-rule data-source-names="dbtbl_0_master,dbtbl_0_slave_0,dbtbl_0_slave_1,dbtbl_1_master,dbtbl_1_slave_0,dbtbl_1_slave_1" default-key-generator-ref="defaultKeyGeneratorConfig">
             <sharding:master-slave-rules>
                 <sharding:master-slave-rule id="dbtbl_0" master-data-source-name="dbtbl_0_master" slave-data-source-names="dbtbl_0_slave_0,dbtbl_0_slave_1" strategy-ref="randomLoadBalanceAlgorithm"/>
                 <sharding:master-slave-rule id="dbtbl_1" master-data-source-name="dbtbl_1_master" slave-data-source-names="dbtbl_1_slave_0,dbtbl_1_slave_1" strategy-ref="randomLoadBalanceAlgorithm"/>
             </sharding:master-slave-rules>
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGenerator" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGeneratorConfig" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>
@@ -111,7 +110,7 @@
             default-data-source-name="dbtbl_0"
             default-database-strategy-ref="standardStrategy"
             default-table-strategy-ref="inlineStrategy"
-            default-key-generator-ref="defaultKeyGenerator">
+            default-key-generator-ref="defaultKeyGeneratorConfig">
             <sharding:table-rules>
                 <sharding:table-rule logic-table="t_order" />
             </sharding:table-rules>
@@ -121,7 +120,7 @@
     <sharding:data-source id="tableRuleWithAttributesDataSource">
         <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1">
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGenerator" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="standardStrategy" table-strategy-ref="inlineStrategy" key-generator-ref="orderKeyGeneratorConfig" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
@@ -37,7 +37,7 @@
     <bean id="rangeModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.RangeModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
         <property name="type" value="INCREMENT" />
     </bean>
     

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
@@ -31,10 +31,18 @@
     
     <sharding:standard-strategy id="databaseStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="tableStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" />
-    
-    <sharding:key-generator id="defaultKeyGenerator" type="INCREMENT" column="id" />
-    <sharding:key-generator id="itemKeyGenerator" type="DECREMENT" column="order_item_id" />
-    <sharding:key-generator id="orderKeyGenerator" type="INCREMENT" column="order_id" />
+
+    <bean id="incrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
+        <constructor-arg value="INCREMENT"/>
+    </bean>
+
+    <bean id="decrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
+        <constructor-arg value="DECREMENT"/>
+    </bean>
+
+    <sharding:key-generator id="defaultKeyGenerator" column="id" generator-ref="incrementKeyGenerator" />
+    <sharding:key-generator id="itemKeyGenerator" column="order_item_id" generator-ref="decrementKeyGenerator" />
+    <sharding:key-generator id="orderKeyGenerator" column="order_id" generator-ref="incrementKeyGenerator" />
     
     <sharding:data-source id="shardingDataSource">
         <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1" default-data-source-name="dbtbl_0" default-key-generator-ref="defaultKeyGenerator">

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
@@ -28,25 +28,25 @@
     
     <bean id="preciseModuloDatabaseShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloDatabaseShardingAlgorithm" />
     <bean id="preciseModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloTableShardingAlgorithm" />
-    <bean id="incrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
-        <constructor-arg value="INCREMENT"/>
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+        <property name="type" value="INCREMENT" />
     </bean>
-    <bean id="decrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
-        <constructor-arg value="DECREMENT"/>
+    <bean id="decrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+        <property name="type" value="DECREMENT" />
     </bean>
-
+    
     <sharding:standard-strategy id="databaseStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="tableStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" />
-
-    <sharding:key-generator id="defaultKeyGeneratorConfig" column="id" generator-ref="incrementKeyGenerator" />
-    <sharding:key-generator id="itemKeyGeneratorConfig" column="order_item_id" generator-ref="decrementKeyGenerator" />
-    <sharding:key-generator id="orderKeyGeneratorConfig" column="order_id" generator-ref="incrementKeyGenerator" />
+    
+    <sharding:key-generator id="defaultKeyGenerator" column="id" algorithm-ref="incrementAlgorithm" />
+    <sharding:key-generator id="itemKeyGenerator" column="order_item_id" algorithm-ref="decrementAlgorithm" />
+    <sharding:key-generator id="orderKeyGenerator" column="order_id" algorithm-ref="incrementAlgorithm" />
     
     <sharding:data-source id="shardingDataSource">
-        <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1" default-data-source-name="dbtbl_0" default-key-generator-ref="defaultKeyGeneratorConfig">
+        <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1" default-data-source-name="dbtbl_0" default-key-generator-ref="defaultKeyGenerator">
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="orderKeyGeneratorConfig" />
-                <sharding:table-rule logic-table="t_order_item" actual-data-nodes="dbtbl_${0..1}.t_order_item_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="itemKeyGeneratorConfig" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="orderKeyGenerator" />
+                <sharding:table-rule logic-table="t_order_item" actual-data-nodes="dbtbl_${0..1}.t_order_item_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="itemKeyGenerator" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
@@ -28,10 +28,10 @@
     
     <bean id="preciseModuloDatabaseShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloDatabaseShardingAlgorithm" />
     <bean id="preciseModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloTableShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
         <property name="type" value="INCREMENT" />
     </bean>
-    <bean id="decrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorAlgorithmFactoryBean">
+    <bean id="decrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
         <property name="type" value="DECREMENT" />
     </bean>
     

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
@@ -28,27 +28,25 @@
     
     <bean id="preciseModuloDatabaseShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloDatabaseShardingAlgorithm" />
     <bean id="preciseModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.PreciseModuloTableShardingAlgorithm" />
-    
-    <sharding:standard-strategy id="databaseStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
-    <sharding:standard-strategy id="tableStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" />
-
     <bean id="incrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
         <constructor-arg value="INCREMENT"/>
     </bean>
-
     <bean id="decrementKeyGenerator" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGeneratorFactoryBean">
         <constructor-arg value="DECREMENT"/>
     </bean>
 
-    <sharding:key-generator id="defaultKeyGenerator" column="id" generator-ref="incrementKeyGenerator" />
-    <sharding:key-generator id="itemKeyGenerator" column="order_item_id" generator-ref="decrementKeyGenerator" />
-    <sharding:key-generator id="orderKeyGenerator" column="order_id" generator-ref="incrementKeyGenerator" />
+    <sharding:standard-strategy id="databaseStrategy" sharding-column="user_id" precise-algorithm-ref="preciseModuloDatabaseShardingAlgorithm" />
+    <sharding:standard-strategy id="tableStrategy" sharding-column="order_id" precise-algorithm-ref="preciseModuloTableShardingAlgorithm" />
+
+    <sharding:key-generator id="defaultKeyGeneratorConfig" column="id" generator-ref="incrementKeyGenerator" />
+    <sharding:key-generator id="itemKeyGeneratorConfig" column="order_item_id" generator-ref="decrementKeyGenerator" />
+    <sharding:key-generator id="orderKeyGeneratorConfig" column="order_id" generator-ref="incrementKeyGenerator" />
     
     <sharding:data-source id="shardingDataSource">
-        <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1" default-data-source-name="dbtbl_0" default-key-generator-ref="defaultKeyGenerator">
+        <sharding:sharding-rule data-source-names="dbtbl_0,dbtbl_1" default-data-source-name="dbtbl_0" default-key-generator-ref="defaultKeyGeneratorConfig">
             <sharding:table-rules>
-                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="orderKeyGenerator" />
-                <sharding:table-rule logic-table="t_order_item" actual-data-nodes="dbtbl_${0..1}.t_order_item_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="itemKeyGenerator" />
+                <sharding:table-rule logic-table="t_order" actual-data-nodes="dbtbl_${0..1}.t_order_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="orderKeyGeneratorConfig" />
+                <sharding:table-rule logic-table="t_order_item" actual-data-nodes="dbtbl_${0..1}.t_order_item_${0..3}" database-strategy-ref="databaseStrategy" table-strategy-ref="tableStrategy" key-generator-ref="itemKeyGeneratorConfig" />
             </sharding:table-rules>
         </sharding:sharding-rule>
     </sharding:data-source>

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm
@@ -15,6 +15,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.core.strategy.keygen.SnowflakeShardingKeyGenerator
-org.apache.shardingsphere.core.strategy.keygen.UUIDShardingKeyGenerator
-org.apache.shardingsphere.shardingjdbc.fixture.IncrementShardingKeyGenerator
+org.apache.shardingsphere.shardingjdbc.spring.fixture.DecrementKeyGenerateAlgorithm
+org.apache.shardingsphere.shardingjdbc.spring.fixture.IncrementKeyGenerateAlgorithm


### PR DESCRIPTION
Fixes #1977.

Changes proposed in this pull request:
- [✓] change `shardingNamespace.xml` configuration.
- [✓] create class `KeyGeneratorFactoryBean` extends `TypeBasedSPIConfiguration`  implements `FactoryBean<ShardingKeyGenerator>`,leverage `FactoryBean` to create KeyGenerator.
- [✓] modify class `KeyGeneratorConfiguration`~~extends TypeBasedSPIConfiguration~~，add member variables `ShardingKeyGenerator keyGenerator`.
- [✓] modify class `KeyGeneratorBeanDefinitionParser` addConstructorArgReference with `KeyGenerator` by using TAG `generator-ref`.
- [✓] modify class `TableRule`, shardingKeyGenerator=tableRuleConfig.getKeyGeneratorConfig().getKeyGenerator().
- [✓] modify class `ShardingRule`, use keyGeneratorConfiguration.getKeyGenerator() instead of create by ShardingKeyGeneratorServiceLoader.
- [✓] modify correlative tests, add test on `ShardingKeyGenerator` Bean.
