### PR TITLE
add sharding.transaction.seata.at.enable config to compatible with se…

### DIFF
--- a/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingTransactionManager.java
+++ b/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingTransactionManager.java
@@ -47,14 +47,33 @@ public final class SeataATShardingTransactionManager implements ShardingTransact
     
     private final Map<String, DataSource> dataSourceMap = new HashMap<>();
     
-    private final FileConfiguration configuration = new FileConfiguration("seata.conf");
+    private final String applicationId;
+    
+    private final String transactionServiceGroup;
+    
+    private final boolean enableSeataAT;
+    
+    public SeataATShardingTransactionManager() {
+        FileConfiguration configuration = new FileConfiguration("seata.conf");
+        enableSeataAT = configuration.getBoolean("sharding.transaction.seata.at.enable", true);
+        applicationId = configuration.getConfig("client.application.id");
+        transactionServiceGroup = configuration.getConfig("client.transaction.service.group", "default");
+    }
     
     @Override
     public void init(final DatabaseType databaseType, final Collection<ResourceDataSource> resourceDataSources) {
-        initSeataRPCClient();
-        for (ResourceDataSource each : resourceDataSources) {
-            dataSourceMap.put(each.getOriginalName(), new DataSourceProxy(each.getDataSource()));
+        if (enableSeataAT) {
+            initSeataRPCClient();
+            for (ResourceDataSource each : resourceDataSources) {
+                dataSourceMap.put(each.getOriginalName(), new DataSourceProxy(each.getDataSource()));
+            }
         }
+    }
+    
+    private void initSeataRPCClient() {
+        Preconditions.checkNotNull(applicationId, "please config application id within seata.conf file.");
+        TMClient.init(applicationId, transactionServiceGroup);
+        RMClient.init(applicationId, transactionServiceGroup);
     }
     
     @Override
@@ -64,17 +83,20 @@ public final class SeataATShardingTransactionManager implements ShardingTransact
     
     @Override
     public boolean isInTransaction() {
+        Preconditions.checkState(enableSeataAT, "sharding seata-at transaction has been disabled.");
         return null != RootContext.getXID();
     }
     
     @Override
     public Connection getConnection(final String dataSourceName) throws SQLException {
+        Preconditions.checkState(enableSeataAT, "sharding seata-at transaction has been disabled.");
         return dataSourceMap.get(dataSourceName).getConnection();
     }
     
     @Override
     @SneakyThrows
     public void begin() {
+        Preconditions.checkState(enableSeataAT, "sharding seata-at transaction has been disabled.");
         GlobalTransaction globalTransaction = GlobalTransactionContext.getCurrentOrCreate();
         globalTransaction.begin();
         SeataTransactionHolder.set(globalTransaction);
@@ -83,6 +105,7 @@ public final class SeataATShardingTransactionManager implements ShardingTransact
     @Override
     @SneakyThrows
     public void commit() {
+        Preconditions.checkState(enableSeataAT, "sharding seata-at transaction has been disabled.");
         try {
             SeataTransactionHolder.get().commit();
         } finally {
@@ -94,6 +117,7 @@ public final class SeataATShardingTransactionManager implements ShardingTransact
     @Override
     @SneakyThrows
     public void rollback() {
+        Preconditions.checkState(enableSeataAT, "sharding seata-at transaction has been disabled.");
         try {
             SeataTransactionHolder.get().rollback();
         } finally {
@@ -108,13 +132,5 @@ public final class SeataATShardingTransactionManager implements ShardingTransact
         SeataTransactionHolder.clear();
         TmRpcClient.getInstance().destroy();
         RmRpcClient.getInstance().destroy();
-    }
-    
-    private void initSeataRPCClient() {
-        String applicationId = configuration.getConfig("client.application.id");
-        Preconditions.checkNotNull(applicationId, "please config application id within seata.conf file");
-        String transactionServiceGroup = configuration.getConfig("client.transaction.service.group", "default");
-        TMClient.init(applicationId, transactionServiceGroup);
-        RMClient.init(applicationId, transactionServiceGroup);
     }
 }

--- a/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/main/resources/META-INF/services/org.apache.shardingsphere.transaction.spi.ShardingTransactionManager
+++ b/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/main/resources/META-INF/services/org.apache.shardingsphere.transaction.spi.ShardingTransactionManager
@@ -15,21 +15,4 @@
 # limitations under the License.
 #
 
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingTransactionManager

--- a/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/test/resources/seata.conf
+++ b/sharding-transaction/sharding-transaction-base/sharding-transaction-base-seata-at/src/test/resources/seata.conf
@@ -15,6 +15,8 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
+sharding.transaction.seata.at.enable = true
+
 client {
     application.id = test
     transaction.service.group = my_test_tx_group


### PR DESCRIPTION
when `sharding.transaction.seata.at.enable = false`,  `SeataATShardingTransactionManager` will be disabled, in this way original seata global transaction across services will compatible with shardingsphere since `TransactionalSQLExecutionHook` can transport global txId in multi-threads.

user should pay attention that `@ShardingTransactionType(TransactionType.BASE)` should not been introduced in original seata global transaction across services