### PR TITLE
add KeyGenerateAlgorithmBeanDefinitionParser to simplify the configuration API of KeyGenerateAlgorithm

### DIFF
--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingDataSourceNamespace.xml
@@ -19,10 +19,14 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
+    xmlns:spi="http://shardingsphere.apache.org/schema/shardingsphere/spi"
     xsi:schemaLocation="http://www.springframework.org/schema/beans 
                         http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding
-                        http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd">
+                        http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi/spi.xsd
+                        ">
     <import resource="../datasource/dataSource.xml" />
     <import resource="../datasource/masterSlaveDataSource.xml" />
     
@@ -30,9 +34,8 @@
     <bean id="standardModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.StandardModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
-        <property name="type" value="INCREMENT" />
-    </bean>
+    
+    <spi:key-generate-algorithm id="incrementAlgorithm" type="INCREMENT" />
     
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" algorithm-ref="standardModuloDatabaseShardingAlgorithm" />
     <sharding:complex-strategy id="complexStrategy" sharding-columns="order_id,user_id" algorithm-ref="defaultComplexKeysShardingAlgorithm" />

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/test/resources/META-INF/rdb/namespace/shardingMasterSlaveNamespace.xml
@@ -20,12 +20,15 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
        xmlns:master-slave="http://shardingsphere.apache.org/schema/shardingsphere/masterslave"
+       xmlns:spi="http://shardingsphere.apache.org/schema/shardingsphere/spi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                         http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave/master-slave.xsd
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi/spi.xsd
                         ">
 
     <import resource="../datasource/masterSlaveDataSource.xml" />
@@ -34,9 +37,8 @@
     <bean id="standardModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.StandardModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.orchestration.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
-        <property name="type" value="INCREMENT" />
-    </bean>
+   
+    <spi:key-generate-algorithm id="incrementAlgorithm" type="INCREMENT" />
     
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" algorithm-ref="standardModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" algorithm-ref="standardModuloTableShardingAlgorithm" />

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/constants/SPIBeanDefinitionParserTag.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/constants/SPIBeanDefinitionParserTag.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shardingjdbc.spring.namespace.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * SPI parser tag constants.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SPIBeanDefinitionParserTag {
+    
+    public static final String KEY_GENERATE_ALGORITHM_TAG = "key-generate-algorithm";
+    
+    public static final String KEY_GENERATE_ALGORITHM_TYPE_ATTRIBUTE = "type";
+    
+    public static final String KEY_GENERATE_ALGORITHM_PROPERTY_REF_ATTRIBUTE = "props-ref";
+}

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGenerateAlgorithmFactoryBean.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/factorybean/KeyGenerateAlgorithmFactoryBean.java
@@ -19,22 +19,18 @@ package org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import java.util.Properties;
 import lombok.Getter;
-import lombok.Setter;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.spi.type.TypedSPIRegistry;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.InitializingBean;
-
-import java.util.Properties;
 
 /**
  * Key generate algorithm FactoryBean.
  */
-@Setter
 @Getter
-public final class KeyGenerateAlgorithmFactoryBean implements FactoryBean<KeyGenerateAlgorithm>, InitializingBean {
+public final class KeyGenerateAlgorithmFactoryBean implements FactoryBean<KeyGenerateAlgorithm> {
     
     static {
         ShardingSphereServiceLoader.register(KeyGenerateAlgorithm.class);
@@ -42,7 +38,13 @@ public final class KeyGenerateAlgorithmFactoryBean implements FactoryBean<KeyGen
     
     private String type;
     
-    private Properties properties = new Properties();
+    private Properties properties;
+    
+    public KeyGenerateAlgorithmFactoryBean(final String type, final Properties properties) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "The type of keyGenerateAlgorithm is required.");
+        this.type = type;
+        this.properties = properties;
+    }
     
     @Override
     public KeyGenerateAlgorithm getObject() {
@@ -57,10 +59,5 @@ public final class KeyGenerateAlgorithmFactoryBean implements FactoryBean<KeyGen
     @Override
     public boolean isSingleton() {
         return true;
-    }
-    
-    @Override
-    public void afterPropertiesSet() {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "The type of keyGenerateAlgorithm is required.");
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/handler/SPINamespaceHandler.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/handler/SPINamespaceHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shardingjdbc.spring.namespace.handler;
+
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.constants.SPIBeanDefinitionParserTag;
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.parser.KeyGenerateAlgorithmBeanDefinitionParser;
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * Spring namespace handler for SPI.
+ */
+public final class SPINamespaceHandler extends NamespaceHandlerSupport {
+    
+    @Override
+    public void init() {
+        registerBeanDefinitionParser(SPIBeanDefinitionParserTag.KEY_GENERATE_ALGORITHM_TAG, new KeyGenerateAlgorithmBeanDefinitionParser());
+    }
+}

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/parser/KeyGenerateAlgorithmBeanDefinitionParser.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/namespace/parser/KeyGenerateAlgorithmBeanDefinitionParser.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shardingjdbc.spring.namespace.parser;
+
+import com.google.common.base.Strings;
+import java.util.Properties;
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.constants.SPIBeanDefinitionParserTag;
+import org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+
+/**
+ * Key generate algorithm bean parser for spring namespace.
+ */
+public final class KeyGenerateAlgorithmBeanDefinitionParser extends AbstractBeanDefinitionParser {
+    
+    @Override
+    protected AbstractBeanDefinition parseInternal(final Element element, final ParserContext parserContext) {
+        BeanDefinitionBuilder factory = BeanDefinitionBuilder.rootBeanDefinition(KeyGenerateAlgorithmFactoryBean.class);
+        factory.addConstructorArgValue(element.getAttribute(SPIBeanDefinitionParserTag.KEY_GENERATE_ALGORITHM_TYPE_ATTRIBUTE));
+        parseProperties(element, factory);
+        return factory.getBeanDefinition();
+    }
+    
+    private void parseProperties(final Element element, final BeanDefinitionBuilder factory) {
+        String properties = element.getAttribute(SPIBeanDefinitionParserTag.KEY_GENERATE_ALGORITHM_PROPERTY_REF_ATTRIBUTE);
+        if (!Strings.isNullOrEmpty(properties)) {
+            factory.addConstructorArgReference(properties);
+        } else {
+            factory.addConstructorArgValue(new Properties());
+        }
+    }
+}

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/spi.xsd
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/namespace/spi.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns="http://shardingsphere.apache.org/schema/shardingsphere/spi"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://shardingsphere.apache.org/schema/shardingsphere/spi"
+            elementFormDefault="qualified">
+    <xsd:element name="key-generate-algorithm">
+        <xsd:complexType>
+            <xsd:attribute name="id" type="xsd:string" use="required" />
+            <xsd:attribute name="type" type="xsd:string" />
+            <xsd:attribute name="props-ref" type="xsd:string" />
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/spring.handlers
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/spring.handlers
@@ -18,3 +18,4 @@
 http\://shardingsphere.apache.org/schema/shardingsphere/sharding=org.apache.shardingsphere.shardingjdbc.spring.namespace.handler.ShardingNamespaceHandler
 http\://shardingsphere.apache.org/schema/shardingsphere/masterslave=org.apache.shardingsphere.shardingjdbc.spring.namespace.handler.MasterSlaveNamespaceHandler
 http\://shardingsphere.apache.org/schema/shardingsphere/encrypt=org.apache.shardingsphere.shardingjdbc.spring.namespace.handler.EncryptNamespaceHandler
+http\://shardingsphere.apache.org/schema/shardingsphere/spi=org.apache.shardingsphere.shardingjdbc.spring.namespace.handler.SPINamespaceHandler

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/spring.schemas
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/resources/META-INF/spring.schemas
@@ -18,3 +18,4 @@
 http\://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd=META-INF/namespace/sharding.xsd
 http\://shardingsphere.apache.org/schema/shardingsphere/masterslave/master-slave.xsd=META-INF/namespace/master-slave.xsd
 http\://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd=META-INF/namespace/encrypt.xsd
+http\://shardingsphere.apache.org/schema/shardingsphere/spi/spi.xsd=META-INF/namespace/spi.xsd

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/KeyGenerateAlgorithmTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/KeyGenerateAlgorithmTest.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 @ContextConfiguration(locations = "classpath:META-INF/rdb/datasource/dataSource.xml")
-public final class GenerateKeyAlgorithmTest extends AbstractJUnit4SpringContextTests {
+public final class KeyGenerateAlgorithmTest extends AbstractJUnit4SpringContextTests {
     
     @Test(expected = BeanCreationException.class)
     public void assertTypelessKeyGenerateAlgorithm() {
@@ -45,7 +45,7 @@ public final class GenerateKeyAlgorithmTest extends AbstractJUnit4SpringContextT
     @Test
     public void assertKeyGenerateAlgorithm() {
         GenericApplicationContext context = (GenericApplicationContext) applicationContext;
-        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGenerateAlgorithmFactoryBean.class).addPropertyValue("type", "INCREMENT");
+        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(KeyGenerateAlgorithmFactoryBean.class).addConstructorArgValue("INCREMENT");
         BeanDefinition beanDefinition = builder.getBeanDefinition();
         context.registerBeanDefinition("incrementAlgorithm", beanDefinition);
         KeyGenerateAlgorithm incrementKeyGenerateAlgorithm = (KeyGenerateAlgorithm) context.getBean("incrementAlgorithm");

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/java/org/apache/shardingsphere/shardingjdbc/spring/ShardingNamespaceTest.java
@@ -17,6 +17,18 @@
 
 package org.apache.shardingsphere.shardingjdbc.spring;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import javax.sql.DataSource;
 import org.apache.shardingsphere.api.config.sharding.strategy.ComplexShardingStrategyConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.HintShardingStrategyConfiguration;
 import org.apache.shardingsphere.api.config.sharding.strategy.InlineShardingStrategyConfiguration;
@@ -46,24 +58,11 @@ import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
-import javax.sql.DataSource;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 @ContextConfiguration(locations = "classpath:META-INF/rdb/shardingNamespace.xml")
 public class ShardingNamespaceTest extends AbstractJUnit4SpringContextTests {
     
     @Test
-    public void assertKeyGenerator() {
+    public void assertKeyGenerateAlgorithm() {
         assertThat(applicationContext.getBean("incrementAlgorithm"), instanceOf(KeyGenerateAlgorithm.class));
         KeyGenerateAlgorithm incrementKeyGenerateAlgorithm = (KeyGenerateAlgorithm) applicationContext.getBean("incrementAlgorithm");
         KeyGenerateAlgorithm directIncrementKeyGenerateAlgorithm = new IncrementKeyGenerateAlgorithm();

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/shardingNamespace.xml
@@ -20,6 +20,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:master-slave="http://shardingsphere.apache.org/schema/shardingsphere/masterslave"
        xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
+       xmlns:spi="http://shardingsphere.apache.org/schema/shardingsphere/spi"
        xmlns:bean="http://www.springframework.org/schema/util"
        xmlns:encrypt="http://shardingsphere.apache.org/schema/shardingsphere/encrypt"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
@@ -28,6 +29,8 @@
                         http://shardingsphere.apache.org/schema/shardingsphere/masterslave/master-slave.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi/spi.xsd
                         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://shardingsphere.apache.org/schema/shardingsphere/encrypt http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd">
     <import resource="datasource/dataSource.xml" />
     <import resource="datasource/masterSlaveDataSource.xml" />
@@ -36,9 +39,8 @@
     <bean id="standardModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.StandardModuloTableShardingAlgorithm" />
     <bean id="defaultComplexKeysShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultComplexKeysShardingAlgorithm" />
     <bean id="defaultHintShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.DefaultHintShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
-        <property name="type" value="INCREMENT" />
-    </bean>
+
+    <spi:key-generate-algorithm id="incrementAlgorithm" type="INCREMENT" />
     
     <sharding:standard-strategy id="standardStrategy" sharding-column="user_id" algorithm-ref="standardModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="rangeStandardStrategy" sharding-column="order_id" algorithm-ref="standardModuloTableShardingAlgorithm" />

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/test/resources/META-INF/rdb/withNamespaceGenerateKeyColumns.xml
@@ -19,21 +19,21 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:sharding="http://shardingsphere.apache.org/schema/shardingsphere/sharding"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans 
+       xmlns:spi="http://shardingsphere.apache.org/schema/shardingsphere/spi"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
                         http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding
                         http://shardingsphere.apache.org/schema/shardingsphere/sharding/sharding.xsd
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi
+                        http://shardingsphere.apache.org/schema/shardingsphere/spi/spi.xsd
                         ">
     <import resource="datasource/dataSource.xml" />
     
     <bean id="standardModuloDatabaseShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.StandardModuloDatabaseShardingAlgorithm" />
     <bean id="standardModuloTableShardingAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.algorithm.StandardModuloTableShardingAlgorithm" />
-    <bean id="incrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
-        <property name="type" value="INCREMENT" />
-    </bean>
-    <bean id="decrementAlgorithm" class="org.apache.shardingsphere.shardingjdbc.spring.namespace.factorybean.KeyGenerateAlgorithmFactoryBean">
-        <property name="type" value="DECREMENT" />
-    </bean>
+    
+    <spi:key-generate-algorithm id="incrementAlgorithm" type="INCREMENT" />
+    <spi:key-generate-algorithm id="decrementAlgorithm" type="DECREMENT" />
     
     <sharding:standard-strategy id="databaseStrategy" sharding-column="user_id" algorithm-ref="standardModuloDatabaseShardingAlgorithm" />
     <sharding:standard-strategy id="tableStrategy" sharding-column="order_id" algorithm-ref="standardModuloTableShardingAlgorithm" />


### PR DESCRIPTION
Fixes #5168.

