### PR TITLE
Enhance type enum valueOf in mysql protocol.

### DIFF
--- a/shardingsphere-database-protocol/shardingsphere-database-protocol-mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinlogEventType.java
+++ b/shardingsphere-database-protocol/shardingsphere-database-protocol-mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinlogEventType.java
@@ -20,6 +20,9 @@ package org.apache.shardingsphere.database.protocol.mysql.constant;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * MySQL binlog event type.
  *
@@ -101,7 +104,15 @@ public enum MySQLBinlogEventType {
     
     PREVIOUS_GTIDS_EVENT(0x23);
     
+    private static final Map<Integer, MySQLBinlogEventType> VALUE_AND_EVENT_TYPE_MAP = new HashMap<>(MySQLBinlogEventType.values().length, 1);
+    
     private final int value;
+    
+    static {
+        for (MySQLBinlogEventType each : MySQLBinlogEventType.values()) {
+            VALUE_AND_EVENT_TYPE_MAP.put(each.value, each);
+        }
+    }
     
     /**
      * Value of {@code MySQLBinlogEventType}.
@@ -110,10 +121,8 @@ public enum MySQLBinlogEventType {
      * @return MySQL binlog event type
      */
     public static MySQLBinlogEventType valueOf(final int value) {
-        for (MySQLBinlogEventType each : MySQLBinlogEventType.values()) {
-            if (each.getValue() == value) {
-                return each;
-            }
+        if (VALUE_AND_EVENT_TYPE_MAP.containsKey(value)) {
+            return VALUE_AND_EVENT_TYPE_MAP.get(value);
         }
         throw new IllegalArgumentException(String.format("Cannot find value '%s' in binlog event type", value));
     }

--- a/shardingsphere-database-protocol/shardingsphere-database-protocol-mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLColumnType.java
+++ b/shardingsphere-database-protocol/shardingsphere-database-protocol-mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLColumnType.java
@@ -103,6 +103,8 @@ public enum MySQLColumnType {
     
     private static final Map<Integer, MySQLColumnType> JDBC_TYPE_AND_COLUMN_TYPE_MAP = new HashMap<>(MySQLColumnType.values().length, 1);
     
+    private static final Map<Integer, MySQLColumnType> VALUE_AND_COLUMN_TYPE_MAP = new HashMap<>(MySQLColumnType.values().length, 1);
+    
     private final int value;
     
     static {
@@ -127,6 +129,9 @@ public enum MySQLColumnType {
         JDBC_TYPE_AND_COLUMN_TYPE_MAP.put(Types.LONGVARBINARY, MYSQL_TYPE_VAR_STRING);
         JDBC_TYPE_AND_COLUMN_TYPE_MAP.put(Types.NULL, MYSQL_TYPE_NULL);
         JDBC_TYPE_AND_COLUMN_TYPE_MAP.put(Types.BLOB, MYSQL_TYPE_BLOB);
+        for (MySQLColumnType each : MySQLColumnType.values()) {
+            VALUE_AND_COLUMN_TYPE_MAP.put(each.value, each);
+        }
     }
     
     /**
@@ -149,10 +154,8 @@ public enum MySQLColumnType {
      * @return column type
      */
     public static MySQLColumnType valueOf(final int value) {
-        for (MySQLColumnType each : MySQLColumnType.values()) {
-            if (value == each.value) {
-                return each;
-            }
+        if (VALUE_AND_COLUMN_TYPE_MAP.containsKey(value)) {
+            return VALUE_AND_COLUMN_TYPE_MAP.get(value);
         }
         throw new IllegalArgumentException(String.format("Cannot find value '%s' in column type", value));
     }


### PR DESCRIPTION
During parsing binlog protocol, `MySQLBinlogEventType.valueOf` will be called for each binlog to determine the type of binlog. 

The old implementation, is O(n) time complexity, which will have a little impact on performance for many binlog events.

The problem for `MySQLColumnType.valueOf`, each row-based event include column types for each column. So there are many times to call this method.