### PR TITLE
Fix param check of KeyGeneratorConfiguration

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapper.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/yaml/swapper/KeyGeneratorConfigurationYamlSwapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.core.yaml.swapper;
 
+import com.google.common.base.Strings;
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlKeyGeneratorConfiguration;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
@@ -44,7 +45,8 @@ public final class KeyGeneratorConfigurationYamlSwapper implements YamlSwapper<Y
     
     @Override
     public KeyGeneratorConfiguration swap(final YamlKeyGeneratorConfiguration yamlConfiguration) {
-        KeyGenerateAlgorithm keyGenerateAlgorithm = TypedSPIRegistry.getRegisteredService(KeyGenerateAlgorithm.class, yamlConfiguration.getType(), yamlConfiguration.getProps());
+        KeyGenerateAlgorithm keyGenerateAlgorithm = !Strings.isNullOrEmpty(yamlConfiguration.getType())
+                ? TypedSPIRegistry.getRegisteredService(KeyGenerateAlgorithm.class, yamlConfiguration.getType(), yamlConfiguration.getProps()) : null;
         return new KeyGeneratorConfiguration(yamlConfiguration.getColumn(), keyGenerateAlgorithm);
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/sharding.xsd
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/sharding.xsd
@@ -143,7 +143,7 @@
     <xsd:element name="key-generator">
         <xsd:complexType>
             <xsd:attribute name="id" type="xsd:string" use="required" />
-            <xsd:attribute name="column" type="xsd:string" />
+            <xsd:attribute name="column" type="xsd:string" use="required" />
             <xsd:attribute name="algorithm-ref" type="xsd:string" />
         </xsd:complexType>
     </xsd:element>


### PR DESCRIPTION
In KeyGeneratorConfigurationYamlSwapper.swap(final YamlKeyGeneratorConfiguration yamlConfiguration), check whether the type of keyGenerateAlgorithm is null.

In sharding.xsd, add use="required" on attribute column of element key-generator.
